### PR TITLE
MR1K1 Veto Device and Bender Faults

### DIFF
--- a/lcls-plc-rixs-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/PMPS_PRE.xti
+++ b/lcls-plc-rixs-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/PMPS_PRE.xti
@@ -294,7 +294,7 @@
 		<EtherCAT SlaveType="3" AdsServerAddress="ac155c440205eb03" PdiType="#x0008" MboxDataLinkLayer="true" StateMBoxPolling="true" CycleMBoxPollingTime="0" CoeType="47" EoeType="1" FoeType="1" VendorId="#x00000002" ProductCode="#x1a273052" RevisionNo="#x00050000" InfoDataAddr="true" InfoDataNetId="true" TimeoutMailbox2="2000" GenerateOwnNetId="true" CheckRevisionNoType="3" PortPhys="51" DcTimeLoopControlOnly="true" MaxSlotCount="256" MaxSlotGroupCount="1" SlotPdoIncrement="1" SlotIndexIncrement="16" Type="EL6695 EtherCAT Bridge terminal (Primary)" Desc="EL6695">
 			<SyncMan>0010000426000100010000008000da050004001026010000</SyncMan>
 			<SyncMan>0016000422000100020000008000da050004001622010000</SyncMan>
-			<SyncMan>001c98006400010003000000000000000000001c64010000</SyncMan>
+			<SyncMan>001c9c006400010003000000000000000000001c64010000</SyncMan>
 			<SyncMan>008e9a002000010004000000000000000200008e20010000</SyncMan>
 			<Fmmu>0000000000000000001c00020100000001000000000000000000000000000000</Fmmu>
 			<Fmmu>0000000000000000008e00010100000002000000000000000000000000000000</Fmmu>
@@ -446,6 +446,9 @@
 			<Pdo Name="IO Outputs" Index="#x1608" InOut="1" Flags="#x0020" SyncMan="2">
 				<Entry Name="RequestedBP" Index="#x7000" Sub="#x01">
 					<Type GUID="{5FC92061-002A-45B0-B954-CD8F28B5CE49}">ST_BeamParams_IO</Type>
+				</Entry>
+				<Entry Name="MR1K1_Y_ENC" Index="#x7000" Sub="#x02">
+					<Type>UDINT</Type>
 				</Entry>
 			</Pdo>
 			<CoeProfile ProfileNo="5001"/>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-BEND-DS.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-BEND-DS.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.32" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -622,7 +622,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1014,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1330,15 +1330,18 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1e-06" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="6"/>
+				<SoftEndMinControl Enable="true" Range="20.6"/>
+				<SoftEndMaxControl Range="21.8"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
+				<ParameterChanged>14</ParameterChanged>
+				<ParameterChanged>13</ParameterChanged>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>40064</BitOffs>
+					<BitOffs>40384</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
 						<Comment>
@@ -1368,7 +1371,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>61568</BitOffs>
+					<BitOffs>61888</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1382,7 +1385,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>40704</BitOffs>
+					<BitOffs>41024</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
@@ -1420,7 +1423,7 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>62208</BitOffs>
+					<BitOffs>62528</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1474,15 +1477,15 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>FromPlc</Name>
 				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>39040</BitOffs>
+				<BitOffs>39360</BitOffs>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>59520</BitOffs>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
+				<BitOffs>59840</BitOffs>
 				<SubVar>
 					<Name>AxisState</Name>
 					<Comment>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-BEND-US.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-BEND-US.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.32" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -622,7 +622,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1014,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1330,15 +1330,19 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1e-06" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="6"/>
+				<SoftEndMinControl Enable="true" Range="20.9"/>
+				<SoftEndMaxControl Enable="true" Range="22.1"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
+				<ParameterChanged>14</ParameterChanged>
+				<ParameterChanged>13</ParameterChanged>
+				<ParameterChanged>12</ParameterChanged>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>38080</BitOffs>
+					<BitOffs>38400</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
 						<Comment>
@@ -1368,7 +1372,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>58560</BitOffs>
+					<BitOffs>58880</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1382,7 +1386,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>38720</BitOffs>
+					<BitOffs>39040</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
@@ -1420,7 +1424,7 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>59200</BitOffs>
+					<BitOffs>59520</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1474,15 +1478,15 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>FromPlc</Name>
 				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>37056</BitOffs>
+				<BitOffs>37376</BitOffs>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>56512</BitOffs>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
+				<BitOffs>56832</BitOffs>
 				<SubVar>
 					<Name>AxisState</Name>
 					<Comment>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M1K1_BENDER_Constants.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M1K1_BENDER_Constants.TcGVL
@@ -6,6 +6,13 @@ VAR_GLOBAL CONSTANT
 	// Encoder reference values in counts = nm
 	nM1K1bendUS_ENC_REF : ULINT := 21458400;
 	nM1K1bendDS_ENC_REF : ULINT := 21225900;
+    
+    // PMPS Limits for benders
+    nM1K1bendUS_PMPS_UpperLimit : ULINT := 22100000;
+    nM1K1bendUS_PMPS_LowerLimit : ULINT := 20900000;
+    
+    nM1K1bendDS_PMPS_UpperLimit : ULINT := 21800000;
+    nM1K1bendDS_PMPS_LowerLimit : ULINT := 20600000;
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -149,7 +149,17 @@ VAR
         field: ONAM ON
     '}
 	{attribute 'TcLinkTo' := 'TIIB[EL2024-0010_M1K1_BEND_LED1]^Channel 4^Output'}
-    bLEDPower04 AT %Q*: BOOL;	
+    bLEDPower04 AT %Q*: BOOL;
+
+    // MR1K1 Y Encoder for PMPS Veto Device
+    ///////////////////////////////////////
+        {attribute 'TcLinkTo' := 'TIIB[PMPS_PRE]^IO Outputs^MR1K1_Y_ENC'}
+        nMR1K1_Y_ENC_PMPS AT %Q* : UDINT;
+        {attribute 'TcLinkTo' := 'TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Status^Ready'}
+        bMR1K1_Y_ENC_Ready AT %I* : BOOL;
+        {attribute 'TcLinkTo' := 'TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Status^TxPDO State'}
+        bMR1K1_Y_ENC_TxPDO AT %I* : BOOL;
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -232,7 +242,14 @@ mcReadParameterPitchM1K1(Axis:=M16.Axis,
 				         ReadMode:=READMODE_CYCLIC,
 				         Value=>fEncRefPitchM1K1_urad);
 
-nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm);]]></ST>
+nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm);
+
+// Export the Y encoder value for PMPS veto device evaluation
+    IF bMR1K1_Y_ENC_Ready AND NOT bMR1K1_Y_ENC_TxPDO THEN
+        nMR1K1_Y_ENC_PMPS := nEncCntYupM1K1;
+    ELSE
+        nMR1K1_Y_ENC_PMPS := 0;
+    END_IF]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND_BENDER.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND_BENDER.TcPOU
@@ -115,6 +115,13 @@ VAR
 	// Logging
 	fbLogHandler : FB_LogHandler;
 	fbBendUSRMSErrorMR1K1: INT;
+    
+    // PMPS
+    ffBenderRange : FB_FastFault := (
+        i_xAutoReset := TRUE,
+        i_DevName := 'MR1K1 Bender',
+        i_Desc := 'Benders have moved out of range, monochromator beam may be focused where it can damage the BCS. Adjust bender to be within limits to clear fault',
+        i_TypeCode := 16#402);
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[//FB_Motion stages for MR1K1 Benders
@@ -166,6 +173,11 @@ bM1K1DS_RTD_3_Err := fM1K1DS_RTD_3 = 0;
 // M1K1 Bender RTD interlocks
 M17.bHardwareEnable R= fM1K1US_RTD_1 > 10000 OR bM1K1US_RTD_1_Err;
 M18.bHardwareEnable R= fM1K1DS_RTD_1 > 10000 OR bM1K1DS_RTD_1_Err;
+
+ffBenderRange.i_xOK :=
+    GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit < nEncCntBendUSM1K1 AND nEncCntBendUSM1K1 < GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit AND
+    GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit < nEncCntBendDSM1K1 AND nEncCntBendDSM1K1 < GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit;
+ffBenderRange(io_fbFFHWO := GVL_PMPS.fbFastFaultOutput1);
 ]]></ST>
     </Implementation>
   </POU>


### PR DESCRIPTION
This is the logic required to provide the arbiter with the MR1K1 Y position so it can be a veto device in the system. If the mirror is inserted it will block beam to the rest of the line much like a stopper.

This PR also includes the logic for the bender fast faults. for BCS protection.