### PR TITLE
MNT: newest ads-ioc, standardize prefix

### DIFF
--- a/iocBoot/ioc-rixs-optics/Makefile
+++ b/iocBoot/ioc-rixs-optics/Makefile
@@ -1,4 +1,4 @@
-IOC_TOP = /reg/g/pcds/epics/ioc/common/ads-ioc/R0.3.1
+IOC_TOP = /reg/g/pcds/epics/ioc/common/ads-ioc/R0.4.1
 
 IOC_INSTANCE_PATH := $(shell pwd)
 
@@ -10,6 +10,6 @@ PROJECT_PATH := ../../lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
 PLC := rixs_optics
 
 PYTMC_OPTS := 
-PREFIX := PLC:RIXS:OPTICS
+PREFIX := PLC:RIX:OPTICS
 
 include $(IOC_TOP)/iocBoot/templates/Makefile.base


### PR DESCRIPTION
IOC updates

Pick newest ads-ioc
Change prefix to RIX instead of RIXS in IOC Makefile to match the internal prefixes used in the pytmc pragmas

closes #48

Makes IOC work with the plc ioc tab in the pmps diagnostic