### PR TITLE
MNT: adjust parameters for low speed and higher accuracy for sp1k1 pitches

### DIFF
--- a/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
@@ -1327,8 +1327,8 @@ External Setpoint Generation:
 			<General UnitName="urad"/>
 			<Dynamic Acceleration="2000" Deceleration="2000" Jerk="3000"/>
 			<PositionAreaControl Range="0.05"/>
-			<MotionControl Enable="true"/>
-			<TargetPosControl Range="0.05"/>
+			<MotionControl Time="1"/>
+			<TargetPosControl Range="0.05" Time="0.5"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="e_dwn" EncType="29">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/m_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/m_pi.xti
@@ -1326,6 +1326,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<General UnitName="urad"/>
 			<Dynamic Acceleration="2000" Deceleration="2000" Jerk="3000"/>
+			<TargetPosControl Range="0.05" Time="0.5"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="e_dwn" EncType="29">


### PR DESCRIPTION
- Remove the "Motion Monitoring" from the g-pi because this prevents moves slower than 30 urad/s. This is a monitor that throws an error if, during a move, we move too slowly. I experimented a bit with changing the values but I couldn't find a useful configuration due to the slow speed we want to move at combined with the encoder noise floor: either it would trigger too much due to the low speed or theoretically never trigger due to the noise. So therefore, it is now turned off.
- Allow the "Target Position Monitoring" for both g-pi and m-pi 0.5s instead of 0.02s to settle. Decrease the target range of the m-pi axis to 0.05 (previously 2.0). These parameters are used to determine when the motor is "done" moving for the purposes of EPICS and for the purpose of turning off the motor power after a move. Since these time ranges were so small, the motor was turning off before the position could be fully corrected. Since the m-pi distance range was so large, the motor was considered done extremely early.