### PR TITLE
SP1K1 Grating Pitch Stats Migration 

### DIFF
--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -54,43 +54,6 @@
 			</SubItem>
 		</DataType>
 		<DataType>
-			<Name GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
-			<BitSize>0</BitSize>
-			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
-		</DataType>
-		<DataType>
-			<Name GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
-			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
-			<BitSize>128</BitSize>
-			<SubItem>
-				<Name>Count</Name>
-				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-				<BitSize>64</BitSize>
-				<BitOffs>0</BitOffs>
-				<Properties>
-					<Property>
-						<Name>TcAddressType</Name>
-						<Value>Input</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>Status</Name>
-				<Type GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
-				<Comment><![CDATA[ Status struct placeholder]]></Comment>
-				<BitSize>0</BitSize>
-				<BitOffs>64</BitOffs>
-			</SubItem>
-			<SubItem>
-				<Name>Ref</Name>
-				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment><![CDATA[ Encoder zero position (useful for aligned position with gantries)]]></Comment>
-				<BitSize>64</BitSize>
-				<BitOffs>64</BitOffs>
-			</SubItem>
-		</DataType>
-		<DataType>
 			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
@@ -884,6 +847,43 @@ External Setpoint Generation:
 			</Relations>
 		</DataType>
 		<DataType>
+			<Name GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
+			<BitSize>0</BitSize>
+			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
+		</DataType>
+		<DataType>
+			<Name GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
+			<BitSize>128</BitSize>
+			<SubItem>
+				<Name>Count</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+				<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+				<BitSize>64</BitSize>
+				<BitOffs>0</BitOffs>
+				<Properties>
+					<Property>
+						<Name>TcAddressType</Name>
+						<Value>Input</Value>
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>Status</Name>
+				<Type GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
+				<Comment><![CDATA[ Status struct placeholder]]></Comment>
+				<BitSize>0</BitSize>
+				<BitOffs>64</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>Ref</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+				<Comment><![CDATA[ Encoder zero position (useful for aligned position with gantries)]]></Comment>
+				<BitSize>64</BitSize>
+				<BitOffs>64</BitOffs>
+			</SubItem>
+		</DataType>
+		<DataType>
 			<Name GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Name>
 			<BitSize>64</BitSize>
 			<SubItem>
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{B84F8694-6679-14A7-53B9-D28E1E05082C}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{916A7B6C-B4EB-3A58-E441-28321EF7D007}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1368,7 +1368,14 @@ External Setpoint Generation:
 					<Type GUID="{64E6921B-16B3-48BF-80E0-352129E45D23}" Namespace="Tc2_SerialCom">EL6outData22B</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="1" ContextId="2" AreaNo="32">
+			<Vars VarGrpType="1" ContextId="1" AreaNo="16">
+				<Name>StatsTask Inputs</Name>
+				<Var>
+					<Name>Main.M7.Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+			</Vars>
+			<Vars VarGrpType="1" ContextId="3" AreaNo="48">
 				<Name>DaqTask Inputs</Name>
 				<Var>
 					<Name>PRG_DAQ_ENCODER.iLatchPos</Name>
@@ -1384,7 +1391,7 @@ External Setpoint Generation:
 					<Type>ULINT</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="1" ContextId="3" AreaNo="48">
+			<Vars VarGrpType="1" ContextId="4" AreaNo="64">
 				<Name>PlcTask Inputs</Name>
 				<Var>
 					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
@@ -1934,6 +1941,16 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
 					<Type>BOOL</Type>
 				</Var>
@@ -1993,6 +2010,16 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
 					<Comment><![CDATA[ M1K1 US RTDs]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -2331,10 +2358,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.M6.nRawEncoderINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>Main.M7.Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M7.bLimitForwardEnable</Name>
@@ -3621,28 +3644,8 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.sio_load</Name>
 					<Type>UINT</Type>
 				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
 			</Vars>
-			<Vars VarGrpType="2" ContextId="3" AreaNo="49">
+			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
 				<Var>
 					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -4201,7 +4204,7 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="8" ContextId="3" AreaNo="52">
+			<Vars VarGrpType="8" ContextId="4" AreaNo="68">
 				<Name>PlcTask Retains</Name>
 				<Var>
 					<Name>PMPS_GVL.SuccessfulPreemption</Name>
@@ -4292,6 +4295,15 @@ Emergency Stop for MR1K1]]></Comment>
 				</Context>
 				<Context>
 					<Id NeedCalleeCall="true">1</Id>
+					<Name>StatsTask</Name>
+					<ManualConfig>
+						<OTCID>#x02010090</OTCID>
+					</ManualConfig>
+					<Priority>2</Priority>
+					<CycleTime>2000000</CycleTime>
+				</Context>
+				<Context>
+					<Id NeedCalleeCall="true">2</Id>
 					<Name>PiezoDriver</Name>
 					<ManualConfig>
 						<OTCID>#x02010060</OTCID>
@@ -4300,7 +4312,7 @@ Emergency Stop for MR1K1]]></Comment>
 					<CycleTime>1000000</CycleTime>
 				</Context>
 				<Context>
-					<Id NeedCalleeCall="true">2</Id>
+					<Id NeedCalleeCall="true">3</Id>
 					<Name>DaqTask</Name>
 					<ManualConfig>
 						<OTCID>#x02010080</OTCID>
@@ -4309,7 +4321,7 @@ Emergency Stop for MR1K1]]></Comment>
 					<CycleTime>1000000</CycleTime>
 				</Context>
 				<Context>
-					<Id NeedCalleeCall="true">3</Id>
+					<Id NeedCalleeCall="true">4</Id>
 					<Name>PlcTask</Name>
 					<ManualConfig>
 						<OTCID>#x02010030</OTCID>
@@ -4320,6 +4332,7 @@ Emergency Stop for MR1K1]]></Comment>
 			</Contexts>
 			<TaskPouOids>
 				<TaskPouOid Prio="1" OTCID="#x08502001"/>
+				<TaskPouOid Prio="2" OTCID="#x08502005"/>
 				<TaskPouOid Prio="3" OTCID="#x08502002"/>
 				<TaskPouOid Prio="19" OTCID="#x08502003"/>
 				<TaskPouOid Prio="20" OTCID="#x08502004"/>
@@ -4936,8 +4949,8 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Outputs^Main.M9.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^g_pi">
-				<Link VarA="PlcTask Inputs^Main.M7.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M7.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
+				<Link VarA="StatsTask Inputs^Main.M7.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^m_h">
 				<Link VarA="PlcTask Inputs^Main.M8.Axis.NcToPlc" VarB="Outputs^ToPlc"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{916A7B6C-B4EB-3A58-E441-28321EF7D007}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{AF746F3C-18E1-BB13-C597-9DE0DD4AE3BE}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1370,6 +1370,10 @@ External Setpoint Generation:
 			</Vars>
 			<Vars VarGrpType="1" ContextId="1" AreaNo="16">
 				<Name>StatsTask Inputs</Name>
+				<Var>
+					<Name>Main.M6.Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
 				<Var>
 					<Name>Main.M7.Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
@@ -2319,10 +2323,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.M5.nRawEncoderINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>Main.M6.Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitForwardEnable</Name>
@@ -4957,8 +4957,8 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Outputs^Main.M8.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^m_pi">
-				<Link VarA="PlcTask Inputs^Main.M6.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M6.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
+				<Link VarA="StatsTask Inputs^Main.M6.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^s_io">
 				<Link VarA="PlcTask Inputs^Main.M10.Axis.NcToPlc" VarB="Outputs^ToPlc"/>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -31,10 +31,10 @@
 				<Task Id="7" Priority="1" CycleTime="20000" AmsPort="352" AdtTasks="true">
 					<Name>SerialIO</Name>
 				</Task>
-				<Task Id="8" Priority="19" CycleTime="10000" AmsPort="353" Affinity="#x00000008" AdtTasks="true">
+				<Task Id="8" Priority="19" CycleTime="10000" AmsPort="353" Affinity="#x00000004" AdtTasks="true">
 					<Name>DaqTask</Name>
 				</Task>
-				<Task Id="9" Priority="2" CycleTime="20000" AmsPort="354" AdtTasks="true">
+				<Task Id="9" Priority="2" CycleTime="20000" AmsPort="354" Affinity="#x00000008" AdtTasks="true">
 					<Name>StatsTask</Name>
 				</Task>
 			</Tasks>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -34,6 +34,9 @@
 				<Task Id="8" Priority="19" CycleTime="10000" AmsPort="353" Affinity="#x00000008" AdtTasks="true">
 					<Name>DaqTask</Name>
 				</Task>
+				<Task Id="9" Priority="2" CycleTime="20000" AmsPort="354" AdtTasks="true">
+					<Name>StatsTask</Name>
+				</Task>
 			</Tasks>
 		</System>
 		<Motion>
@@ -48,11 +51,12 @@
 	</Project>
 	<Mappings>
 		<MappingInfo Identifier="{00000000-2001-0850-0020-500810000403}" Id="#x02030010"/>
-		<MappingInfo Identifier="{00000000-2003-0850-0220-500852000403}" Id="#x02030050"/>
-		<MappingInfo Identifier="{00000000-2004-0850-0320-500863000403}" Id="#x02030060"/>
+		<MappingInfo Identifier="{00000000-2003-0850-0320-500852000403}" Id="#x02030050"/>
+		<MappingInfo Identifier="{00000000-2004-0850-0420-500863000403}" Id="#x02030060"/>
 		<MappingInfo Identifier="{00000000-0040-0304-3000-040341000403}" Id="#x02030020"/>
 		<MappingInfo Identifier="{08502003-0040-0304-0020-500840000403}" Id="#x02030030" Watchdog="00000000000000000000000000000000"/>
 		<MappingInfo Identifier="{08502004-0040-0304-0020-500840000403}" Id="#x02030040" Watchdog="00000000000000000000000000000000"/>
-		<MappingInfo Identifier="{05000010-2004-0850-3000-040303205008}" Id="#x02030070" Watchdog="14000000040000000400000004000000"/>
+		<MappingInfo Identifier="{08502005-0010-0500-0120-500830000403}" Id="#x02030070" Watchdog="04000000040000000400000004000000"/>
+		<MappingInfo Identifier="{05000010-2004-0850-3000-040304205008}" Id="#x02030080" Watchdog="14000000040000000400000004000000"/>
 	</Mappings>
 </TcSmProject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="PRG_SP1K1_MONO" Id="{397aec28-b6d3-4c1c-afed-2cc3b34939d3}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_SP1K1_MONO
 VAR
@@ -192,18 +192,8 @@ VAR
     '}
     fSP1K1_Press_1_val : LREAL;
 
-    // SP1K1 Grating Mono Vibration Stats
-    fGpiEncoderPosDiff: LREAL;
-    afGpiPosDiffBuffer: ARRAY[1..1000] OF LREAL;
-    afGpiExtraBuffer: ARRAY[1..1000] OF LREAL;
-    fbGpiPosDiffCollect: FB_DataBuffer;
-    {attribute 'pytmc' := '
-        pv: SP1K1:MONO:MMS:G_PI:ENCDIFF
-    '}
-    fbGpiPosDiffStats: FB_BasicStats;
-    fGpiRangeMax: LREAL;
-    rtNewGpiMove: R_TRIG;
-    tonNewGpiMove: TON;
+
+
 
     // SP1K1 Mirror Pitch Mono Vibration Stats
     fMpiEncoderPosDiff: LREAL;
@@ -232,31 +222,6 @@ fbMotionStage_g_h  (stMotionStage:=M9);
 fbMotionStage_s_io  (stMotionStage:=M10);
 fbMotionStage_s_r  (stMotionStage:=M11);
 
-fGpiEncoderPosDiff := M7.nEncoderCount - (M7.Axis.NcToPlc.SetPos - M7.stAxisParameters.fEncOffset) * 150;
-fbGpiPosDiffCollect(
-    bExecute:=TRUE,
-    pInputAdr:=ADR(fGpiEncoderPosDiff),
-    iInputSize:=SIZEOF(fGpiEncoderPosDiff),
-    iElemCount:=1000,
-    pPartialAdr:=ADR(afGpiPosDiffBuffer),
-    pOutputAdr:=ADR(afGpiExtraBuffer),
-);
-fbGpiPosDiffStats(
-    aSignal:=afGpiPosDiffBuffer,
-    bAlwaysCalc:=TRUE,
-);
-rtNewGpiMove(CLK:=M7.bExecute);
-tonNewGpiMove(
-    IN:=M7.bExecute,
-    PT:=T#15s,
-);
-IF rtNewGpiMove.Q THEN
-    // Reset before a move
-    fGpiRangeMax := 0;
-ELSIF tonNewGpiMove.Q AND ABS(M7.fPosition - M7.stAxisStatus.fActPosition) > 5 THEN
-    // Update only during moves, not at the start or end
-    fGpiRangeMax := MAX(fGpiRangeMax, fbGpiPosDiffStats.fRange);
-END_IF
 
 fMpiEncoderPosDiff := M6.nEncoderCount - (M6.Axis.NcToPlc.SetPos - M6.stAxisParameters.fEncOffset) / 0.004505;
 fbMpiPosDiffCollect(

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -192,18 +192,6 @@ VAR
     '}
     fSP1K1_Press_1_val : LREAL;
 
-
-
-
-    // SP1K1 Mirror Pitch Mono Vibration Stats
-    fMpiEncoderPosDiff: LREAL;
-    afMpiPosDiffBuffer: ARRAY[1..1000] OF LREAL;
-    afMpiExtraBuffer: ARRAY[1..1000] OF LREAL;
-    fbMpiPosDiffCollect: FB_DataBuffer;
-    {attribute 'pytmc' := '
-        pv: SP1K1:MONO:MMS:M_PI:ENCDIFF
-    '}
-    fbMpiPosDiffStats: FB_BasicStats;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -223,19 +211,7 @@ fbMotionStage_s_io  (stMotionStage:=M10);
 fbMotionStage_s_r  (stMotionStage:=M11);
 
 
-fMpiEncoderPosDiff := M6.nEncoderCount - (M6.Axis.NcToPlc.SetPos - M6.stAxisParameters.fEncOffset) / 0.004505;
-fbMpiPosDiffCollect(
-    bExecute:=TRUE,
-    pInputAdr:=ADR(fMpiEncoderPosDiff),
-    iInputSize:=SIZEOF(fMpiEncoderPosDiff),
-    iElemCount:=1000,
-    pPartialAdr:=ADR(afMpiPosDiffBuffer),
-    pOutputAdr:=ADR(afMpiExtraBuffer),
-);
-fbMpiPosDiffStats(
-    aSignal:=afMpiPosDiffBuffer,
-    bAlwaysCalc:=TRUE,
-);
+
 
 
 //S_R with no hardware limit switched

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_Stats.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_Stats.TcPOU
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="PRG_Stats" Id="{5b50d104-4857-43bf-bc63-e1797ec364ef}" SpecialFunc="None">
+    <Declaration><![CDATA[PROGRAM PRG_Stats
+VAR
+    // SP1K1 Grating Mono Vibration Stats
+    fGpiEncoderPosDiff: LREAL;
+    afGpiPosDiffBuffer: ARRAY[1..10000] OF LREAL;
+    afGpiExtraBuffer: ARRAY[1..10000] OF LREAL;
+    fbGpiPosDiffCollect: FB_DataBuffer;
+    {attribute 'pytmc' := '
+        pv: SP1K1:MONO:MMS:G_PI:ENCDIFF
+    '}
+    fbGpiPosDiffStats: FB_BasicStats;
+
+    fGpiRangeMax: LREAL;
+    rtNewGpiMove: R_TRIG;
+    tonNewGpiMove: TON;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF rtNewGpiMove.Q THEN
+    // Reset before a move
+    fGpiRangeMax := 0;
+ELSIF tonNewGpiMove.Q AND ABS(M7.fPosition - M7.stAxisStatus.fActPosition) > 5 THEN
+    // Update only during moves, not at the start or end
+    fGpiRangeMax := MAX(fGpiRangeMax, fbGpiPosDiffStats.fRange);
+END_IF
+
+fGpiEncoderPosDiff := M7.nEncoderCount - (M7.Axis.NcToPlc.SetPos - M7.stAxisParameters.fEncOffset) * 150;
+fbGpiPosDiffCollect(
+    bExecute:=TRUE,
+    pInputAdr:=ADR(fGpiEncoderPosDiff),
+    iInputSize:=SIZEOF(fGpiEncoderPosDiff),
+    iElemCount:=1000,
+    pPartialAdr:=ADR(afGpiPosDiffBuffer),
+    pOutputAdr:=ADR(afGpiExtraBuffer),
+);
+fbGpiPosDiffStats(
+    aSignal:=afGpiPosDiffBuffer,
+    bAlwaysCalc:=TRUE,
+);
+rtNewGpiMove(CLK:=M7.bExecute);
+tonNewGpiMove(
+    IN:=M7.bExecute,
+    PT:=T#15s,
+);
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_Stats.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_Stats.TcPOU
@@ -16,6 +16,17 @@ VAR
     fGpiRangeMax: LREAL;
     rtNewGpiMove: R_TRIG;
     tonNewGpiMove: TON;
+
+
+    // SP1K1 Mirror Pitch Mono Vibration Stats
+    fMpiEncoderPosDiff: LREAL;
+    afMpiPosDiffBuffer: ARRAY[1..10000] OF LREAL;
+    afMpiExtraBuffer: ARRAY[1..10000] OF LREAL;
+    fbMpiPosDiffCollect: FB_DataBuffer;
+    {attribute 'pytmc' := '
+        pv: SP1K1:MONO:MMS:M_PI:ENCDIFF
+    '}
+    fbMpiPosDiffStats: FB_BasicStats;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -32,7 +43,7 @@ fbGpiPosDiffCollect(
     bExecute:=TRUE,
     pInputAdr:=ADR(fGpiEncoderPosDiff),
     iInputSize:=SIZEOF(fGpiEncoderPosDiff),
-    iElemCount:=1000,
+    iElemCount:=10000,
     pPartialAdr:=ADR(afGpiPosDiffBuffer),
     pOutputAdr:=ADR(afGpiExtraBuffer),
 );
@@ -45,6 +56,20 @@ tonNewGpiMove(
     IN:=M7.bExecute,
     PT:=T#15s,
 );
+
+(*fMpiEncoderPosDiff := M6.nEncoderCount - (M6.Axis.NcToPlc.SetPos - M6.stAxisParameters.fEncOffset) / 0.004505;
+fbMpiPosDiffCollect(
+    bExecute:=TRUE,
+    pInputAdr:=ADR(fMpiEncoderPosDiff),
+    iInputSize:=SIZEOF(fMpiEncoderPosDiff),
+    iElemCount:=1000,
+    pPartialAdr:=ADR(afMpiPosDiffBuffer),
+    pOutputAdr:=ADR(afMpiExtraBuffer),
+);
+fbMpiPosDiffStats(
+    aSignal:=afMpiPosDiffBuffer,
+    bAlwaysCalc:=TRUE,
+);*)
 ]]></ST>
     </Implementation>
   </POU>

--- a/lcls-plc-rixs-optics/rixs_optics/StatsTask.TcTTO
+++ b/lcls-plc-rixs-optics/rixs_optics/StatsTask.TcTTO
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <Task Name="StatsTask" Id="{005b7d03-6645-431f-be1b-0d0221b9f2d5}">
+    <!--CycleTime in micro seconds.-->
+    <CycleTime>2000</CycleTime>
+    <Priority>2</Priority>
+    <PouCall>
+      <Name>PRG_Stats</Name>
+    </PouCall>
+    <TaskFBGuid>{05afe09e-8a2a-4617-ad9e-f6287fa29cc5}</TaskFBGuid>
+    <Fb_init>{535a1bfa-4291-4ec8-b84f-28964878bc65}</Fb_init>
+    <Fb_exit>{bc52925d-e508-440e-8f5a-96ee4d72d41c}</Fb_exit>
+    <CycleUpdate>{b2582ce0-d1e1-4850-8ac3-45c6ef7cf569}</CycleUpdate>
+    <PostCycleUpdate>{045b1103-7505-476d-aacb-94b3b8de9f43}</PostCycleUpdate>
+  </Task>
+</TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -171,6 +171,9 @@
     <Compile Include="POUs\PRG_ST1K1_ZOS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\PRG_Stats.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\PRG_ZeroOrder_PMPS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -181,6 +184,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="SerialIO.TcTTO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="StatsTask.TcTTO">
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{916A7B6C-B4EB-3A58-E441-28321EF7D007}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{AF746F3C-18E1-BB13-C597-9DE0DD4AE3BE}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -72326,7 +72326,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72349,7 +72349,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72370,7 +72370,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72468,7 +72468,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
+          <Symbol>
+            <Name>Main.M6.Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1295891392</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72486,7 +72498,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72531,6 +72543,44 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
             <BitOffs>1271777536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6</Name>
+            <Comment> M_PI, urad</Comment>
+            <BitSize>21184</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_PI
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1295890304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
@@ -72627,7 +72677,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <LBound>1</LBound>
               <Elements>10000</Elements>
             </ArrayInfo>
-            <BitOffs>1311032128</BitOffs>
+            <BitOffs>1310820160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.afGpiExtraBuffer</Name>
@@ -72637,14 +72687,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               <LBound>1</LBound>
               <Elements>10000</Elements>
             </ArrayInfo>
-            <BitOffs>1311672128</BitOffs>
+            <BitOffs>1311460160</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -72741,7 +72791,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72796,7 +72846,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -73273,7 +73323,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -76475,18 +76525,6 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1295878288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1295891392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -81288,7 +81326,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -83400,7 +83438,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -90519,6 +90557,33 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1265833152</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_Stats.fMpiEncoderPosDiff</Name>
+            <Comment> SP1K1 Mirror Pitch Mono Vibration Stats</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1271647744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.fbMpiPosDiffCollect</Name>
+            <BitSize>448</BitSize>
+            <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
+            <BitOffs>1271711808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.fbMpiPosDiffStats</Name>
+            <BitSize>1152</BitSize>
+            <BaseType Namespace="LCLS_General">FB_BasicStats</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_PI:ENCDIFF
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1271712256</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1</Name>
             <BitSize>23552</BitSize>
             <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
@@ -91998,53 +92063,6 @@ M1K1 BEND US ENC CNT</Comment>
               </Property>
             </Properties>
             <BitOffs>1284218688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fMpiEncoderPosDiff</Name>
-            <Comment> SP1K1 Mirror Pitch Mono Vibration Stats</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1284218752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.afMpiPosDiffBuffer</Name>
-            <BitSize>64000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1000</Elements>
-            </ArrayInfo>
-            <BitOffs>1284218816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.afMpiExtraBuffer</Name>
-            <BitSize>64000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1000</Elements>
-            </ArrayInfo>
-            <BitOffs>1284282816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMpiPosDiffCollect</Name>
-            <BitSize>448</BitSize>
-            <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
-            <BitOffs>1284346816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMpiPosDiffStats</Name>
-            <BitSize>1152</BitSize>
-            <BaseType Namespace="LCLS_General">FB_BasicStats</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_PI:ENCDIFF
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284347264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -94873,44 +94891,6 @@ M4K2 KBV X ENC CNT</Comment>
             <BitOffs>1295869120</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M6</Name>
-            <Comment> M_PI, urad</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_PI
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1295890304</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.M8</Name>
             <Comment> M_H, um</Comment>
             <BitSize>21184</BitSize>
@@ -96951,12 +96931,32 @@ M4K2 KBV X ENC CNT</Comment>
             </Properties>
             <BitOffs>1302861376</BitOffs>
           </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afMpiPosDiffBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1312312128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afMpiExtraBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1313594368</BitOffs>
+          </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -97036,7 +97036,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-01-30T11:21:31</Value>
+          <Value>2024-01-30T13:39:53</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
@@ -97044,7 +97044,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>162648064</Value>
+          <Value>162791424</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{B84F8694-6679-14A7-53B9-D28E1E05082C}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{916A7B6C-B4EB-3A58-E441-28321EF7D007}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -953,6 +953,4384 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="LCLS_General">FB_DataBuffer</Name>
+      <BitSize>448</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether or not to accumulate on this cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pInputAdr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Address of the value to accumulate</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iInputSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Size of the accumulated value</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iElemCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of values in the output array</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pPartialAdr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Address of the rolling buffer to be filled every cycle</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pOutputAdr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Address of the output buffer to be filled when the rolling buffer is full</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bNewArray</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE on the cycle that we copy the output array</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iArrayIndex</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>416</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">R_TRIG</Name>
+      <Comment>
+	Rising Edge detection.
+</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> Signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> rising edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_BasicStats</Name>
+      <BitSize>1152</BitSize>
+      <SubItem>
+        <Name>aSignal</Name>
+        <Type PointerTo="1">LREAL</Type>
+        <Comment> Input array of floats</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:DATA
+        io: i
+    </Value>
+          </Property>
+          <Property>
+            <Name>variable_length_array</Name>
+          </Property>
+          <Property>
+            <Name>Dimensions</Name>
+            <Value>1</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAlwaysCalc</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we will update the results every cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATS:ALWAYS_CALC</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> On rising edge, do one calculation</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATS:EXECUTE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> If set to TRUE, reset outputs</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATS:RESET</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nElems</Name>
+        <Type>UDINT</Type>
+        <Comment> If nonzero, we will only pay attention to the first nElems items in aSignal</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:NELM
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMean</Name>
+        <Type>LREAL</Type>
+        <Comment> Average of all values in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:MEAN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fStDev</Name>
+        <Type>LREAL</Type>
+        <Comment> Standard deviation of all values in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:STDEV
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMax</Name>
+        <Type>LREAL</Type>
+        <Comment> Largest value in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:MAX
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMin</Name>
+        <Type>LREAL</Type>
+        <Comment> Smallest value in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:MIN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fRange</Name>
+        <Type>LREAL</Type>
+        <Comment> Largest array element subtracted by the smallest</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:RANGE
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fRMS</Name>
+        <Type>LREAL</Type>
+        <Comment> RMS of all values in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:RMS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> True if the other outputs are valid</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:VALID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rTrig</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nElemsSeen</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRMSSum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVarianceSum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVarianceMean</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">TON</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>IN</Name>
+        <Type>BOOL</Type>
+        <Comment> starts timer with rising edge, resets timer with falling edge </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PT</Name>
+        <Type>TIME</Type>
+        <Comment> time to pass, before Q is set </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> gets TRUE, delay time (PT) after a rising edge at IN </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ET</Name>
+        <Type>TIME</Type>
+        <Comment> elapsed time </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StartTime</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">PLCTONC_AXIS_REF_CTRL</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>Enable</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FeedEnablePlus</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>1</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>FeedEnableMinus</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>2</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HomingSensor</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>5</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AcceptBlockedDrive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PlcDebugFlag</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>30</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcDebugFlag</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>31</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+      <BitSize>1024</BitSize>
+      <SubItem>
+        <Name>ControlDWord</Name>
+        <Type GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC">PLCTONC_AXIS_REF_CTRL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Override</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AxisModeRequest</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AxisModeDWord</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AxisModeLReal</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PositionCorrection</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtSetPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtSetVelo</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtSetAcc</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtSetDirection</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtControllerOutput</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>GearRatio1</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>GearRatio2</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>GearRatio3</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>GearRatio4</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MapState</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PlcCycleControl</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000001}">BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>840</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PlcCycleCount</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000001}">BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtTorque</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>NcStructType</Name>
+          <Value>1</Value>
+        </Property>
+      </Properties>
+      <Relations>
+        <Relation Priority="100">
+          <Type GUID="{60392271-8688-4F4C-B404-618DF106325D}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}"/>
+        </Relation>
+      </Relations>
+    </DataType>
+    <DataType>
+      <Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>Operational</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Homed</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>1</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NotMoving</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>2</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InPositionArea</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>3</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InTargetPosition</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>4</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Protected</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>5</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorPropagationDelayed</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>6</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HasBeenStopped</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>7</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HasJob</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PositiveDirection</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>9</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NegativeDirection</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>10</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HomingBusy</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>11</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ConstantVelocity</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>12</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Compensating</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>13</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtSetPointGenEnabled</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>14</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PhasingActive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>15</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExternalLatchValid</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NewTargetPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>17</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IsDriveLimitActive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>18</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ContinuousMotion</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>19</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ControlLoopClosed</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>20</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamTableQueued</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>21</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamDataQueued</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>22</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamScalingPending</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>23</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CmdBuffered</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PTPmode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>25</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SoftLimitMinExceeded</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>26</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SoftLimitMaxExceeded</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>27</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DriveDeviceError</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>28</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MotionCommandsLocked</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>29</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IoDataInvalid</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>30</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>31</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+      <Relations>
+        <Relation Priority="100">
+          <Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+        </Relation>
+      </Relations>
+    </DataType>
+    <DataType>
+      <Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>OpModePosAreaMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeTargetPosMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>1</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeLoop</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>2</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeMotionMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>3</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModePEHTimeMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>4</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeBacklashCompensation</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>5</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeDelayedErrorReaction</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>6</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeModulo</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>7</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeSimulationAxis</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModePosLagMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeVeloLagMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>17</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeSoftLimitMinMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>18</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeSoftLimitMaxMonitoring</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>19</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModePosCorrection</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>20</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeAllowSlaveCommands</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>21</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeAllowExtSetAxisCommands</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>22</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ApplicationRequest</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>23</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{303D9411-849C-467F-8A4C-5C8CD0F3DD46}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE2_FLAGS</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>AvoidingCollision</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name GUID="{669F3788-48FD-42CF-8A59-2DA946853FB6}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE2</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>Value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Flags</Name>
+        <Type GUID="{303D9411-849C-467F-8A4C-5C8CD0F3DD46}" Namespace="MC">NCTOPLC_AXIS_REF_STATE2_FLAGS</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3_FLAGS</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>TouchProbe1InputState </Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TouchProbe2InputState </Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>1</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>Value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Flags</Name>
+        <Type GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3_FLAGS</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Name>
+      <BitSize>8</BitSize>
+      <SubItem>
+        <Name>CamActivationPending</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamDeactivationPending</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>1</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamActive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>2</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamDataQueued</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>6</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamScalingPending</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>7</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{18071995-0000-0000-0000-000000000039}" TcBaseType="true" HideType="true">UINTARR8</Name>
+      <BitSize>128</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000005}">UINT</BaseType>
+      <ArrayInfo>
+        <LBound>0</LBound>
+        <Elements>8</Elements>
+      </ArrayInfo>
+    </DataType>
+    <DataType>
+      <Name GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+      <BitSize>2048</BitSize>
+      <SubItem>
+        <Name>StateDWord</Name>
+        <Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AxisState</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <Comment>Present State Of The Axis Movement (continuous axis):
+0  = INACTIVE:		axis has no job
+1  = RUNNING:		axis is executing a motion job
+2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
+3  = PHASE_VELOCONST:	axis is moving at constant velocity
+4  = PHASE_ACCPOS:	axis is accelerating
+5  = PHASE_ACCNEG:	axis is decelerating
+Slaves only:
+11 = PREPHASE:		slave axis is in a motion pre-phase
+12 = SYNCHRONIZING:	slave axis is synchronizing
+13 = SYNCHRONOUS:	slave axis is moving synchronously
+External Setpoint Generation:
+41 = EXTSETGEN_MODE1:	external setpoint generation active
+42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
+</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AxisModeConfirmation</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HomingState</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <Comment>Axis Homing Status:
+0: idle
+1: start homing
+2: searching home switch
+3: stopping on home switch
+4: moving off home switch
+5: searching sync pulse
+6: stopping after homing
+</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CoupleState</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <Comment>Axis Coupling Status:
+0: axis is a single axis (not coupled)
+1: axis is a master axis
+2: axis is master and slave
+3: axis is a slave axis
+</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SvbEntries</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SafEntries</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AxisId</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpModeDWord</Name>
+        <Type GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC">NCTOPLC_AXIS_REF_OPMODE</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ModuloActPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActiveControlLoopIndex</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ControlLoopIndex</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ModuloActTurns</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActVelo</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PosDiff</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SetPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SetVelo</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SetAcc</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TargetPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ModuloSetPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ModuloSetTurns</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CmdNo</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CmdState</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SetJerk</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SetTorque</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActTorque</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StateDWord2</Name>
+        <Type GUID="{669F3788-48FD-42CF-8A59-2DA946853FB6}" Namespace="MC">NCTOPLC_AXIS_REF_STATE2</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StateDWord3</Name>
+        <Type GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1248</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TouchProbeState</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TouchProbeCounter</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamCouplingState</Name>
+        <Type GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>8</Elements>
+        </ArrayInfo>
+        <BitSize>64</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamCouplingTableID</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000039}">UINTARR8</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActTorqueDerivative</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SetTorqueDerivative</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AbsPhasingPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TorqueOffset</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActPosWithoutPosCorrection</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ActAcc</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DcTimeStamp</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>UserData</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>NcStructType</Name>
+          <Value>2</Value>
+        </Property>
+      </Properties>
+      <Relations>
+        <Relation Priority="100">
+          <Type GUID="{429B767E-373B-40AE-BFA5-E1C08B444DF3}">NCAXLESTRUCT_TOPLC</Type>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{E8DA524A-605F-4879-82E6-B86EF6986572}">NCAXLESTRUCT_TOPLC2</Type>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{B507963E-69F3-4B64-BB8C-2BD7A560976D}">NCAXLESTRUCT_TOPLC3</Type>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{10036166-C9D3-404B-BDD3-323034AAA7F4}"/>
+        </Relation>
+      </Relations>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_AdsAddress</Name>
+      <BitSize>224</BitSize>
+      <SubItem>
+        <Name>NetId</Name>
+        <Type>STRING(23)</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Port</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Channel</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_AxisStates</Name>
+      <Comment> 	PLCopen axis states
+	The axis states are defined in the PLCopen state diagram
+</Comment>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_UNDEFINED</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_DISABLED</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_STANDSTILL</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_ERRORSTOP</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_STOPPING</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_HOMING</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_DISCRETEMOTION</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_CONTINOUSMOTION</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_AXISSTATE_SYNCHRONIZEDMOTION</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_AxisOpModes</Name>
+      <Comment> axis operation mode feedback from NcToPlc. </Comment>
+      <BitSize>136</BitSize>
+      <SubItem>
+        <Name>PositionAreaMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 0 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TargetPositionMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 1 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LoopMode</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 2 - OpModeDWord - loop mode for two speed axes </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MotionMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 3 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PEHTimeMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 4 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>BacklashCompensation</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 5 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>40</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DelayedErrorReaction</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 6 - OpModeDWord  </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Modulo</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 7 - OpModeDWord - axis is parameterized as modulo axis </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>56</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SimulationAxis</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 8 - OpModeDWord - axis is a simulation axis - available from 2.11 R2 B2033 - 2011-05-31 KSt </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StopMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 12 - OpModeDWord - TargetPositionMonitoring for Stop and Halt commands - available from 2.11 R3 - 2011-12-09 KSt </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PositionLagMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 16 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>VelocityLagMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 17 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>88</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SoftLimitMinMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 18 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SoftLimitMaxMonitoring</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 19 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>104</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PositionCorrection</Name>
+        <Type>BOOL</Type>
+        <Comment> bit 20 - OpModeDWord </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AllowSlaveCommands</Name>
+        <Type>BOOL</Type>
+        <Comment> 2009-02-20 KSt </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>AllowExtSetAxisCommands</Name>
+        <Type>BOOL</Type>
+        <Comment> 2011-10-13 KSt </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_AxisStatus</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>UpdateTaskIndex</Name>
+        <Type>BYTE</Type>
+        <Comment> Task-Index of the task that updated this data set </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>UpdateCycleTime</Name>
+        <Type>LREAL</Type>
+        <Comment> task cycle time of the task which calls the status function </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CycleCounter</Name>
+        <Type>UDINT</Type>
+        <Comment> PLC cycle counter when this data set updated </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcCycleCounter</Name>
+        <Type>UDINT</Type>
+        <Comment> NC cycle counter incremented after NC task updated NcToPlc data structures </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MotionState</Name>
+        <Type Namespace="Tc2_MC2">MC_AxisStates</Type>
+        <Comment> motion state in the PLCopen state diagram </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 31 - axis error state </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> axis error code </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorStop</Name>
+        <Type>BOOL</Type>
+        <Comment> PLCopen motion control statemachine states: </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Disabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Stopping</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>StandStill</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DiscreteMotion</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ContinuousMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 19 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SynchronizedMotion</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Homing</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>312</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ConstantVelocity</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 12 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Accelerating</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Decelerating</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Operational</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 0 - (was ready) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ControlLoopClosed</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 20 - operational and position control active </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HasJob</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 8 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HasBeenStopped</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 7 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NewTargetPosition</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 17 - new target position commanded during move </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>376</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InPositionArea</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 3 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>InTargetPosition</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 4 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ProtectedMode</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 5 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Homed</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 1 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>HomingBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 11 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>416</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>MotionCommandsLocked</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 29 - stop 'n hold </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SoftLimitMinExceeded</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 26 - reverse soft travel limit exceeded </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SoftLimitMaxExceeded</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 27 - forward soft travel limit exceeded </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>440</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Moving</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 9+10 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PositiveDirection</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 9 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NegativeDirection</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 10 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NotMoving</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 2 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Compensating</Name>
+        <Type>BOOL</Type>
+        <Comment> superposition - overlayed motion </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExtSetPointGenEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 14 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>488</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PhasingActive</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 15 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ExternalLatchValid</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 16 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>504</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamDataQueued</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 22 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamTableQueued</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 21 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CamScalingPending</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 23 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>528</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CmdBuffered</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 24 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PTPmode</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 25 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DriveDeviceError</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 28 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>552</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IoDataInvalid</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 30 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorPropagationDelayed</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 6 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DriveLimitActive</Name>
+        <Type>BOOL</Type>
+        <Comment> StateDWord bit 18 - 20181213 Fap</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Coupled</Name>
+        <Type>BOOL</Type>
+        <Comment> Axis.NcToPlc.CoupleState </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>OpMode</Name>
+        <Type Namespace="Tc2_MC2">ST_AxisOpModes</Type>
+        <Comment> axis operation mode feedback from NcToPlc </Comment>
+        <BitSize>136</BitSize>
+        <BitOffs>592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcApplicationRequest</Name>
+        <Type>BOOL</Type>
+        <Comment> OpModeDWord bit 23 </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>728</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_AmsNetID</Name>
+      <Comment> TwinCAT AMS netID address string. </Comment>
+      <BitSize>192</BitSize>
+      <BaseType>STRING(23)</BaseType>
+    </DataType>
+    <DataType>
+      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+      <BitSize>48</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+      <ArrayInfo>
+        <LBound>0</LBound>
+        <Elements>6</Elements>
+      </ArrayInfo>
+      <Format>
+        <Printf>%d.%d.%d.%d.%d.%d</Printf>
+        <Parameter>[0]</Parameter>
+        <Parameter>[1]</Parameter>
+        <Parameter>[2]</Parameter>
+        <Parameter>[3]</Parameter>
+        <Parameter>[4]</Parameter>
+        <Parameter>[5]</Parameter>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_AmsNetIdArr</Name>
+      <Comment> TwinCAT AMS netID address bytes. </Comment>
+      <BitSize>48</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_AmsPort</Name>
+      <Comment> TwinCAT AMS port address. </Comment>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">E_NcDriveType</Name>
+      <BitSize>32</BitSize>
+      <BaseType>DWORD</BaseType>
+      <EnumInfo>
+        <Text>NcDriveType_undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_M2400_DAC1</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_M2400_DAC2</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_M2400_DAC3</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_M2400_DAC4</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_KL4XXX</Text>
+        <Enum>5</Enum>
+        <Comment> MDP 252/253: KL4xxx, PWM KL2502_30K (Frq-Cnt-Impuls-Modus), KL4132 (16 Bit), Pulse-Train KL2521, IP2512</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_KL4XXX_NonLinear</Text>
+        <Enum>6</Enum>
+        <Comment> MDP 252/253: Analog-Typ für nichtlineare Kennlinie</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_Discete_TwoSpeed</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_Stepper</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_Sercos</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_KL5051</Text>
+        <Enum>10</Enum>
+        <Comment> MDP 510: BISSI Drive KL5051 mit 32 Bit (siehe KL4XXX)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_AX2000_B200</Text>
+        <Enum>11</Enum>
+        <Comment> AX2000-B200 Lightbus, Inkremental mit 32 Bit (AX2000)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_ProfiDrive</Text>
+        <Enum>12</Enum>
+        <Comment> Inkremental mit 32 Bit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_Universal</Text>
+        <Enum>13</Enum>
+        <Comment> Variable Bitmaske (max. 32 Bit, signed value)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_NcBackplane</Text>
+        <Enum>14</Enum>
+        <Comment> Variable Bitmaske (max. 32 Bit, signed value)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_CANopen_Lenze</Text>
+        <Enum>15</Enum>
+        <Comment> CANopen Lenze (max. 32 Bit, signed value)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_CANopen_DS402_MDP742</Text>
+        <Enum>16</Enum>
+        <Comment> MDP 742 (DS402): CANopen und EtherCAT (AX2000-B510, AX2000-B1x0, EL7201, AX8000)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_AX2000_B900</Text>
+        <Enum>17</Enum>
+        <Comment> AX2000-B900 Ethernet (max. 32 Bit, signed value)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_KL2531_Stepper</Text>
+        <Enum>20</Enum>
+        <Comment> Schrittmotorklemme KL2531/KL2541</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_KL2532_DC</Text>
+        <Enum>21</Enum>
+        <Comment> 2-Kanal-DC-Motor-Endstufe (2-channel DC motor stage) KL2532/KL2542, 2-Kanal-PWM-DC-Motorendstufe KL2535/KL2545</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_TCOM</Text>
+        <Enum>22</Enum>
+        <Comment> TCOM Drive -&gt; Interface to Soft Drive</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_MDP_733</Text>
+        <Enum>23</Enum>
+        <Comment> MDP 733: Modular Device Profile MDP 733 for DC (e.g. EL7332/EL7342) (20.02.09)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcDriveType_MDP_703</Text>
+        <Enum>24</Enum>
+        <Comment> MDP 703: Modular Device Profile MDP 703 for stepper (e.g. EL7031/EL7041) </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">E_NcEncoderType</Name>
+      <BitSize>32</BitSize>
+      <BaseType>DWORD</BaseType>
+      <EnumInfo>
+        <Text>NcEncoderType_undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_Simulation</Text>
+        <Enum>1</Enum>
+        <Comment> Simulation</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_ABS_M3000</Text>
+        <Enum>2</Enum>
+        <Comment> Absolut mit 24 und 25 Bit sowie 12 und 13 Bit Single Turn Encoder (M3000)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_M31X0</Text>
+        <Enum>3</Enum>
+        <Comment> Inkremental mit 24 Bit (M31x0, M3200, M3100, M2000)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_KL5101</Text>
+        <Enum>4</Enum>
+        <Comment> MDP 511: Inkremental mit 16 Bit und Latch (MDP511: EL7041, EL5101, EL5151, EL2521, EL5021(SinCos); KL5101, IP5109, KL5111)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_ABS_KL5001_SSI</Text>
+        <Enum>5</Enum>
+        <Comment> MDP 500/501: Absolut SSI mit 24 Bit (KL5001, IP5009)(MDP 501: EL5001)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_KL5051</Text>
+        <Enum>6</Enum>
+        <Comment> MDP 510: Absolut/Inkremental BISSI mit 16 Bit (KL5051, PWM KL2502_30K (Frq-Cnt-Impuls-Modus), Pulse-Train KL2521, IP2512 ) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_ABS_KL30XX</Text>
+        <Enum>7</Enum>
+        <Comment> Absolut Analog Eingang mit 16 Bit (KL30xx)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_Sercos_P</Text>
+        <Enum>8</Enum>
+        <Comment> SERCOS "Encoder" POS</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_Sercos_PV</Text>
+        <Enum>9</Enum>
+        <Comment> SERCOS "Encoder" POS und VELO</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_Binary</Text>
+        <Enum>10</Enum>
+        <Comment> Binaerer Inkremental Encoder (0/1)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_ABS_M2510</Text>
+        <Enum>11</Enum>
+        <Comment> Absolut Analog Eingang mit 12 Bit (M2510)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_ABS_FOX50</Text>
+        <Enum>12</Enum>
+        <Comment> T&amp;R Fox 50 Modul (24 Bit Absolut (SSI))</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_ABS_HYDRAULIC_FORCE</Text>
+        <Enum>13</Enum>
+        <Comment> MMW-Typ: Kraftermittlung aus Pa, Pb, Aa, Ab</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_AX2000_B200</Text>
+        <Enum>14</Enum>
+        <Comment> Inkremental AX2000-B200 Lightbus mit 16/20 Bit (AX2000)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_PROFIDRIVE</Text>
+        <Enum>15</Enum>
+        <Comment> Inkremental mit 32 Bit</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_UNIVERSAL</Text>
+        <Enum>16</Enum>
+        <Comment> Inkremental mit variabler Bitmaske (max. 32 Bit)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_NCBACKPLANE</Text>
+        <Enum>17</Enum>
+        <Comment> Inkremental NC Rückwand</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_CANOPEN_LENZE</Text>
+        <Enum>18</Enum>
+        <Comment> Inkremental CANopen Lenze</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_CANOPEN_DS402_MDP513_MDP742</Text>
+        <Enum>19</Enum>
+        <Comment> MDP 513 / MDP 742 (DS402): CANopen und EtherCAT (AX2000-B510, AX2000-B1x0, EL7201, EL5032/32Bit)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_AX2000_B900</Text>
+        <Enum>20</Enum>
+        <Comment> Inkremental AX2000-B900 Ethernet</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_KL5151</Text>
+        <Enum>21</Enum>
+        <Comment> Inkremental mit 32 Bit Zaehler und int.+ ext. 32 Bit Latch (KL5151_0000) (nur umschaltbar), die 2-kanalige KL5151_0050 hat kein Latch !</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_IP5209</Text>
+        <Enum>24</Enum>
+        <Comment> Inkremental mit 32 Bit Zaehler und int. 32 Bit Latch (IP5209)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_KL2531_Stepper</Text>
+        <Enum>25</Enum>
+        <Comment> Inkremental mit 16 Bit Zaehler und int.+ext. 16 Bit Latch (nur umschaltbar) (Schrittmotorklemme KL2531/KL2541)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_KL2532_DC</Text>
+        <Enum>26</Enum>
+        <Comment> Inkremental mit 16 Bit Zaehler und ext. 16 Bit Latch (nur umschaltbar) (2-Kanal-DC-Motor-Endstufe KL2532/KL2542), 2-Kanal-PWM-DC-Motorendstufe KL2535/KL2545</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_TIMEBASEGENERATOR</Text>
+        <Enum>27</Enum>
+        <Comment> Time Base Generator</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_TCOM</Text>
+        <Enum>28</Enum>
+        <Comment> TCOM Encoder -&gt; Interface to Soft Drive Encoder</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_INC_CANOPEN_MDP513_64BIT</Text>
+        <Enum>29</Enum>
+        <Comment> MDP 513 (DS402, EnDat2.2, 64 Bit): EL5032/64Bit</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcEncoderType_SPECIFIC</Text>
+        <Enum>100</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">E_NcAxisType</Name>
+      <BitSize>32</BitSize>
+      <BaseType>DWORD</BaseType>
+      <EnumInfo>
+        <Text>NcAxisType_undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_Continious</Text>
+        <Enum>1</Enum>
+        <Comment> Kontinuierliche Achse (auch SERCOS)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_Discrete_TwoSpeed</Text>
+        <Enum>2</Enum>
+        <Comment> Diskrete Achse (Eil/Schleich-Achse)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_LowCostStepper_DigIO</Text>
+        <Enum>3</Enum>
+        <Comment> Schrittmotor Achse (ohne PWM Klemme KL2502/30 und ohne Pulse-Train KL2521)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_Encoder</Text>
+        <Enum>5</Enum>
+        <Comment> Encoder Achse</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_Hydraulic</Text>
+        <Enum>6</Enum>
+        <Comment> Kontinuierliche Achse mit Betriebsartumschaltung fur Positions-/Druck-Regelung</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_TimeGenerator</Text>
+        <Enum>7</Enum>
+        <Comment> Time Base Generator </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NcAxisType_Specific</Text>
+        <Enum>100</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_DriveAddress</Name>
+      <BitSize>640</BitSize>
+      <SubItem>
+        <Name>NetID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> AMS NetID of the hardware drive as a string </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NetIdBytes</Name>
+        <Type Namespace="Tc2_System">T_AmsNetIdArr</Type>
+        <Comment> AMS NetID of the hardware drive as a byte array (same information as NetID) </Comment>
+        <BitSize>48</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>SlaveAddress</Name>
+        <Type Namespace="Tc2_System">T_AmsPort</Type>
+        <Comment> slave address of the hardware drive connected to a bus master </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Channel</Name>
+        <Type>BYTE</Type>
+        <Comment> channel number of the hardware drive </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcDriveId</Name>
+        <Type>DWORD</Type>
+        <Comment> ID [1..255] of the NC software drive of an axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcDriveIndex</Name>
+        <Type>DWORD</Type>
+        <Comment> index [0..9] of the NC software drive of an axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcDriveType</Name>
+        <Type Namespace="Tc2_MC2">E_NcDriveType</Type>
+        <Comment> type enumeration of the NC software drive of an axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcEncoderId</Name>
+        <Type>DWORD</Type>
+        <Comment> ID [1..255] of the NC software encoder of an axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcEncoderIndex</Name>
+        <Type>DWORD</Type>
+        <Comment> index [0..9] of the NC software encoder of an axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>416</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcEncoderType</Name>
+        <Type Namespace="Tc2_MC2">E_NcEncoderType</Type>
+        <Comment> type enumeration of the NC encoder drive of an axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcAxisId</Name>
+        <Type>DWORD</Type>
+        <Comment> ID [1..255] of the NC axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcAxisType</Name>
+        <Type Namespace="Tc2_MC2">E_NcAxisType</Type>
+        <Comment> type enumeration of the NC axis </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TcSoftDriveObjectId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <Comment> new since 2016-04-11 FAP - just available with versions after this date, otherwise zero </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TcDriveObjectId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TcEncoderObjectId</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_E_PhasingState</Name>
+      <Comment> Phasing internal probe states </Comment>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>PhasingInactive</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhasingActivated</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhasingAborted</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_InternalAxisRefData</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>NcCycleCounterAvailable</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the NcCycleCounter is definitely available on the target system - FALSE if undefined </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>NcCycleCounter_AtReadStatusCall</Name>
+        <Type>UDINT</Type>
+        <Comment> current NC cycle counter when calling ReadStatus </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LastTaskIndex_AtReadStatusCall</Name>
+        <Type>BYTE</Type>
+        <Comment> task index of last recent status update </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CounterSameTaskIndex_AtReadStatusCall</Name>
+        <Type>UINT</Type>
+        <Comment> counter increments to max 100 if the task index for the status update never changes </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PhasingState</Name>
+        <Type Namespace="Tc2_MC2">_E_PhasingState</Type>
+        <Comment> KSt 20190703 global handshake for phasing blocks</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">AXIS_REF</Name>
+      <Comment>
+	AXIS_REF data structure
+
+	The FBAXIS_REF is actually not a function block but a data structure
+	It includes the axis I/O variables as well as additional information.
+	The reason for not using a STRUCT is that structures cannot hold
+	located I/O variables.
+	The user is supposed to use the AXIS_REF data type which internally
+	redirects the type to this function block definition (alias).
+</Comment>
+      <BitSize>9024</BitSize>
+      <SubItem>
+        <Name>PlcToNc</Name>
+        <Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</Type>
+        <BitSize>1024</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>NcToPlc</Name>
+        <Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ADS</Name>
+        <Type Namespace="Tc2_MC2">ST_AdsAddress</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>3136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Status</Name>
+        <Type Namespace="Tc2_MC2">ST_AxisStatus</Type>
+        <BitSize>768</BitSize>
+        <BitOffs>3392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>DriveAddress</Name>
+        <Type Namespace="Tc2_MC2">ST_DriveAddress</Type>
+        <BitSize>640</BitSize>
+        <BitOffs>4160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>_internal</Name>
+        <Type Namespace="Tc2_MC2">_InternalAxisRefData</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>4800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Storage</Name>
+        <Type>DWORD</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>128</Elements>
+        </ArrayInfo>
+        <BitSize>4096</BitSize>
+        <BitOffs>4928</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ReadStatus</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>ALWAYS</Text>
+        <Enum>0</Enum>
+        <Comment> Always set bEnable to TRUE</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NEVER</Text>
+        <Enum>1</Enum>
+        <Comment> Only change bEnable on errors</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>DURING_MOTION</Text>
+        <Enum>2</Enum>
+        <Comment> Enable before motion, disable after motion</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>IF_ENABLED</Text>
+        <Enum>0</Enum>
+        <Comment> Disengage brake when the motor is enabled</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IF_MOVING</Text>
+        <Enum>1</Enum>
+        <Comment> Disengage brake when the motor is moving</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NO_BRAKE</Text>
+        <Enum>2</Enum>
+        <Comment> Do not change the brake state in FB_MotionStage</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>LOW_LIMIT</Text>
+        <Enum>1</Enum>
+        <Comment> Low limit switch</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>HIGH_LIMIT</Text>
+        <Enum>2</Enum>
+        <Comment> High limit switch</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>HOME_VIA_LOW</Text>
+        <Enum>3</Enum>
+        <Comment> Home switch via low switch</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>HOME_VIA_HIGH</Text>
+        <Enum>4</Enum>
+        <Comment> Home switch via high switch</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ABSOLUTE_SET</Text>
+        <Enum>15</Enum>
+        <Comment> Set here to be fHomePosition</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NONE</Text>
+        <Enum>-1</Enum>
+        <Comment> Do not home, ever</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_AxisParameterSet</Name>
+      <BitSize>8192</BitSize>
+      <SubItem>
+        <Name>AxisId</Name>
+        <Type>DWORD</Type>
+        <Comment> TC3 &amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp; </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nAxisType</Name>
+        <Type Namespace="Tc2_MC2">E_NcAxisType</Type>
+        <Comment> 0x00000003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sAxisName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00000002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAxisCycleTime</Name>
+        <Type>LREAL</Type>
+        <Comment> available from Tc 2.11 R2 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionAreaControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0000000F </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPositionAreaControlRange</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000010 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotionControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000011 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fMotionControlTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000012 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableLoop</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000013 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLoopDistance</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000014 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableTargetPosControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000015 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTargetPosControlRange</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000016 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTargetPosControlTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000017 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloMaximum</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000027 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRefVeloSearch</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000006 calibration velo (TO plc cam)		(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fRefVeloSync</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000007 calibration velo (off plc cam)	(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloSlowManual</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000008 manual velocity (slow)			(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloFastManual</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000009 manual velocity (fast)			(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fMotionControlRange</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000028 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePEHTimeControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000029 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPEHControlTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0000002A </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBacklashCompensation</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0000002B </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fBacklash</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0000002C </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sAmsNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> 0x00000031 (Wandlung von "BYTE b[6]" zum nullterminierten STRING mit 23+1 Zeichen) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPort</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000031 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nChnNo</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00000031 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAcceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000101 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDeceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000102 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fJerk</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00000103 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncId</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010001 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncType</Name>
+        <Type Namespace="Tc2_MC2">E_NcEncoderType</Type>
+        <Comment> 0x00010003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sEncName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00010002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScaleFactorNumerator</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010023 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScaleFactorDenominator</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010024 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScaleFactorInternal</Name>
+        <Type>LREAL</Type>
+        <Comment> fEncScaleFactorInternal = fEncScaleFactorNumerator / fEncScaleFactorDenominator </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncOffset</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010007 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncIsInverse</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00010008 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncModuloFactor</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010009 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncMode</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x0001000A </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncEnableSoftEndMinControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0001000B </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2784</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncEnableSoftEndMaxControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x0001000C </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncSoftEndMin</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0001000D </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncSoftEndMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0001000E </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncMaxIncrement</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010015 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncRefSoftSyncMask</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010108 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncEnablePosCorrection</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00010016 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncReferenceSystem</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00010019	(15.10.15: parameter extension) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3040</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncPosCorrectionFilterTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010017 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncRefSearchInverse</Name>
+        <Type>UINT</Type>
+        <Comment> 0x00010101 	(17.05.11: parameter extension) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3136</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEncRefSyncInverse</Name>
+        <Type>UINT</Type>
+        <Comment> 0x00010102 	(17.05.11: parameter extension) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEncRefMode</Name>
+        <Type>UDINT</Type>
+        <Comment> 0x00010107 	(17.05.11: parameter extension) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncRefPosition</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00010103 	(17.05.11: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlId</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00020001 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlType</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00020003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>3296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCtrlName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00020002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>3328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCtrlEnablePosDiffControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00020010 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3584</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCtrlEnableVeloDiffControl</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00020011 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>3600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosDiffMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020012 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosDiffMaxTime</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020013 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosKp</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020102 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3776</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosTn</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020103 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3840</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosTv</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020104 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosTd</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020105 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>3968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosExtKp</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020106 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlPosExtVelo</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020107 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlAccKa</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00020108 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDriveId</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00030001 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDriveType</Name>
+        <Type Namespace="Tc2_MC2">E_NcDriveType</Type>
+        <Comment> 0x00030003 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sDriveName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> 0x00030002 </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>4288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDriveIsInverse</Name>
+        <Type>WORD</Type>
+        <Comment> 0x00030006 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>4544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDriveControlDWord</Name>
+        <Type>DWORD</Type>
+        <Comment> 0x00030010 </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>4576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveVeloReferenz</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030101 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveOutputReferenz</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030102 </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveOutputScalingAcc</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0003000A	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveOutputScalingTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x0003000B	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveInputScalingTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030031	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4864</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveInputFiltertimeTorque</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030032	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDriveInputFiltertimeTorqueDerivative</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x00030033	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>4992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAccelerationMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x000000F1	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>5056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDecelerationMax</Name>
+        <Type>LREAL</Type>
+        <Comment> 0x000000F2	(15.10.15: parameter extension) </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>5120</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCommand</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCmdData</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fAcceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fDeceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bJogFwd</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bJogBwd</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLimitFwd</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLimitBwd</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOverride</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bHomeSensor</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bEnabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fActVelocity</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fActPosition</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fActDiff</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHomed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>712</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
+      <BitSize>21184</BitSize>
+      <SubItem>
+        <Name>Axis</Name>
+        <Type Namespace="Tc2_MC2">AXIS_REF</Type>
+        <Comment> Hardware 
+ PLC Axis Reference</Comment>
+        <BitSize>9024</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLimitForwardEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bLimitForwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if forward limit hit
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bLimitBackwardEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9032</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bLimitBackwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if reverse limit hit
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHome</Name>
+        <Type>BOOL</Type>
+        <Comment> NO Home Switch: TRUE if at home</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9040</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bHome
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if at homing switch
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBrakeRelease</Name>
+        <Type>BOOL</Type>
+        <Comment> NC Brake Output: TRUE to release brake</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9048</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bBrakeRelease
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if brake released
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHardwareEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> NC STO Input: TRUE if ok to move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRawEncoderULINT</Name>
+        <Type>ULINT</Type>
+        <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>9088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRawEncoderUINT</Name>
+        <Type>UINT</Type>
+        <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nRawEncoderINT</Name>
+        <Type>INT</Type>
+        <Comment> Raw encoder IO for INT (LVDT)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAllForwardEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Psuedo-hardware 
+ Forward enable EPS summary</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9184</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bAllForwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Summary of axis permission to move forward
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAllBackwardEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Backward enable EPS summary</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9192</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bAllBackwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Summary of axis permission to move backward
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAllEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Enable EPS summary encapsulating emergency stop button and any additional motion preventive hardware</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9200</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bAllEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Summary of axis permission to have power
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryForwardEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Forward virtual gantry limit switch</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9208</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bGantryForwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if gantry ok to move forward
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryBackwardEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Backward virtual gantry limit switch</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9216</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bGantryBackwardEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if gantry ok to move backward
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Encoder count summary, if linked above</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>9248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nEncoderCount
+        io: i
+        field: DESC Count from encoder hardware
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Settings 
+ Name to use for log messages, fast faults, etc.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>9280</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:sName
+        io: i
+        field: DESC PLC program name
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bPowerSelf</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we want to enable the motor independently of PMPS or other safety systems.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9928</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bPowerSelf
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC FALSE if axis is in PMPS
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEnableMode</Name>
+        <Type Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Type>
+        <Comment> Determines when we automatically enable the motor</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9936</BitOffs>
+        <Default>
+          <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nEnableMode
+        io: i
+        field: DESC Describes when the axis will automatically get power
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nBrakeMode</Name>
+        <Type Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Type>
+        <Comment> Determines when we automatically disengage the brake</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9952</BitOffs>
+        <Default>
+          <EnumText>ENUM_StageBrakeMode.IF_ENABLED</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nBrakeMode
+        io: i
+        field: DESC Describes when the brake will be released
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nHomingMode</Name>
+        <Type Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Type>
+        <Comment> Determines our encoder homing strategy</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>9968</BitOffs>
+        <Default>
+          <EnumText>ENUM_EpicsHomeCmd.NONE</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nHomingMode
+        io: i
+        field: DESC Describes our homing strategy
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAxis</Name>
+        <Type>BOOL</Type>
+        <Comment> Set true to activate gantry EPS</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>9984</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bGantryAxis
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if gantry EPS active
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTol</Name>
+        <Type>LINT</Type>
+        <Comment> Set to gantry difference tolerance</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10048</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nEncRef</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder count at which this axis is aligned with other axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10112</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Commands 
+ Used internally to request enables</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bEnable
+        io: io
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Used internally to request enables
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Used internally to reset errors and other state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bReset
+        io: io
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Used internally to reset errors
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Used internally and by the IOC to start or stop a move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bExecute
+        io: io
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC Used internally and by the IOC to start or stop
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUserEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Used by the IOC to disable an axis</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10200</BitOffs>
+        <Default>
+          <Bool>1</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bUserEnable
+        io: io
+        field: ZNAM DISABLE
+        field: ONAM ENABLE
+        field: DESC Used to disable power entirely for an axis
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveCmd</Name>
+        <Type>BOOL</Type>
+        <Comment> Shortcut Commands 
+ Start a move to fPosition with fVelocity</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bMoveCmd
+        io: io
+        field: DESC Start a move
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHomeCmd</Name>
+        <Type>BOOL</Type>
+        <Comment> Start the homing routine</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bHomeCmd
+        io: io
+        field: DESC Start the homing routine
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCommand</Name>
+        <Type>INT</Type>
+        <Comment> Command Args 
+ Used internally and by the IOC to pick what kind of move to do</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>10224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nCommand
+        io: io
+        field: DESC Used internally and by the IOC to pick move type
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCmdData</Name>
+        <Type>INT</Type>
+        <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>10240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nCmdData
+        io: io
+        field: DESC Used internally and by the IOC to pass extra args
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fPosition
+        io: io
+        field: DESC Used internally and by the IOC as the set position
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <Comment> Used internally and by the IOC to pick a move velocity</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10368</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fVelocity
+        io: io
+        field: DESC Used internally and by the IOC to set velocity
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAcceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fAcceleration
+        io: io
+        field: DESC Used internally and by the IOC to set acceleration
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDeceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fDeceleration
+        io: io
+        field: DESC Used internally and by the IOC to set deceleration
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fHomePosition</Name>
+        <Type>LREAL</Type>
+        <Comment> Used internally and by the IOC to pick a home position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>10560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fHomePosition
+        io: io
+        field: DESC Used internally and by the IOC to pick home position
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMotionAxisID</Name>
+        <Type>UDINT</Type>
+        <Comment> Info 
+ Unique ID assigned to each axis in the NC</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>10624</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nMotionAxisID
+        io: i
+        field: DESC Unique ID assigned to each axis in the NC
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableDone</Name>
+        <Type>BOOL</Type>
+        <Comment> Returns 
+ TRUE if done enabling</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10656</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bEnableDone
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if done enabling
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if in the middle of a command</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10664</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bBusy
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if in the middle of a command
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we've done a command and it has finished</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bDone
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if command finished successfully
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHomed</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the motor has been homed, or does not need to be homed</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10680</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bHomed
+        io: i
+        field: DESC TRUE if the motor has been homed
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSafetyReady</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have safety permission to move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10688</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bSafetyReady
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if safe to start a move
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're in an error state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>10696</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:bError
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if we are in an error state
+        update: 100Hz notify
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code if nonzero</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>10720</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:nErrorId
+        io: i
+        field: DESC Error code if nonzero
+        update: 100Hz notify
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Message to identify the error state</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>10752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:sErrorMessage
+        io: i
+        field: DESC Message to identify the error state
+        update: 100Hz notify
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sCustomErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Internal hook for custom error messages</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>11400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stAxisParameters</Name>
+        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
+        <Comment> MC_ReadParameterSet Output</Comment>
+        <BitSize>8192</BitSize>
+        <BitOffs>12096</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAxisParamsInit</Name>
+        <Type>BOOL</Type>
+        <Comment> True if we've updated stAxisParameters at least once</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>20288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stAxisStatus</Name>
+        <Type Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Type>
+        <Comment> Misc axis status information for the IOC</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>20352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPosDiff</Name>
+        <Type>LREAL</Type>
+        <Comment> Other status information for users of the IOC 
+ Position lag difference</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>21120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:fPosDiff
+        io: i
+        field: DESC Position lag difference
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="Tc2_System">T_MaxString</Name>
       <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
       <BitSize>2048</BitSize>
@@ -1216,59 +5594,6 @@
           <Value>-10</Value>
         </Default>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">R_TRIG</Name>
-      <Comment>
-	Rising Edge detection.
-</Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> Signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ClearComBuffer</Name>
@@ -2669,80 +6994,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_Standard">TON</Name>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>IN</Name>
-        <Type>BOOL</Type>
-        <Comment> starts timer with rising edge, resets timer with falling edge </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PT</Name>
-        <Type>TIME</Type>
-        <Comment> time to pass, before Q is set </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> gets TRUE, delay time (PT) after a rising edge at IN </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ET</Name>
-        <Type>TIME</Type>
-        <Comment> elapsed time </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>StartTime</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Name>
       <BitSize>35200</BitSize>
       <SubItem>
@@ -3430,12 +7681,6 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">T_AmsNetID</Name>
-      <Comment> TwinCAT AMS netID address string. </Comment>
-      <BitSize>192</BitSize>
-      <BaseType>STRING(23)</BaseType>
-    </DataType>
-    <DataType>
       <Name Namespace="Tc2_Utilities">ST_IPAdapterHwAddr</Name>
       <Comment> Local adapter hardware address </Comment>
       <BitSize>96</BitSize>
@@ -3621,12 +7866,6 @@
         <BitSize>32</BitSize>
         <BitOffs>4128</BitOffs>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">T_AmsPort</Name>
-      <Comment> TwinCAT AMS port address. </Comment>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_System">ADSREAD</Name>
@@ -5979,3845 +10218,6 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">PLCTONC_AXIS_REF_CTRL</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>FeedEnablePlus</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>1</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>FeedEnableMinus</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>2</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HomingSensor</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>5</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AcceptBlockedDrive</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PlcDebugFlag</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>30</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcDebugFlag</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>31</BitOffs>
-      </SubItem>
-      <Format Name="Short">
-        <Printf>%08x</Printf>
-      </Format>
-      <Format Name="Cpp">
-        <Printf>0x%08x</Printf>
-      </Format>
-      <Format Name="IEC">
-        <Printf>16#%08X</Printf>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
-      <BitSize>1024</BitSize>
-      <SubItem>
-        <Name>ControlDWord</Name>
-        <Type GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC">PLCTONC_AXIS_REF_CTRL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Override</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AxisModeRequest</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AxisModeDWord</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AxisModeLReal</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PositionCorrection</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtSetPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtSetVelo</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtSetAcc</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtSetDirection</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtControllerOutput</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>GearRatio1</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>GearRatio2</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>GearRatio3</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>GearRatio4</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MapState</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000030}">BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PlcCycleControl</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000001}">BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PlcCycleCount</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000001}">BYTE</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtTorque</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>NcStructType</Name>
-          <Value>1</Value>
-        </Property>
-      </Properties>
-      <Relations>
-        <Relation Priority="100">
-          <Type GUID="{60392271-8688-4F4C-B404-618DF106325D}"/>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}"/>
-        </Relation>
-      </Relations>
-    </DataType>
-    <DataType>
-      <Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>Operational</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Homed</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>1</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NotMoving</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>2</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InPositionArea</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>3</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InTargetPosition</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>4</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Protected</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>5</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorPropagationDelayed</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>6</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HasBeenStopped</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>7</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HasJob</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PositiveDirection</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>9</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NegativeDirection</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>10</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HomingBusy</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>11</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ConstantVelocity</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>12</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Compensating</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>13</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtSetPointGenEnabled</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>14</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PhasingActive</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>15</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExternalLatchValid</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NewTargetPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>17</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IsDriveLimitActive</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>18</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ContinuousMotion</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>19</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ControlLoopClosed</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>20</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamTableQueued</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>21</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamDataQueued</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>22</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamScalingPending</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>23</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CmdBuffered</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>24</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PTPmode</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>25</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SoftLimitMinExceeded</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>26</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SoftLimitMaxExceeded</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>27</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DriveDeviceError</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>28</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MotionCommandsLocked</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>29</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IoDataInvalid</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>30</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>31</BitOffs>
-      </SubItem>
-      <Format Name="Short">
-        <Printf>%08x</Printf>
-      </Format>
-      <Format Name="Cpp">
-        <Printf>0x%08x</Printf>
-      </Format>
-      <Format Name="IEC">
-        <Printf>16#%08X</Printf>
-      </Format>
-      <Relations>
-        <Relation Priority="100">
-          <Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
-        </Relation>
-      </Relations>
-    </DataType>
-    <DataType>
-      <Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>OpModePosAreaMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeTargetPosMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>1</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeLoop</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>2</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeMotionMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>3</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModePEHTimeMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>4</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeBacklashCompensation</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>5</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeDelayedErrorReaction</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>6</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeModulo</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>7</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeSimulationAxis</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModePosLagMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeVeloLagMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>17</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeSoftLimitMinMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>18</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeSoftLimitMaxMonitoring</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>19</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModePosCorrection</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>20</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeAllowSlaveCommands</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>21</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeAllowExtSetAxisCommands</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>22</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ApplicationRequest</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>23</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{303D9411-849C-467F-8A4C-5C8CD0F3DD46}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE2_FLAGS</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>AvoidingCollision</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <Format Name="Short">
-        <Printf>%08x</Printf>
-      </Format>
-      <Format Name="Cpp">
-        <Printf>0x%08x</Printf>
-      </Format>
-      <Format Name="IEC">
-        <Printf>16#%08X</Printf>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name GUID="{669F3788-48FD-42CF-8A59-2DA946853FB6}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE2</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>Value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Flags</Name>
-        <Type GUID="{303D9411-849C-467F-8A4C-5C8CD0F3DD46}" Namespace="MC">NCTOPLC_AXIS_REF_STATE2_FLAGS</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <Format Name="Short">
-        <Printf>%08x</Printf>
-      </Format>
-      <Format Name="Cpp">
-        <Printf>0x%08x</Printf>
-      </Format>
-      <Format Name="IEC">
-        <Printf>16#%08X</Printf>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3_FLAGS</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>TouchProbe1InputState </Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TouchProbe2InputState </Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>1</BitOffs>
-      </SubItem>
-      <Format Name="Short">
-        <Printf>%08x</Printf>
-      </Format>
-      <Format Name="Cpp">
-        <Printf>0x%08x</Printf>
-      </Format>
-      <Format Name="IEC">
-        <Printf>16#%08X</Printf>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3</Name>
-      <BitSize>32</BitSize>
-      <SubItem>
-        <Name>Value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Flags</Name>
-        <Type GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3_FLAGS</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <Format Name="Short">
-        <Printf>%08x</Printf>
-      </Format>
-      <Format Name="Cpp">
-        <Printf>0x%08x</Printf>
-      </Format>
-      <Format Name="IEC">
-        <Printf>16#%08X</Printf>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>CamActivationPending</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamDeactivationPending</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>1</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamActive</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>2</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamDataQueued</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>6</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamScalingPending</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-        <BitSize>1</BitSize>
-        <BitOffs>7</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{18071995-0000-0000-0000-000000000039}" TcBaseType="true" HideType="true">UINTARR8</Name>
-      <BitSize>128</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000005}">UINT</BaseType>
-      <ArrayInfo>
-        <LBound>0</LBound>
-        <Elements>8</Elements>
-      </ArrayInfo>
-    </DataType>
-    <DataType>
-      <Name GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
-      <BitSize>2048</BitSize>
-      <SubItem>
-        <Name>StateDWord</Name>
-        <Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorCode</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AxisState</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <Comment>Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AxisModeConfirmation</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HomingState</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <Comment>Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CoupleState</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <Comment>Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SvbEntries</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SafEntries</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AxisId</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpModeDWord</Name>
-        <Type GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC">NCTOPLC_AXIS_REF_OPMODE</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ModuloActPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActiveControlLoopIndex</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ControlLoopIndex</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ModuloActTurns</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActVelo</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PosDiff</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SetPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SetVelo</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SetAcc</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TargetPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ModuloSetPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ModuloSetTurns</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CmdNo</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CmdState</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000005}">UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1008</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SetJerk</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SetTorque</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActTorque</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>StateDWord2</Name>
-        <Type GUID="{669F3788-48FD-42CF-8A59-2DA946853FB6}" Namespace="MC">NCTOPLC_AXIS_REF_STATE2</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>StateDWord3</Name>
-        <Type GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1248</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TouchProbeState</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TouchProbeCounter</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1312</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamCouplingState</Name>
-        <Type GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>8</Elements>
-        </ArrayInfo>
-        <BitSize>64</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamCouplingTableID</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000039}">UINTARR8</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActTorqueDerivative</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SetTorqueDerivative</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AbsPhasingPos</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TorqueOffset</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1728</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActPosWithoutPosCorrection</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ActAcc</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1856</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DcTimeStamp</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>UserData</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1984</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>NcStructType</Name>
-          <Value>2</Value>
-        </Property>
-      </Properties>
-      <Relations>
-        <Relation Priority="100">
-          <Type GUID="{429B767E-373B-40AE-BFA5-E1C08B444DF3}">NCAXLESTRUCT_TOPLC</Type>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{E8DA524A-605F-4879-82E6-B86EF6986572}">NCAXLESTRUCT_TOPLC2</Type>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{B507963E-69F3-4B64-BB8C-2BD7A560976D}">NCAXLESTRUCT_TOPLC3</Type>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}"/>
-        </Relation>
-        <Relation Priority="100">
-          <Type GUID="{10036166-C9D3-404B-BDD3-323034AAA7F4}"/>
-        </Relation>
-      </Relations>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_AdsAddress</Name>
-      <BitSize>224</BitSize>
-      <SubItem>
-        <Name>NetId</Name>
-        <Type>STRING(23)</Type>
-        <BitSize>192</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Port</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Channel</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_AxisStates</Name>
-      <Comment> 	PLCopen axis states
-	The axis states are defined in the PLCopen state diagram
-</Comment>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_UNDEFINED</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_DISABLED</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_STANDSTILL</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_ERRORSTOP</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_STOPPING</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_HOMING</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_DISCRETEMOTION</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_CONTINOUSMOTION</Text>
-        <Enum>7</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_AXISSTATE_SYNCHRONIZEDMOTION</Text>
-        <Enum>8</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_AxisOpModes</Name>
-      <Comment> axis operation mode feedback from NcToPlc. </Comment>
-      <BitSize>136</BitSize>
-      <SubItem>
-        <Name>PositionAreaMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 0 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TargetPositionMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 1 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LoopMode</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 2 - OpModeDWord - loop mode for two speed axes </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MotionMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 3 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PEHTimeMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 4 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>BacklashCompensation</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 5 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>40</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DelayedErrorReaction</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 6 - OpModeDWord  </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>48</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Modulo</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 7 - OpModeDWord - axis is parameterized as modulo axis </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>56</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SimulationAxis</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 8 - OpModeDWord - axis is a simulation axis - available from 2.11 R2 B2033 - 2011-05-31 KSt </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>StopMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 12 - OpModeDWord - TargetPositionMonitoring for Stop and Halt commands - available from 2.11 R3 - 2011-12-09 KSt </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PositionLagMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 16 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>VelocityLagMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 17 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>88</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SoftLimitMinMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 18 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SoftLimitMaxMonitoring</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 19 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>104</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PositionCorrection</Name>
-        <Type>BOOL</Type>
-        <Comment> bit 20 - OpModeDWord </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AllowSlaveCommands</Name>
-        <Type>BOOL</Type>
-        <Comment> 2009-02-20 KSt </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>120</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>AllowExtSetAxisCommands</Name>
-        <Type>BOOL</Type>
-        <Comment> 2011-10-13 KSt </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_AxisStatus</Name>
-      <BitSize>768</BitSize>
-      <SubItem>
-        <Name>UpdateTaskIndex</Name>
-        <Type>BYTE</Type>
-        <Comment> Task-Index of the task that updated this data set </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>UpdateCycleTime</Name>
-        <Type>LREAL</Type>
-        <Comment> task cycle time of the task which calls the status function </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleCounter</Name>
-        <Type>UDINT</Type>
-        <Comment> PLC cycle counter when this data set updated </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcCycleCounter</Name>
-        <Type>UDINT</Type>
-        <Comment> NC cycle counter incremented after NC task updated NcToPlc data structures </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MotionState</Name>
-        <Type Namespace="Tc2_MC2">MC_AxisStates</Type>
-        <Comment> motion state in the PLCopen state diagram </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 31 - axis error state </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> axis error code </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorStop</Name>
-        <Type>BOOL</Type>
-        <Comment> PLCopen motion control statemachine states: </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Disabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Stopping</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>StandStill</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DiscreteMotion</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ContinuousMotion</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 19 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>296</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SynchronizedMotion</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>304</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Homing</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>312</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ConstantVelocity</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 12 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Accelerating</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Decelerating</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>336</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Operational</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 0 - (was ready) </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ControlLoopClosed</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 20 - operational and position control active </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HasJob</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 8 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>360</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HasBeenStopped</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 7 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>368</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NewTargetPosition</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 17 - new target position commanded during move </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>376</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InPositionArea</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 3 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InTargetPosition</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 4 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>392</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ProtectedMode</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 5 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>400</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Homed</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 1 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>HomingBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 11 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>416</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MotionCommandsLocked</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 29 - stop 'n hold </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SoftLimitMinExceeded</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 26 - reverse soft travel limit exceeded </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>432</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SoftLimitMaxExceeded</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 27 - forward soft travel limit exceeded </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>440</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Moving</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 9+10 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PositiveDirection</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 9 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>456</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NegativeDirection</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 10 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NotMoving</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 2 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Compensating</Name>
-        <Type>BOOL</Type>
-        <Comment> superposition - overlayed motion </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExtSetPointGenEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 14 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>488</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PhasingActive</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 15 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>496</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ExternalLatchValid</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 16 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>504</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamDataQueued</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 22 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamTableQueued</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 21 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CamScalingPending</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 23 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>528</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CmdBuffered</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 24 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PTPmode</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 25 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DriveDeviceError</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 28 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>552</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IoDataInvalid</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 30 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>560</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorPropagationDelayed</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 6 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>568</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DriveLimitActive</Name>
-        <Type>BOOL</Type>
-        <Comment> StateDWord bit 18 - 20181213 Fap</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Coupled</Name>
-        <Type>BOOL</Type>
-        <Comment> Axis.NcToPlc.CoupleState </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>584</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>OpMode</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisOpModes</Type>
-        <Comment> axis operation mode feedback from NcToPlc </Comment>
-        <BitSize>136</BitSize>
-        <BitOffs>592</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcApplicationRequest</Name>
-        <Type>BOOL</Type>
-        <Comment> OpModeDWord bit 23 </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>728</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-      <BitSize>48</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-      <ArrayInfo>
-        <LBound>0</LBound>
-        <Elements>6</Elements>
-      </ArrayInfo>
-      <Format>
-        <Printf>%d.%d.%d.%d.%d.%d</Printf>
-        <Parameter>[0]</Parameter>
-        <Parameter>[1]</Parameter>
-        <Parameter>[2]</Parameter>
-        <Parameter>[3]</Parameter>
-        <Parameter>[4]</Parameter>
-        <Parameter>[5]</Parameter>
-      </Format>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">T_AmsNetIdArr</Name>
-      <Comment> TwinCAT AMS netID address bytes. </Comment>
-      <BitSize>48</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">E_NcDriveType</Name>
-      <BitSize>32</BitSize>
-      <BaseType>DWORD</BaseType>
-      <EnumInfo>
-        <Text>NcDriveType_undefined</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_M2400_DAC1</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_M2400_DAC2</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_M2400_DAC3</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_M2400_DAC4</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_KL4XXX</Text>
-        <Enum>5</Enum>
-        <Comment> MDP 252/253: KL4xxx, PWM KL2502_30K (Frq-Cnt-Impuls-Modus), KL4132 (16 Bit), Pulse-Train KL2521, IP2512</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_KL4XXX_NonLinear</Text>
-        <Enum>6</Enum>
-        <Comment> MDP 252/253: Analog-Typ für nichtlineare Kennlinie</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_Discete_TwoSpeed</Text>
-        <Enum>7</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_Stepper</Text>
-        <Enum>8</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_Sercos</Text>
-        <Enum>9</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_KL5051</Text>
-        <Enum>10</Enum>
-        <Comment> MDP 510: BISSI Drive KL5051 mit 32 Bit (siehe KL4XXX)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_AX2000_B200</Text>
-        <Enum>11</Enum>
-        <Comment> AX2000-B200 Lightbus, Inkremental mit 32 Bit (AX2000)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_ProfiDrive</Text>
-        <Enum>12</Enum>
-        <Comment> Inkremental mit 32 Bit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_Universal</Text>
-        <Enum>13</Enum>
-        <Comment> Variable Bitmaske (max. 32 Bit, signed value)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_NcBackplane</Text>
-        <Enum>14</Enum>
-        <Comment> Variable Bitmaske (max. 32 Bit, signed value)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_CANopen_Lenze</Text>
-        <Enum>15</Enum>
-        <Comment> CANopen Lenze (max. 32 Bit, signed value)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_CANopen_DS402_MDP742</Text>
-        <Enum>16</Enum>
-        <Comment> MDP 742 (DS402): CANopen und EtherCAT (AX2000-B510, AX2000-B1x0, EL7201, AX8000)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_AX2000_B900</Text>
-        <Enum>17</Enum>
-        <Comment> AX2000-B900 Ethernet (max. 32 Bit, signed value)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_KL2531_Stepper</Text>
-        <Enum>20</Enum>
-        <Comment> Schrittmotorklemme KL2531/KL2541</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_KL2532_DC</Text>
-        <Enum>21</Enum>
-        <Comment> 2-Kanal-DC-Motor-Endstufe (2-channel DC motor stage) KL2532/KL2542, 2-Kanal-PWM-DC-Motorendstufe KL2535/KL2545</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_TCOM</Text>
-        <Enum>22</Enum>
-        <Comment> TCOM Drive -&gt; Interface to Soft Drive</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_MDP_733</Text>
-        <Enum>23</Enum>
-        <Comment> MDP 733: Modular Device Profile MDP 733 for DC (e.g. EL7332/EL7342) (20.02.09)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcDriveType_MDP_703</Text>
-        <Enum>24</Enum>
-        <Comment> MDP 703: Modular Device Profile MDP 703 for stepper (e.g. EL7031/EL7041) </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">E_NcEncoderType</Name>
-      <BitSize>32</BitSize>
-      <BaseType>DWORD</BaseType>
-      <EnumInfo>
-        <Text>NcEncoderType_undefined</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_Simulation</Text>
-        <Enum>1</Enum>
-        <Comment> Simulation</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_ABS_M3000</Text>
-        <Enum>2</Enum>
-        <Comment> Absolut mit 24 und 25 Bit sowie 12 und 13 Bit Single Turn Encoder (M3000)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_M31X0</Text>
-        <Enum>3</Enum>
-        <Comment> Inkremental mit 24 Bit (M31x0, M3200, M3100, M2000)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_KL5101</Text>
-        <Enum>4</Enum>
-        <Comment> MDP 511: Inkremental mit 16 Bit und Latch (MDP511: EL7041, EL5101, EL5151, EL2521, EL5021(SinCos); KL5101, IP5109, KL5111)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_ABS_KL5001_SSI</Text>
-        <Enum>5</Enum>
-        <Comment> MDP 500/501: Absolut SSI mit 24 Bit (KL5001, IP5009)(MDP 501: EL5001)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_KL5051</Text>
-        <Enum>6</Enum>
-        <Comment> MDP 510: Absolut/Inkremental BISSI mit 16 Bit (KL5051, PWM KL2502_30K (Frq-Cnt-Impuls-Modus), Pulse-Train KL2521, IP2512 ) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_ABS_KL30XX</Text>
-        <Enum>7</Enum>
-        <Comment> Absolut Analog Eingang mit 16 Bit (KL30xx)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_Sercos_P</Text>
-        <Enum>8</Enum>
-        <Comment> SERCOS "Encoder" POS</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_Sercos_PV</Text>
-        <Enum>9</Enum>
-        <Comment> SERCOS "Encoder" POS und VELO</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_Binary</Text>
-        <Enum>10</Enum>
-        <Comment> Binaerer Inkremental Encoder (0/1)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_ABS_M2510</Text>
-        <Enum>11</Enum>
-        <Comment> Absolut Analog Eingang mit 12 Bit (M2510)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_ABS_FOX50</Text>
-        <Enum>12</Enum>
-        <Comment> T&amp;R Fox 50 Modul (24 Bit Absolut (SSI))</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_ABS_HYDRAULIC_FORCE</Text>
-        <Enum>13</Enum>
-        <Comment> MMW-Typ: Kraftermittlung aus Pa, Pb, Aa, Ab</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_AX2000_B200</Text>
-        <Enum>14</Enum>
-        <Comment> Inkremental AX2000-B200 Lightbus mit 16/20 Bit (AX2000)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_PROFIDRIVE</Text>
-        <Enum>15</Enum>
-        <Comment> Inkremental mit 32 Bit</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_UNIVERSAL</Text>
-        <Enum>16</Enum>
-        <Comment> Inkremental mit variabler Bitmaske (max. 32 Bit)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_NCBACKPLANE</Text>
-        <Enum>17</Enum>
-        <Comment> Inkremental NC Rückwand</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_CANOPEN_LENZE</Text>
-        <Enum>18</Enum>
-        <Comment> Inkremental CANopen Lenze</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_CANOPEN_DS402_MDP513_MDP742</Text>
-        <Enum>19</Enum>
-        <Comment> MDP 513 / MDP 742 (DS402): CANopen und EtherCAT (AX2000-B510, AX2000-B1x0, EL7201, EL5032/32Bit)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_AX2000_B900</Text>
-        <Enum>20</Enum>
-        <Comment> Inkremental AX2000-B900 Ethernet</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_KL5151</Text>
-        <Enum>21</Enum>
-        <Comment> Inkremental mit 32 Bit Zaehler und int.+ ext. 32 Bit Latch (KL5151_0000) (nur umschaltbar), die 2-kanalige KL5151_0050 hat kein Latch !</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_IP5209</Text>
-        <Enum>24</Enum>
-        <Comment> Inkremental mit 32 Bit Zaehler und int. 32 Bit Latch (IP5209)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_KL2531_Stepper</Text>
-        <Enum>25</Enum>
-        <Comment> Inkremental mit 16 Bit Zaehler und int.+ext. 16 Bit Latch (nur umschaltbar) (Schrittmotorklemme KL2531/KL2541)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_KL2532_DC</Text>
-        <Enum>26</Enum>
-        <Comment> Inkremental mit 16 Bit Zaehler und ext. 16 Bit Latch (nur umschaltbar) (2-Kanal-DC-Motor-Endstufe KL2532/KL2542), 2-Kanal-PWM-DC-Motorendstufe KL2535/KL2545</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_TIMEBASEGENERATOR</Text>
-        <Enum>27</Enum>
-        <Comment> Time Base Generator</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_TCOM</Text>
-        <Enum>28</Enum>
-        <Comment> TCOM Encoder -&gt; Interface to Soft Drive Encoder</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_INC_CANOPEN_MDP513_64BIT</Text>
-        <Enum>29</Enum>
-        <Comment> MDP 513 (DS402, EnDat2.2, 64 Bit): EL5032/64Bit</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcEncoderType_SPECIFIC</Text>
-        <Enum>100</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">E_NcAxisType</Name>
-      <BitSize>32</BitSize>
-      <BaseType>DWORD</BaseType>
-      <EnumInfo>
-        <Text>NcAxisType_undefined</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_Continious</Text>
-        <Enum>1</Enum>
-        <Comment> Kontinuierliche Achse (auch SERCOS)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_Discrete_TwoSpeed</Text>
-        <Enum>2</Enum>
-        <Comment> Diskrete Achse (Eil/Schleich-Achse)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_LowCostStepper_DigIO</Text>
-        <Enum>3</Enum>
-        <Comment> Schrittmotor Achse (ohne PWM Klemme KL2502/30 und ohne Pulse-Train KL2521)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_Encoder</Text>
-        <Enum>5</Enum>
-        <Comment> Encoder Achse</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_Hydraulic</Text>
-        <Enum>6</Enum>
-        <Comment> Kontinuierliche Achse mit Betriebsartumschaltung fur Positions-/Druck-Regelung</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_TimeGenerator</Text>
-        <Enum>7</Enum>
-        <Comment> Time Base Generator </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcAxisType_Specific</Text>
-        <Enum>100</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_DriveAddress</Name>
-      <BitSize>640</BitSize>
-      <SubItem>
-        <Name>NetID</Name>
-        <Type Namespace="Tc2_System">T_AmsNetID</Type>
-        <Comment> AMS NetID of the hardware drive as a string </Comment>
-        <BitSize>192</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NetIdBytes</Name>
-        <Type Namespace="Tc2_System">T_AmsNetIdArr</Type>
-        <Comment> AMS NetID of the hardware drive as a byte array (same information as NetID) </Comment>
-        <BitSize>48</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>SlaveAddress</Name>
-        <Type Namespace="Tc2_System">T_AmsPort</Type>
-        <Comment> slave address of the hardware drive connected to a bus master </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>240</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Channel</Name>
-        <Type>BYTE</Type>
-        <Comment> channel number of the hardware drive </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcDriveId</Name>
-        <Type>DWORD</Type>
-        <Comment> ID [1..255] of the NC software drive of an axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcDriveIndex</Name>
-        <Type>DWORD</Type>
-        <Comment> index [0..9] of the NC software drive of an axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcDriveType</Name>
-        <Type Namespace="Tc2_MC2">E_NcDriveType</Type>
-        <Comment> type enumeration of the NC software drive of an axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcEncoderId</Name>
-        <Type>DWORD</Type>
-        <Comment> ID [1..255] of the NC software encoder of an axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcEncoderIndex</Name>
-        <Type>DWORD</Type>
-        <Comment> index [0..9] of the NC software encoder of an axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>416</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcEncoderType</Name>
-        <Type Namespace="Tc2_MC2">E_NcEncoderType</Type>
-        <Comment> type enumeration of the NC encoder drive of an axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcAxisId</Name>
-        <Type>DWORD</Type>
-        <Comment> ID [1..255] of the NC axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcAxisType</Name>
-        <Type Namespace="Tc2_MC2">E_NcAxisType</Type>
-        <Comment> type enumeration of the NC axis </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TcSoftDriveObjectId</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-        <Comment> new since 2016-04-11 FAP - just available with versions after this date, otherwise zero </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TcDriveObjectId</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>TcEncoderObjectId</Name>
-        <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>608</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_E_PhasingState</Name>
-      <Comment> Phasing internal probe states </Comment>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>PhasingInactive</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PhasingActivated</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PhasingAborted</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_InternalAxisRefData</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>NcCycleCounterAvailable</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the NcCycleCounter is definitely available on the target system - FALSE if undefined </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcCycleCounter_AtReadStatusCall</Name>
-        <Type>UDINT</Type>
-        <Comment> current NC cycle counter when calling ReadStatus </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LastTaskIndex_AtReadStatusCall</Name>
-        <Type>BYTE</Type>
-        <Comment> task index of last recent status update </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CounterSameTaskIndex_AtReadStatusCall</Name>
-        <Type>UINT</Type>
-        <Comment> counter increments to max 100 if the task index for the status update never changes </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PhasingState</Name>
-        <Type Namespace="Tc2_MC2">_E_PhasingState</Type>
-        <Comment> KSt 20190703 global handshake for phasing blocks</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">AXIS_REF</Name>
-      <Comment>
-	AXIS_REF data structure
-
-	The FBAXIS_REF is actually not a function block but a data structure
-	It includes the axis I/O variables as well as additional information.
-	The reason for not using a STRUCT is that structures cannot hold
-	located I/O variables.
-	The user is supposed to use the AXIS_REF data type which internally
-	redirects the type to this function block definition (alias).
-</Comment>
-      <BitSize>9024</BitSize>
-      <SubItem>
-        <Name>PlcToNc</Name>
-        <Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</Type>
-        <BitSize>1024</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>NcToPlc</Name>
-        <Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ADS</Name>
-        <Type Namespace="Tc2_MC2">ST_AdsAddress</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>3136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Status</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisStatus</Type>
-        <BitSize>768</BitSize>
-        <BitOffs>3392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>DriveAddress</Name>
-        <Type Namespace="Tc2_MC2">ST_DriveAddress</Type>
-        <BitSize>640</BitSize>
-        <BitOffs>4160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>_internal</Name>
-        <Type Namespace="Tc2_MC2">_InternalAxisRefData</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>4800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Storage</Name>
-        <Type>DWORD</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>128</Elements>
-        </ArrayInfo>
-        <BitSize>4096</BitSize>
-        <BitOffs>4928</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ReadStatus</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>ALWAYS</Text>
-        <Enum>0</Enum>
-        <Comment> Always set bEnable to TRUE</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NEVER</Text>
-        <Enum>1</Enum>
-        <Comment> Only change bEnable on errors</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>DURING_MOTION</Text>
-        <Enum>2</Enum>
-        <Comment> Enable before motion, disable after motion</Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>IF_ENABLED</Text>
-        <Enum>0</Enum>
-        <Comment> Disengage brake when the motor is enabled</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>IF_MOVING</Text>
-        <Enum>1</Enum>
-        <Comment> Disengage brake when the motor is moving</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NO_BRAKE</Text>
-        <Enum>2</Enum>
-        <Comment> Do not change the brake state in FB_MotionStage</Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>LOW_LIMIT</Text>
-        <Enum>1</Enum>
-        <Comment> Low limit switch</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>HIGH_LIMIT</Text>
-        <Enum>2</Enum>
-        <Comment> High limit switch</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>HOME_VIA_LOW</Text>
-        <Enum>3</Enum>
-        <Comment> Home switch via low switch</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>HOME_VIA_HIGH</Text>
-        <Enum>4</Enum>
-        <Comment> Home switch via high switch</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ABSOLUTE_SET</Text>
-        <Enum>15</Enum>
-        <Comment> Set here to be fHomePosition</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NONE</Text>
-        <Enum>-1</Enum>
-        <Comment> Do not home, ever</Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_AxisParameterSet</Name>
-      <BitSize>8192</BitSize>
-      <SubItem>
-        <Name>AxisId</Name>
-        <Type>DWORD</Type>
-        <Comment> TC3 &amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp; </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nAxisType</Name>
-        <Type Namespace="Tc2_MC2">E_NcAxisType</Type>
-        <Comment> 0x00000003 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sAxisName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> 0x00000002 </Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fAxisCycleTime</Name>
-        <Type>LREAL</Type>
-        <Comment> available from Tc 2.11 R2 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnablePositionAreaControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x0000000F </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPositionAreaControlRange</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000010 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableMotionControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00000011 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fMotionControlTime</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000012 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableLoop</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00000013 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLoopDistance</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000014 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableTargetPosControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00000015 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTargetPosControlRange</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000016 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTargetPosControlTime</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000017 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloMaximum</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000027 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fRefVeloSearch</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000006 calibration velo (TO plc cam)		(17.05.11: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fRefVeloSync</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000007 calibration velo (off plc cam)	(17.05.11: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloSlowManual</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000008 manual velocity (slow)			(17.05.11: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloFastManual</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000009 manual velocity (fast)			(17.05.11: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fMotionControlRange</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000028 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnablePEHTimeControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00000029 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPEHControlTime</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x0000002A </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableBacklashCompensation</Name>
-        <Type>WORD</Type>
-        <Comment> 0x0000002B </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fBacklash</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x0000002C </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sAmsNetId</Name>
-        <Type Namespace="Tc2_System">T_AmsNetID</Type>
-        <Comment> 0x00000031 (Wandlung von "BYTE b[6]" zum nullterminierten STRING mit 23+1 Zeichen) </Comment>
-        <BitSize>192</BitSize>
-        <BitOffs>1600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nPort</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00000031 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nChnNo</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00000031 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1808</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fAcceleration</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000101 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1856</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDeceleration</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000102 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fJerk</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00000103 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>1984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncId</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00010001 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncType</Name>
-        <Type Namespace="Tc2_MC2">E_NcEncoderType</Type>
-        <Comment> 0x00010003 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sEncName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> 0x00010002 </Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>2112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScaleFactorNumerator</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00010023 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2368</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScaleFactorDenominator</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00010024 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2432</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScaleFactorInternal</Name>
-        <Type>LREAL</Type>
-        <Comment> fEncScaleFactorInternal = fEncScaleFactorNumerator / fEncScaleFactorDenominator </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2496</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncOffset</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00010007 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2560</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEncIsInverse</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00010008 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncModuloFactor</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00010009 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncMode</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x0001000A </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEncEnableSoftEndMinControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x0001000B </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2784</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEncEnableSoftEndMaxControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x0001000C </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncSoftEndMin</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x0001000D </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2816</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncSoftEndMax</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x0001000E </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncMaxIncrement</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00010015 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2944</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncRefSoftSyncMask</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00010108 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEncEnablePosCorrection</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00010016 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>3008</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncReferenceSystem</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00010019	(15.10.15: parameter extension) </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>3040</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncPosCorrectionFilterTime</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00010017 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3072</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEncRefSearchInverse</Name>
-        <Type>UINT</Type>
-        <Comment> 0x00010101 	(17.05.11: parameter extension) </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>3136</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEncRefSyncInverse</Name>
-        <Type>UINT</Type>
-        <Comment> 0x00010102 	(17.05.11: parameter extension) </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>3152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEncRefMode</Name>
-        <Type>UDINT</Type>
-        <Comment> 0x00010107 	(17.05.11: parameter extension) </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>3168</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncRefPosition</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00010103 	(17.05.11: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3200</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCtrlId</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00020001 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>3264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCtrlType</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00020003 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>3296</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sCtrlName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> 0x00020002 </Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>3328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCtrlEnablePosDiffControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00020010 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>3584</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCtrlEnableVeloDiffControl</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00020011 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>3600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosDiffMax</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020012 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosDiffMaxTime</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020013 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosKp</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020102 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3776</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosTn</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020103 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3840</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosTv</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020104 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3904</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosTd</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020105 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>3968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosExtKp</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020106 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4032</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlPosExtVelo</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020107 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4096</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlAccKa</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00020108 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nDriveId</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00030001 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>4224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nDriveType</Name>
-        <Type Namespace="Tc2_MC2">E_NcDriveType</Type>
-        <Comment> 0x00030003 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>4256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sDriveName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> 0x00030002 </Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>4288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bDriveIsInverse</Name>
-        <Type>WORD</Type>
-        <Comment> 0x00030006 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>4544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nDriveControlDWord</Name>
-        <Type>DWORD</Type>
-        <Comment> 0x00030010 </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>4576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveVeloReferenz</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00030101 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveOutputReferenz</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00030102 </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveOutputScalingAcc</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x0003000A	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveOutputScalingTorque</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x0003000B	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveInputScalingTorque</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00030031	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4864</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveInputFiltertimeTorque</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00030032	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4928</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDriveInputFiltertimeTorqueDerivative</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x00030033	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>4992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fAccelerationMax</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x000000F1	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>5056</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDecelerationMax</Name>
-        <Type>LREAL</Type>
-        <Comment> 0x000000F2	(15.10.15: parameter extension) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>5120</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Name>
-      <BitSize>768</BitSize>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCommand</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCmdData</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>48</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPosition</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fAcceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fDeceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bJogFwd</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bJogBwd</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLimitFwd</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>336</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLimitBwd</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOverride</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>100</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bHomeSensor</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bEnabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>456</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fActVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fActPosition</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fActDiff</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bHomed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>712</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
-      <BitSize>21184</BitSize>
-      <SubItem>
-        <Name>Axis</Name>
-        <Type Namespace="Tc2_MC2">AXIS_REF</Type>
-        <Comment> Hardware 
- PLC Axis Reference</Comment>
-        <BitSize>9024</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLimitForwardEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bLimitBackwardEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9032</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHome</Name>
-        <Type>BOOL</Type>
-        <Comment> NO Home Switch: TRUE if at home</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9040</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBrakeRelease</Name>
-        <Type>BOOL</Type>
-        <Comment> NC Brake Output: TRUE to release brake</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9048</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHardwareEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> NC STO Input: TRUE if ok to move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9056</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nRawEncoderULINT</Name>
-        <Type>ULINT</Type>
-        <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>9088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nRawEncoderUINT</Name>
-        <Type>UINT</Type>
-        <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>9152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nRawEncoderINT</Name>
-        <Type>INT</Type>
-        <Comment> Raw encoder IO for INT (LVDT)</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>9168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAllForwardEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Psuedo-hardware 
- Forward enable EPS summary</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9184</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move forward
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAllBackwardEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Backward enable EPS summary</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9192</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move backward
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAllEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Enable EPS summary encapsulating emergency stop button and any additional motion preventive hardware</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9200</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to have power
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryForwardEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Forward virtual gantry limit switch</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9208</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move forward
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryBackwardEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Backward virtual gantry limit switch</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9216</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move backward
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nEncoderCount</Name>
-        <Type>UDINT</Type>
-        <Comment> Encoder count summary, if linked above</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>9248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nEncoderCount
-        io: i
-        field: DESC Count from encoder hardware
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Settings 
- Name to use for log messages, fast faults, etc.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>9280</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:sName
-        io: i
-        field: DESC PLC program name
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bPowerSelf</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we want to enable the motor independently of PMPS or other safety systems.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9928</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bPowerSelf
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if axis is in PMPS
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nEnableMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Type>
-        <Comment> Determines when we automatically enable the motor</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>9936</BitOffs>
-        <Default>
-          <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nEnableMode
-        io: i
-        field: DESC Describes when the axis will automatically get power
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nBrakeMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Type>
-        <Comment> Determines when we automatically disengage the brake</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>9952</BitOffs>
-        <Default>
-          <EnumText>ENUM_StageBrakeMode.IF_ENABLED</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nBrakeMode
-        io: i
-        field: DESC Describes when the brake will be released
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nHomingMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Type>
-        <Comment> Determines our encoder homing strategy</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>9968</BitOffs>
-        <Default>
-          <EnumText>ENUM_EpicsHomeCmd.NONE</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nHomingMode
-        io: i
-        field: DESC Describes our homing strategy
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAxis</Name>
-        <Type>BOOL</Type>
-        <Comment> Set true to activate gantry EPS</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>9984</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryAxis
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry EPS active
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTol</Name>
-        <Type>LINT</Type>
-        <Comment> Set to gantry difference tolerance</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10048</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nEncRef</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder count at which this axis is aligned with other axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10112</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Commands 
- Used internally to request enables</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnable
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally to request enables
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Used internally to reset errors and other state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bReset
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally to reset errors
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Used internally and by the IOC to start or stop a move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bExecute
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally and by the IOC to start or stop
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUserEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Used by the IOC to disable an axis</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10200</BitOffs>
-        <Default>
-          <Bool>1</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bUserEnable
-        io: io
-        field: ZNAM DISABLE
-        field: ONAM ENABLE
-        field: DESC Used to disable power entirely for an axis
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveCmd</Name>
-        <Type>BOOL</Type>
-        <Comment> Shortcut Commands 
- Start a move to fPosition with fVelocity</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bMoveCmd
-        io: io
-        field: DESC Start a move
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHomeCmd</Name>
-        <Type>BOOL</Type>
-        <Comment> Start the homing routine</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHomeCmd
-        io: io
-        field: DESC Start the homing routine
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCommand</Name>
-        <Type>INT</Type>
-        <Comment> Command Args 
- Used internally and by the IOC to pick what kind of move to do</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>10224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCommand
-        io: io
-        field: DESC Used internally and by the IOC to pick move type
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCmdData</Name>
-        <Type>INT</Type>
-        <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>10240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCmdData
-        io: io
-        field: DESC Used internally and by the IOC to pass extra args
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosition</Name>
-        <Type>LREAL</Type>
-        <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fPosition
-        io: io
-        field: DESC Used internally and by the IOC as the set position
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVelocity</Name>
-        <Type>LREAL</Type>
-        <Comment> Used internally and by the IOC to pick a move velocity</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10368</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fVelocity
-        io: io
-        field: DESC Used internally and by the IOC to set velocity
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAcceleration</Name>
-        <Type>LREAL</Type>
-        <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fAcceleration
-        io: io
-        field: DESC Used internally and by the IOC to set acceleration
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDeceleration</Name>
-        <Type>LREAL</Type>
-        <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fDeceleration
-        io: io
-        field: DESC Used internally and by the IOC to set deceleration
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fHomePosition</Name>
-        <Type>LREAL</Type>
-        <Comment> Used internally and by the IOC to pick a home position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>10560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fHomePosition
-        io: io
-        field: DESC Used internally and by the IOC to pick home position
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nMotionAxisID</Name>
-        <Type>UDINT</Type>
-        <Comment> Info 
- Unique ID assigned to each axis in the NC</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>10624</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nMotionAxisID
-        io: i
-        field: DESC Unique ID assigned to each axis in the NC
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableDone</Name>
-        <Type>BOOL</Type>
-        <Comment> Returns 
- TRUE if done enabling</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10656</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnableDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if done enabling
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if in the middle of a command</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10664</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBusy
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if in the middle of a command
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we've done a command and it has finished</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10672</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if command finished successfully
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHomed</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the motor has been homed, or does not need to be homed</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10680</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHomed
-        io: i
-        field: DESC TRUE if the motor has been homed
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSafetyReady</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we have safety permission to move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10688</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bSafetyReady
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if safe to start a move
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're in an error state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>10696</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bError
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if we are in an error state
-        update: 100Hz notify
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code if nonzero</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>10720</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nErrorId
-        io: i
-        field: DESC Error code if nonzero
-        update: 100Hz notify
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Message to identify the error state</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>10752</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:sErrorMessage
-        io: i
-        field: DESC Message to identify the error state
-        update: 100Hz notify
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sCustomErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Internal hook for custom error messages</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>11400</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stAxisParameters</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
-        <Comment> MC_ReadParameterSet Output</Comment>
-        <BitSize>8192</BitSize>
-        <BitOffs>12096</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAxisParamsInit</Name>
-        <Type>BOOL</Type>
-        <Comment> True if we've updated stAxisParameters at least once</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>20288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stAxisStatus</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Type>
-        <Comment> Misc axis status information for the IOC</Comment>
-        <BitSize>768</BitSize>
-        <BitOffs>20352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPosDiff</Name>
-        <Type>LREAL</Type>
-        <Comment> Other status information for users of the IOC 
- Position lag difference</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>21120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fPosDiff
-        io: i
-        field: DESC Position lag difference
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
       <Comment>Defacto system structure, must be included in all projects</Comment>
       <BitSize>40</BitSize>
@@ -9991,31 +10391,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162883776</GetCodeOffs>
+        <GetCodeOffs>162885272</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162883848</GetCodeOffs>
+        <GetCodeOffs>162885344</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162883864</GetCodeOffs>
+        <GetCodeOffs>162885360</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162883824</GetCodeOffs>
+        <GetCodeOffs>162885320</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162883856</GetCodeOffs>
+        <GetCodeOffs>162885352</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11267,15 +11667,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162883648</GetCodeOffs>
-        <SetCodeOffs>162883696</SetCodeOffs>
+        <GetCodeOffs>162885144</GetCodeOffs>
+        <SetCodeOffs>162885192</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162883728</GetCodeOffs>
-        <SetCodeOffs>162883752</SetCodeOffs>
+        <GetCodeOffs>162885224</GetCodeOffs>
+        <SetCodeOffs>162885248</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11516,31 +11916,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>162883960</GetCodeOffs>
+        <GetCodeOffs>162885456</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>162883920</GetCodeOffs>
+        <GetCodeOffs>162885416</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162884096</GetCodeOffs>
+        <GetCodeOffs>162885592</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162884104</GetCodeOffs>
+        <GetCodeOffs>162885600</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162884016</GetCodeOffs>
+        <GetCodeOffs>162885512</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11552,7 +11952,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162884112</GetCodeOffs>
+        <GetCodeOffs>162885608</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12145,7 +12545,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>162884168</GetCodeOffs>
+        <GetCodeOffs>162885664</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -36544,7 +36944,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>162895792</GetCodeOffs>
+        <GetCodeOffs>162897288</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -38472,31 +38872,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162895192</GetCodeOffs>
+        <GetCodeOffs>162896688</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162895280</GetCodeOffs>
+        <GetCodeOffs>162896776</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162895208</GetCodeOffs>
+        <GetCodeOffs>162896704</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162895256</GetCodeOffs>
+        <GetCodeOffs>162896752</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162895296</GetCodeOffs>
+        <GetCodeOffs>162896792</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -42438,116 +42838,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General">FB_DataBuffer</Name>
-      <BitSize>448</BitSize>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Whether or not to accumulate on this cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pInputAdr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Address of the value to accumulate</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iInputSize</Name>
-        <Type>UDINT</Type>
-        <Comment> Size of the accumulated value</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iElemCount</Name>
-        <Type>UDINT</Type>
-        <Comment> Number of values in the output array</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pPartialAdr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Address of the rolling buffer to be filled every cycle</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pOutputAdr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Address of the output buffer to be filled when the rolling buffer is full</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bNewArray</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE on the cycle that we copy the output array</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iArrayIndex</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>416</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
       <BitSize>128704</BitSize>
       <SubItem>
@@ -42619,296 +42909,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="LCLS_General">FB_DataBuffer</Type>
         <BitSize>448</BitSize>
         <BitOffs>128256</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_BasicStats</Name>
-      <BitSize>1152</BitSize>
-      <SubItem>
-        <Name>aSignal</Name>
-        <Type PointerTo="1">LREAL</Type>
-        <Comment> Input array of floats</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:DATA
-        io: i
-    </Value>
-          </Property>
-          <Property>
-            <Name>variable_length_array</Name>
-          </Property>
-          <Property>
-            <Name>Dimensions</Name>
-            <Value>1</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAlwaysCalc</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we will update the results every cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATS:ALWAYS_CALC</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> On rising edge, do one calculation</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATS:EXECUTE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> If set to TRUE, reset outputs</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATS:RESET</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nElems</Name>
-        <Type>UDINT</Type>
-        <Comment> If nonzero, we will only pay attention to the first nElems items in aSignal</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:NELM
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMean</Name>
-        <Type>LREAL</Type>
-        <Comment> Average of all values in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:MEAN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fStDev</Name>
-        <Type>LREAL</Type>
-        <Comment> Standard deviation of all values in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:STDEV
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMax</Name>
-        <Type>LREAL</Type>
-        <Comment> Largest value in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:MAX
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMin</Name>
-        <Type>LREAL</Type>
-        <Comment> Smallest value in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:MIN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fRange</Name>
-        <Type>LREAL</Type>
-        <Comment> Largest array element subtracted by the smallest</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:RANGE
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fRMS</Name>
-        <Type>LREAL</Type>
-        <Comment> RMS of all values in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:RMS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValid</Name>
-        <Type>BOOL</Type>
-        <Comment> True if the other outputs are valid</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:VALID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rTrig</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nElemsSeen</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fRMSSum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVarianceSum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVarianceMean</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -72293,20 +72293,27 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Context>
         <Context>
           <Id NeedCalleeCall="true">1</Id>
+          <Name>StatsTask</Name>
+          <ManualConfig>
+            <OTCID>#x02010090</OTCID>
+          </ManualConfig>
+        </Context>
+        <Context>
+          <Id NeedCalleeCall="true">2</Id>
           <Name>PiezoDriver</Name>
           <ManualConfig>
             <OTCID>#x02010060</OTCID>
           </ManualConfig>
         </Context>
         <Context>
-          <Id NeedCalleeCall="true">2</Id>
+          <Id NeedCalleeCall="true">3</Id>
           <Name>DaqTask</Name>
           <ManualConfig>
             <OTCID>#x02010080</OTCID>
           </ManualConfig>
         </Context>
         <Context>
-          <Id NeedCalleeCall="true">3</Id>
+          <Id NeedCalleeCall="true">4</Id>
           <Name>PlcTask</Name>
           <ManualConfig>
             <OTCID>#x02010030</OTCID>
@@ -72319,7 +72326,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72335,14 +72342,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294467648</BitOffs>
+            <BitOffs>1294474304</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72356,19 +72363,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294467840</BitOffs>
+            <BitOffs>1294474496</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>1271631936</BitOffs>
+            <BitOffs>1271636288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_M1K2</Name>
@@ -72380,7 +72387,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292415088</BitOffs>
+            <BitOffs>1292421760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -72391,7 +72398,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292417600</BitOffs>
+            <BitOffs>1292424272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -72405,7 +72412,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302784928</BitOffs>
+            <BitOffs>1302850272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -72419,7 +72426,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302784960</BitOffs>
+            <BitOffs>1302850304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -72433,7 +72440,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302791104</BitOffs>
+            <BitOffs>1302857472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -72454,20 +72461,196 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302791360</BitOffs>
+            <BitOffs>1302857792</BitOffs>
+          </Symbol>
+        </DataArea>
+        <DataArea>
+          <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
+          <Name>StatsTask Inputs</Name>
+          <ContextId>1</ContextId>
+          <ByteSize>164233216</ByteSize>
+          <Symbol>
+            <Name>Main.M7.Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1295912576</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
-          <Name>PiezoDriver Internal</Name>
+          <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ByteSize>164233216</ByteSize>
+          <Symbol>
+            <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
+            <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1271647680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.fbGpiPosDiffCollect</Name>
+            <BitSize>448</BitSize>
+            <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
+            <BitOffs>1271775744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.fbGpiPosDiffStats</Name>
+            <BitSize>1152</BitSize>
+            <BaseType Namespace="LCLS_General">FB_BasicStats</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:G_PI:ENCDIFF
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1271776192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.fGpiRangeMax</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1271777344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.rtNewGpiMove</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
+            <BitOffs>1271777408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.tonNewGpiMove</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="Tc2_Standard">TON</BaseType>
+            <BitOffs>1271777536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7</Name>
+            <Comment> G_PI, urad</Comment>
+            <BitSize>21184</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:G_PI
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[g_pi_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[g_pi_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[g_pi_up_dwn_e]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1295911488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1302857504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1302857536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
+            <BitSize>896</BitSize>
+            <BaseType>_Implicit_Task_Info</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.dwVersion</Name>
+                <Value>2</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcContextName</Name>
+                <Value>StatsTask</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1302858688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afGpiPosDiffBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1311032128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afGpiExtraBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1311672128</BitOffs>
+          </Symbol>
+        </DataArea>
+        <DataArea>
+          <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
+          <Name>PiezoDriver Internal</Name>
+          <ContextId>2</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1264929344</BitOffs>
+            <BitOffs>1265714496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -72502,7 +72685,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423360</BitOffs>
+            <BitOffs>1292430016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -72516,7 +72699,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302791136</BitOffs>
+            <BitOffs>1302857568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -72530,7 +72713,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302791168</BitOffs>
+            <BitOffs>1302857600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -72551,14 +72734,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302792256</BitOffs>
+            <BitOffs>1302859584</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
-          <AreaNo AreaType="InputDst" CreateSymbols="true">32</AreaNo>
+          <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
-          <ContextId>2</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ContextId>3</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72574,7 +72757,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265046144</BitOffs>
+            <BitOffs>1264934400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -72590,7 +72773,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265046208</BitOffs>
+            <BitOffs>1264934464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -72606,14 +72789,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265046272</BitOffs>
+            <BitOffs>1264934528</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
-          <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
+          <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
-          <ContextId>2</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ContextId>3</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72757,7 +72940,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265046336</BitOffs>
+            <BitOffs>1264934592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -72766,7 +72949,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265046984</BitOffs>
+            <BitOffs>1264935240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -72775,14 +72958,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265046992</BitOffs>
+            <BitOffs>1264935248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265047000</BitOffs>
+            <BitOffs>1264935256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -72791,20 +72974,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265047008</BitOffs>
+            <BitOffs>1264935264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265047040</BitOffs>
+            <BitOffs>1264935296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265047104</BitOffs>
+            <BitOffs>1264935360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -72813,19 +72996,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265047168</BitOffs>
+            <BitOffs>1264935424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265047232</BitOffs>
+            <BitOffs>1264935488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265047296</BitOffs>
+            <BitOffs>1264935552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -72840,25 +73023,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265047360</BitOffs>
+            <BitOffs>1264935616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265047424</BitOffs>
+            <BitOffs>1264935680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265047680</BitOffs>
+            <BitOffs>1264935936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265047744</BitOffs>
+            <BitOffs>1264936000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -72867,19 +73050,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265047808</BitOffs>
+            <BitOffs>1264936064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265047872</BitOffs>
+            <BitOffs>1264936128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265047936</BitOffs>
+            <BitOffs>1264936192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -72894,67 +73077,67 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265048000</BitOffs>
+            <BitOffs>1264936256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265048064</BitOffs>
+            <BitOffs>1264936320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265049088</BitOffs>
+            <BitOffs>1264937344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265049152</BitOffs>
+            <BitOffs>1264937408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265049216</BitOffs>
+            <BitOffs>1264937472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265049280</BitOffs>
+            <BitOffs>1264937536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265049344</BitOffs>
+            <BitOffs>1264937600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265159936</BitOffs>
+            <BitOffs>1265048192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265435136</BitOffs>
+            <BitOffs>1265323392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265545728</BitOffs>
+            <BitOffs>1265433984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265820928</BitOffs>
+            <BitOffs>1265709184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -72966,7 +73149,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265821440</BitOffs>
+            <BitOffs>1265709696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -72978,14 +73161,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265822016</BitOffs>
+            <BitOffs>1265710272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265822848</BitOffs>
+            <BitOffs>1265711104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -73001,7 +73184,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265823104</BitOffs>
+            <BitOffs>1265711360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -73016,53 +73199,15 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265823136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7</Name>
-            <Comment> G_PI, urad</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:G_PI
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[g_pi_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[g_pi_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[g_pi_up_dwn_e]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1295904832</BitOffs>
+            <BitOffs>1265711392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
-            <BitSize>4096</BitSize>
+            <BitSize>5120</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
-              <Elements>4</Elements>
+              <Elements>5</Elements>
             </ArrayInfo>
             <Properties>
               <Property>
@@ -73072,7 +73217,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302787008</BitOffs>
+            <BitOffs>1302852352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -73086,7 +73231,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302791200</BitOffs>
+            <BitOffs>1302857632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -73100,7 +73245,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302791232</BitOffs>
+            <BitOffs>1302857664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -73121,14 +73266,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302793152</BitOffs>
+            <BitOffs>1302860480</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
-          <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
+          <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
-          <ContextId>3</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ContextId>4</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -73153,7 +73298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271652224</BitOffs>
+            <BitOffs>1271786688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
@@ -73165,7 +73310,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271652232</BitOffs>
+            <BitOffs>1271786696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
@@ -73178,7 +73323,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271652288</BitOffs>
+            <BitOffs>1271786752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
@@ -73190,7 +73335,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271652416</BitOffs>
+            <BitOffs>1271786880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
@@ -73202,7 +73347,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271652544</BitOffs>
+            <BitOffs>1271787008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
@@ -73214,7 +73359,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271652672</BitOffs>
+            <BitOffs>1271787136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -73227,7 +73372,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271653440</BitOffs>
+            <BitOffs>1271787904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -73240,7 +73385,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271653568</BitOffs>
+            <BitOffs>1271788032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -73253,7 +73398,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271664192</BitOffs>
+            <BitOffs>1271798656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -73266,7 +73411,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271664320</BitOffs>
+            <BitOffs>1271798784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73278,7 +73423,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1272903040</BitOffs>
+            <BitOffs>1273037504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73290,7 +73435,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273238080</BitOffs>
+            <BitOffs>1273372544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bMR1K1_Y_ENC_Ready</Name>
@@ -73306,7 +73451,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273563184</BitOffs>
+            <BitOffs>1273697648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bMR1K1_Y_ENC_TxPDO</Name>
@@ -73322,7 +73467,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273563192</BitOffs>
+            <BitOffs>1273697656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_1.iRaw</Name>
@@ -73335,7 +73480,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273568448</BitOffs>
+            <BitOffs>1273702912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_2.iRaw</Name>
@@ -73348,7 +73493,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273569024</BitOffs>
+            <BitOffs>1273703488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Press_1.iRaw</Name>
@@ -73361,7 +73506,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273569600</BitOffs>
+            <BitOffs>1273704064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable1</Name>
@@ -73379,7 +73524,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345504</BitOffs>
+            <BitOffs>1274479968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable2</Name>
@@ -73395,7 +73540,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345512</BitOffs>
+            <BitOffs>1274479976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_1_Err</Name>
@@ -73408,7 +73553,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345520</BitOffs>
+            <BitOffs>1274479984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_2_Err</Name>
@@ -73420,7 +73565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345528</BitOffs>
+            <BitOffs>1274479992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_3_Err</Name>
@@ -73432,7 +73577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345728</BitOffs>
+            <BitOffs>1274480192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_1_Err</Name>
@@ -73444,7 +73589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345736</BitOffs>
+            <BitOffs>1274480200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_2_Err</Name>
@@ -73456,7 +73601,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345744</BitOffs>
+            <BitOffs>1274480208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_3_Err</Name>
@@ -73468,7 +73613,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274345752</BitOffs>
+            <BitOffs>1274480216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
@@ -73481,7 +73626,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280171264</BitOffs>
+            <BitOffs>1280305728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
@@ -73493,7 +73638,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280171272</BitOffs>
+            <BitOffs>1280305736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
@@ -73506,7 +73651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280171328</BitOffs>
+            <BitOffs>1280305792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
@@ -73518,7 +73663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280171456</BitOffs>
+            <BitOffs>1280305920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
@@ -73530,7 +73675,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280171584</BitOffs>
+            <BitOffs>1280306048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
@@ -73542,7 +73687,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280171712</BitOffs>
+            <BitOffs>1280306176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -73555,7 +73700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280172480</BitOffs>
+            <BitOffs>1280306944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -73568,7 +73713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280172608</BitOffs>
+            <BitOffs>1280307072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -73581,7 +73726,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280183232</BitOffs>
+            <BitOffs>1280317696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -73594,7 +73739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1280183360</BitOffs>
+            <BitOffs>1280317824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73606,7 +73751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281422080</BitOffs>
+            <BitOffs>1281556544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73618,7 +73763,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281757056</BitOffs>
+            <BitOffs>1281891520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
@@ -73631,7 +73776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282087424</BitOffs>
+            <BitOffs>1282221888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2.iRaw</Name>
@@ -73644,7 +73789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282088000</BitOffs>
+            <BitOffs>1282222464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
@@ -73657,7 +73802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282088576</BitOffs>
+            <BitOffs>1282223040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
@@ -73674,7 +73819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089408</BitOffs>
+            <BitOffs>1282223872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
@@ -73690,7 +73835,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089416</BitOffs>
+            <BitOffs>1282223880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73702,7 +73847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282092096</BitOffs>
+            <BitOffs>1282226560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73714,7 +73859,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282419520</BitOffs>
+            <BitOffs>1282553984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73726,7 +73871,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282746944</BitOffs>
+            <BitOffs>1282881408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73738,7 +73883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283074368</BitOffs>
+            <BitOffs>1283208832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73750,7 +73895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283401792</BitOffs>
+            <BitOffs>1283536256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73762,7 +73907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283729216</BitOffs>
+            <BitOffs>1283863680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upe</Name>
@@ -73784,7 +73929,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054016</BitOffs>
+            <BitOffs>1284188480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upe</Name>
@@ -73806,7 +73951,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054144</BitOffs>
+            <BitOffs>1284188608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bError</Name>
@@ -73830,7 +73975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054600</BitOffs>
+            <BitOffs>1284189064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bUnderrange</Name>
@@ -73842,7 +73987,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054608</BitOffs>
+            <BitOffs>1284189072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bOverrange</Name>
@@ -73854,7 +73999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054616</BitOffs>
+            <BitOffs>1284189080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.iRaw</Name>
@@ -73866,7 +74011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054624</BitOffs>
+            <BitOffs>1284189088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bError</Name>
@@ -73890,7 +74035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054856</BitOffs>
+            <BitOffs>1284189320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bUnderrange</Name>
@@ -73902,7 +74047,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054864</BitOffs>
+            <BitOffs>1284189328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bOverrange</Name>
@@ -73914,7 +74059,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054872</BitOffs>
+            <BitOffs>1284189336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.iRaw</Name>
@@ -73926,7 +74071,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054880</BitOffs>
+            <BitOffs>1284189344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bError</Name>
@@ -73950,7 +74095,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055112</BitOffs>
+            <BitOffs>1284189576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bUnderrange</Name>
@@ -73962,7 +74107,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055120</BitOffs>
+            <BitOffs>1284189584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bOverrange</Name>
@@ -73974,7 +74119,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055128</BitOffs>
+            <BitOffs>1284189592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.iRaw</Name>
@@ -73986,7 +74131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055136</BitOffs>
+            <BitOffs>1284189600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bError</Name>
@@ -74010,7 +74155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055368</BitOffs>
+            <BitOffs>1284189832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bUnderrange</Name>
@@ -74022,7 +74167,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055376</BitOffs>
+            <BitOffs>1284189840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bOverrange</Name>
@@ -74034,7 +74179,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055384</BitOffs>
+            <BitOffs>1284189848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.iRaw</Name>
@@ -74046,7 +74191,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055392</BitOffs>
+            <BitOffs>1284189856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bError</Name>
@@ -74070,7 +74215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055624</BitOffs>
+            <BitOffs>1284190088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bUnderrange</Name>
@@ -74082,7 +74227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055632</BitOffs>
+            <BitOffs>1284190096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bOverrange</Name>
@@ -74094,7 +74239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055640</BitOffs>
+            <BitOffs>1284190104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.iRaw</Name>
@@ -74106,7 +74251,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055648</BitOffs>
+            <BitOffs>1284190112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bError</Name>
@@ -74130,7 +74275,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055880</BitOffs>
+            <BitOffs>1284190344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bUnderrange</Name>
@@ -74142,7 +74287,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055888</BitOffs>
+            <BitOffs>1284190352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bOverrange</Name>
@@ -74154,7 +74299,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055896</BitOffs>
+            <BitOffs>1284190360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.iRaw</Name>
@@ -74166,7 +74311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055904</BitOffs>
+            <BitOffs>1284190368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bError</Name>
@@ -74190,7 +74335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056136</BitOffs>
+            <BitOffs>1284190600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bUnderrange</Name>
@@ -74202,7 +74347,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056144</BitOffs>
+            <BitOffs>1284190608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bOverrange</Name>
@@ -74214,7 +74359,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056152</BitOffs>
+            <BitOffs>1284190616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.iRaw</Name>
@@ -74226,7 +74371,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056160</BitOffs>
+            <BitOffs>1284190624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bError</Name>
@@ -74250,7 +74395,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056392</BitOffs>
+            <BitOffs>1284190856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bUnderrange</Name>
@@ -74262,7 +74407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056400</BitOffs>
+            <BitOffs>1284190864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bOverrange</Name>
@@ -74274,7 +74419,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056408</BitOffs>
+            <BitOffs>1284190872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.iRaw</Name>
@@ -74286,7 +74431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056416</BitOffs>
+            <BitOffs>1284190880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw</Name>
@@ -74299,7 +74444,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284082624</BitOffs>
+            <BitOffs>1284217088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2.iRaw</Name>
@@ -74312,7 +74457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284083200</BitOffs>
+            <BitOffs>1284217664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
@@ -74325,7 +74470,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284083776</BitOffs>
+            <BitOffs>1284218240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74337,7 +74482,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284380416</BitOffs>
+            <BitOffs>1284384768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74349,7 +74494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284707840</BitOffs>
+            <BitOffs>1284712192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74361,7 +74506,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285035264</BitOffs>
+            <BitOffs>1285039616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74373,7 +74518,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285362688</BitOffs>
+            <BitOffs>1285367040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74385,7 +74530,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285690112</BitOffs>
+            <BitOffs>1285694464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bError</Name>
@@ -74409,7 +74554,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709576</BitOffs>
+            <BitOffs>1286713928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bUnderrange</Name>
@@ -74421,7 +74566,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709584</BitOffs>
+            <BitOffs>1286713936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bOverrange</Name>
@@ -74433,7 +74578,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709592</BitOffs>
+            <BitOffs>1286713944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.iRaw</Name>
@@ -74445,7 +74590,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709600</BitOffs>
+            <BitOffs>1286713952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bError</Name>
@@ -74469,7 +74614,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709832</BitOffs>
+            <BitOffs>1286714184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bUnderrange</Name>
@@ -74481,7 +74626,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709840</BitOffs>
+            <BitOffs>1286714192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bOverrange</Name>
@@ -74493,7 +74638,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709848</BitOffs>
+            <BitOffs>1286714200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.iRaw</Name>
@@ -74505,7 +74650,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709856</BitOffs>
+            <BitOffs>1286714208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bError</Name>
@@ -74529,7 +74674,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710088</BitOffs>
+            <BitOffs>1286714440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bUnderrange</Name>
@@ -74541,7 +74686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710096</BitOffs>
+            <BitOffs>1286714448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bOverrange</Name>
@@ -74553,7 +74698,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710104</BitOffs>
+            <BitOffs>1286714456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.iRaw</Name>
@@ -74565,7 +74710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710112</BitOffs>
+            <BitOffs>1286714464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bError</Name>
@@ -74589,7 +74734,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710344</BitOffs>
+            <BitOffs>1286714696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bUnderrange</Name>
@@ -74601,7 +74746,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710352</BitOffs>
+            <BitOffs>1286714704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bOverrange</Name>
@@ -74613,7 +74758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710360</BitOffs>
+            <BitOffs>1286714712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.iRaw</Name>
@@ -74625,7 +74770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710368</BitOffs>
+            <BitOffs>1286714720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbGetIllPercent.iRaw</Name>
@@ -74638,7 +74783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710656</BitOffs>
+            <BitOffs>1286715008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter.iRaw</Name>
@@ -74651,7 +74796,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286711808</BitOffs>
+            <BitOffs>1286716160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74663,7 +74808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286715200</BitOffs>
+            <BitOffs>1286719552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -74679,7 +74824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287042176</BitOffs>
+            <BitOffs>1287046528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -74700,7 +74845,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287045696</BitOffs>
+            <BitOffs>1287050048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -74721,7 +74866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287045697</BitOffs>
+            <BitOffs>1287050049</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable1</Name>
@@ -74738,7 +74883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535200</BitOffs>
+            <BitOffs>1288539552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2</Name>
@@ -74754,7 +74899,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535208</BitOffs>
+            <BitOffs>1288539560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
@@ -74767,7 +74912,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535216</BitOffs>
+            <BitOffs>1288539568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
@@ -74779,7 +74924,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535224</BitOffs>
+            <BitOffs>1288539576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1.iRaw</Name>
@@ -74792,7 +74937,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535296</BitOffs>
+            <BitOffs>1288539648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2.iRaw</Name>
@@ -74805,7 +74950,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535872</BitOffs>
+            <BitOffs>1288540224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Press_1.iRaw</Name>
@@ -74818,7 +74963,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288536448</BitOffs>
+            <BitOffs>1288540800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
@@ -74830,7 +74975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475712</BitOffs>
+            <BitOffs>1290480064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
@@ -74842,7 +74987,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475720</BitOffs>
+            <BitOffs>1290480072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
@@ -74854,7 +74999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475728</BitOffs>
+            <BitOffs>1290480080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -74866,7 +75011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475736</BitOffs>
+            <BitOffs>1290480088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -74883,7 +75028,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475744</BitOffs>
+            <BitOffs>1290480096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -74899,7 +75044,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475752</BitOffs>
+            <BitOffs>1290480104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -74912,7 +75057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475760</BitOffs>
+            <BitOffs>1290480112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -74924,7 +75069,33 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475768</BitOffs>
+            <BitOffs>1290480120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290480192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290480768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -74948,7 +75119,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292414728</BitOffs>
+            <BitOffs>1292420232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -74960,7 +75131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292414736</BitOffs>
+            <BitOffs>1292420240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -74972,7 +75143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292414744</BitOffs>
+            <BitOffs>1292420248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -74984,7 +75155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292414752</BitOffs>
+            <BitOffs>1292420256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -75008,7 +75179,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292414984</BitOffs>
+            <BitOffs>1292420488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -75020,7 +75191,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292414992</BitOffs>
+            <BitOffs>1292420496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -75032,7 +75203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415000</BitOffs>
+            <BitOffs>1292420504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -75044,7 +75215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415008</BitOffs>
+            <BitOffs>1292420512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -75056,7 +75227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415040</BitOffs>
+            <BitOffs>1292420544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -75068,7 +75239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415048</BitOffs>
+            <BitOffs>1292420552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -75080,7 +75251,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415056</BitOffs>
+            <BitOffs>1292420560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -75092,7 +75263,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415064</BitOffs>
+            <BitOffs>1292420568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -75109,7 +75280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415072</BitOffs>
+            <BitOffs>1292420576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -75125,7 +75296,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292415080</BitOffs>
+            <BitOffs>1292420584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -75145,7 +75316,33 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292420112</BitOffs>
+            <BitOffs>1292420592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292420672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292421248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -75164,7 +75361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292420128</BitOffs>
+            <BitOffs>1292426784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -75183,7 +75380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292420144</BitOffs>
+            <BitOffs>1292426800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
@@ -75196,7 +75393,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292422592</BitOffs>
+            <BitOffs>1292429248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -75216,7 +75413,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423040</BitOffs>
+            <BitOffs>1292429696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -75235,7 +75432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423056</BitOffs>
+            <BitOffs>1292429712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -75254,7 +75451,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423072</BitOffs>
+            <BitOffs>1292429728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -75274,7 +75471,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423088</BitOffs>
+            <BitOffs>1292429744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
@@ -75287,7 +75484,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292425792</BitOffs>
+            <BitOffs>1292432448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -75306,7 +75503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426368</BitOffs>
+            <BitOffs>1292433024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -75325,7 +75522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426384</BitOffs>
+            <BitOffs>1292433040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -75345,7 +75542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426400</BitOffs>
+            <BitOffs>1292433056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -75364,7 +75561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426416</BitOffs>
+            <BitOffs>1292433072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -75383,7 +75580,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426432</BitOffs>
+            <BitOffs>1292433088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -75403,7 +75600,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426448</BitOffs>
+            <BitOffs>1292433104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -75422,7 +75619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426464</BitOffs>
+            <BitOffs>1292433120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -75441,7 +75638,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426480</BitOffs>
+            <BitOffs>1292433136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -75461,7 +75658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427072</BitOffs>
+            <BitOffs>1292433728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -75480,7 +75677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427088</BitOffs>
+            <BitOffs>1292433744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -75499,7 +75696,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427104</BitOffs>
+            <BitOffs>1292433760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -75514,7 +75711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427120</BitOffs>
+            <BitOffs>1292433776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -75526,7 +75723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294469120</BitOffs>
+            <BitOffs>1294475776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -75549,7 +75746,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477056</BitOffs>
+            <BitOffs>1294483712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -75572,7 +75769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477064</BitOffs>
+            <BitOffs>1294483720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -75595,7 +75792,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477072</BitOffs>
+            <BitOffs>1294483728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -75618,7 +75815,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477088</BitOffs>
+            <BitOffs>1294483744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -75631,7 +75828,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477120</BitOffs>
+            <BitOffs>1294483776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -75644,7 +75841,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477184</BitOffs>
+            <BitOffs>1294483840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -75657,7 +75854,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477200</BitOffs>
+            <BitOffs>1294483856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75669,7 +75866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294491840</BitOffs>
+            <BitOffs>1294498496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -75681,7 +75878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294817728</BitOffs>
+            <BitOffs>1294824384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -75704,7 +75901,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825664</BitOffs>
+            <BitOffs>1294832320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -75727,7 +75924,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825672</BitOffs>
+            <BitOffs>1294832328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -75750,7 +75947,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825680</BitOffs>
+            <BitOffs>1294832336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -75773,7 +75970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825696</BitOffs>
+            <BitOffs>1294832352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -75786,7 +75983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825728</BitOffs>
+            <BitOffs>1294832384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -75799,7 +75996,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825792</BitOffs>
+            <BitOffs>1294832448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -75812,7 +76009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825808</BitOffs>
+            <BitOffs>1294832464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75824,7 +76021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294840448</BitOffs>
+            <BitOffs>1294847104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -75836,7 +76033,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295166336</BitOffs>
+            <BitOffs>1295172992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -75859,7 +76056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174272</BitOffs>
+            <BitOffs>1295180928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -75882,7 +76079,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174280</BitOffs>
+            <BitOffs>1295180936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -75905,7 +76102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174288</BitOffs>
+            <BitOffs>1295180944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -75928,7 +76125,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174304</BitOffs>
+            <BitOffs>1295180960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -75941,7 +76138,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174336</BitOffs>
+            <BitOffs>1295180992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -75954,7 +76151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174400</BitOffs>
+            <BitOffs>1295181056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -75967,7 +76164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174416</BitOffs>
+            <BitOffs>1295181072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75979,7 +76176,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295189056</BitOffs>
+            <BitOffs>1295195712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -75991,7 +76188,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295514944</BitOffs>
+            <BitOffs>1295521600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -76014,7 +76211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295522880</BitOffs>
+            <BitOffs>1295529536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -76037,7 +76234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295522888</BitOffs>
+            <BitOffs>1295529544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -76060,7 +76257,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295522896</BitOffs>
+            <BitOffs>1295529552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -76083,7 +76280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295522912</BitOffs>
+            <BitOffs>1295529568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -76096,7 +76293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295522944</BitOffs>
+            <BitOffs>1295529600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -76109,7 +76306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295523008</BitOffs>
+            <BitOffs>1295529664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -76122,7 +76319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295523024</BitOffs>
+            <BitOffs>1295529680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76134,7 +76331,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295537664</BitOffs>
+            <BitOffs>1295544320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -76146,7 +76343,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295863552</BitOffs>
+            <BitOffs>1295870208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -76169,7 +76366,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871488</BitOffs>
+            <BitOffs>1295878144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -76192,7 +76389,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871496</BitOffs>
+            <BitOffs>1295878152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -76215,7 +76412,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871504</BitOffs>
+            <BitOffs>1295878160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -76238,7 +76435,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871520</BitOffs>
+            <BitOffs>1295878176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -76251,7 +76448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871552</BitOffs>
+            <BitOffs>1295878208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -76264,7 +76461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871616</BitOffs>
+            <BitOffs>1295878272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -76277,7 +76474,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871632</BitOffs>
+            <BitOffs>1295878288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -76289,7 +76486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295884736</BitOffs>
+            <BitOffs>1295891392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -76312,7 +76509,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892672</BitOffs>
+            <BitOffs>1295899328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -76335,7 +76532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892680</BitOffs>
+            <BitOffs>1295899336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -76358,7 +76555,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892688</BitOffs>
+            <BitOffs>1295899344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -76381,7 +76578,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892704</BitOffs>
+            <BitOffs>1295899360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -76394,7 +76591,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892736</BitOffs>
+            <BitOffs>1295899392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -76407,7 +76604,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892800</BitOffs>
+            <BitOffs>1295899456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -76420,19 +76617,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1295905920</BitOffs>
+            <BitOffs>1295899472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -76455,7 +76640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913856</BitOffs>
+            <BitOffs>1295920512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -76478,7 +76663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913864</BitOffs>
+            <BitOffs>1295920520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -76501,7 +76686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913872</BitOffs>
+            <BitOffs>1295920528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -76524,7 +76709,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913888</BitOffs>
+            <BitOffs>1295920544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -76537,7 +76722,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913920</BitOffs>
+            <BitOffs>1295920576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -76550,7 +76735,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913984</BitOffs>
+            <BitOffs>1295920640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -76563,7 +76748,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295914000</BitOffs>
+            <BitOffs>1295920656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -76575,7 +76760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295927104</BitOffs>
+            <BitOffs>1295933760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -76598,7 +76783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935040</BitOffs>
+            <BitOffs>1295941696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -76621,7 +76806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935048</BitOffs>
+            <BitOffs>1295941704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -76644,7 +76829,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935056</BitOffs>
+            <BitOffs>1295941712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -76667,7 +76852,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935072</BitOffs>
+            <BitOffs>1295941728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -76680,7 +76865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935104</BitOffs>
+            <BitOffs>1295941760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -76693,7 +76878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935168</BitOffs>
+            <BitOffs>1295941824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -76706,7 +76891,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935184</BitOffs>
+            <BitOffs>1295941840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -76718,7 +76903,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295948288</BitOffs>
+            <BitOffs>1295954944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -76741,7 +76926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956224</BitOffs>
+            <BitOffs>1295962880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -76764,7 +76949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956232</BitOffs>
+            <BitOffs>1295962888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -76787,7 +76972,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956240</BitOffs>
+            <BitOffs>1295962896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -76810,7 +76995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956256</BitOffs>
+            <BitOffs>1295962912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -76823,7 +77008,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956288</BitOffs>
+            <BitOffs>1295962944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -76836,7 +77021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956352</BitOffs>
+            <BitOffs>1295963008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -76849,7 +77034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956368</BitOffs>
+            <BitOffs>1295963024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -76861,7 +77046,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295969472</BitOffs>
+            <BitOffs>1295976128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -76884,7 +77069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977408</BitOffs>
+            <BitOffs>1295984064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -76907,7 +77092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977416</BitOffs>
+            <BitOffs>1295984072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -76930,7 +77115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977424</BitOffs>
+            <BitOffs>1295984080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -76953,7 +77138,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977440</BitOffs>
+            <BitOffs>1295984096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -76966,7 +77151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977472</BitOffs>
+            <BitOffs>1295984128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -76979,7 +77164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977536</BitOffs>
+            <BitOffs>1295984192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -76992,7 +77177,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977552</BitOffs>
+            <BitOffs>1295984208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -77004,7 +77189,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295990656</BitOffs>
+            <BitOffs>1295997312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -77027,7 +77212,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998592</BitOffs>
+            <BitOffs>1296005248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -77050,7 +77235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998600</BitOffs>
+            <BitOffs>1296005256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -77073,7 +77258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998608</BitOffs>
+            <BitOffs>1296005264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -77096,7 +77281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998624</BitOffs>
+            <BitOffs>1296005280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -77109,7 +77294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998656</BitOffs>
+            <BitOffs>1296005312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -77122,7 +77307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998720</BitOffs>
+            <BitOffs>1296005376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -77135,7 +77320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998736</BitOffs>
+            <BitOffs>1296005392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -77147,7 +77332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296011840</BitOffs>
+            <BitOffs>1296018496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -77170,7 +77355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019776</BitOffs>
+            <BitOffs>1296026432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -77193,7 +77378,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019784</BitOffs>
+            <BitOffs>1296026440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -77216,7 +77401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019792</BitOffs>
+            <BitOffs>1296026448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -77239,7 +77424,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019808</BitOffs>
+            <BitOffs>1296026464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -77252,7 +77437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019840</BitOffs>
+            <BitOffs>1296026496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -77265,7 +77450,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019904</BitOffs>
+            <BitOffs>1296026560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -77278,7 +77463,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019920</BitOffs>
+            <BitOffs>1296026576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77290,7 +77475,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296034560</BitOffs>
+            <BitOffs>1296041216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -77302,7 +77487,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296360448</BitOffs>
+            <BitOffs>1296367104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -77325,7 +77510,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368384</BitOffs>
+            <BitOffs>1296375040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -77348,7 +77533,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368392</BitOffs>
+            <BitOffs>1296375048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -77371,7 +77556,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368400</BitOffs>
+            <BitOffs>1296375056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -77394,7 +77579,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368416</BitOffs>
+            <BitOffs>1296375072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -77407,7 +77592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368448</BitOffs>
+            <BitOffs>1296375104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -77420,7 +77605,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368512</BitOffs>
+            <BitOffs>1296375168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -77433,7 +77618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368528</BitOffs>
+            <BitOffs>1296375184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77445,7 +77630,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296383168</BitOffs>
+            <BitOffs>1296389824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -77457,7 +77642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296709056</BitOffs>
+            <BitOffs>1296715712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -77480,7 +77665,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296716992</BitOffs>
+            <BitOffs>1296723648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -77503,7 +77688,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717000</BitOffs>
+            <BitOffs>1296723656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -77526,7 +77711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717008</BitOffs>
+            <BitOffs>1296723664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -77549,7 +77734,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717024</BitOffs>
+            <BitOffs>1296723680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -77562,7 +77747,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717056</BitOffs>
+            <BitOffs>1296723712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -77575,7 +77760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717120</BitOffs>
+            <BitOffs>1296723776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -77588,7 +77773,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717136</BitOffs>
+            <BitOffs>1296723792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77600,7 +77785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296731776</BitOffs>
+            <BitOffs>1296738432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -77612,7 +77797,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297057664</BitOffs>
+            <BitOffs>1297064320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -77635,7 +77820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065600</BitOffs>
+            <BitOffs>1297072256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -77658,7 +77843,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065608</BitOffs>
+            <BitOffs>1297072264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -77681,7 +77866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065616</BitOffs>
+            <BitOffs>1297072272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -77704,7 +77889,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065632</BitOffs>
+            <BitOffs>1297072288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -77717,7 +77902,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065664</BitOffs>
+            <BitOffs>1297072320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -77730,7 +77915,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065728</BitOffs>
+            <BitOffs>1297072384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -77743,7 +77928,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065744</BitOffs>
+            <BitOffs>1297072400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77755,7 +77940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297080384</BitOffs>
+            <BitOffs>1297087040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -77767,7 +77952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297406272</BitOffs>
+            <BitOffs>1297412928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -77790,7 +77975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414208</BitOffs>
+            <BitOffs>1297420864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -77813,7 +77998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414216</BitOffs>
+            <BitOffs>1297420872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -77836,7 +78021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414224</BitOffs>
+            <BitOffs>1297420880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -77859,7 +78044,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414240</BitOffs>
+            <BitOffs>1297420896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -77872,7 +78057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414272</BitOffs>
+            <BitOffs>1297420928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -77885,7 +78070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414336</BitOffs>
+            <BitOffs>1297420992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -77898,7 +78083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414352</BitOffs>
+            <BitOffs>1297421008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -77910,7 +78095,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297427456</BitOffs>
+            <BitOffs>1297434112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -77933,7 +78118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435392</BitOffs>
+            <BitOffs>1297442048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -77956,7 +78141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435400</BitOffs>
+            <BitOffs>1297442056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -77979,7 +78164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435408</BitOffs>
+            <BitOffs>1297442064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -78002,7 +78187,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435424</BitOffs>
+            <BitOffs>1297442080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -78015,7 +78200,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435456</BitOffs>
+            <BitOffs>1297442112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -78028,7 +78213,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435520</BitOffs>
+            <BitOffs>1297442176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -78041,7 +78226,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435536</BitOffs>
+            <BitOffs>1297442192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78053,7 +78238,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297450176</BitOffs>
+            <BitOffs>1297456832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -78065,7 +78250,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297776064</BitOffs>
+            <BitOffs>1297782720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -78088,7 +78273,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784000</BitOffs>
+            <BitOffs>1297790656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -78111,7 +78296,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784008</BitOffs>
+            <BitOffs>1297790664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -78134,7 +78319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784016</BitOffs>
+            <BitOffs>1297790672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -78157,7 +78342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784032</BitOffs>
+            <BitOffs>1297790688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -78170,7 +78355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784064</BitOffs>
+            <BitOffs>1297790720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -78183,7 +78368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784128</BitOffs>
+            <BitOffs>1297790784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -78196,7 +78381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784144</BitOffs>
+            <BitOffs>1297790800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78208,7 +78393,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297798784</BitOffs>
+            <BitOffs>1297805440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -78220,7 +78405,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298124672</BitOffs>
+            <BitOffs>1298131328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -78243,7 +78428,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132608</BitOffs>
+            <BitOffs>1298139264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -78266,7 +78451,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132616</BitOffs>
+            <BitOffs>1298139272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -78289,7 +78474,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132624</BitOffs>
+            <BitOffs>1298139280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -78312,7 +78497,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132640</BitOffs>
+            <BitOffs>1298139296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -78325,7 +78510,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132672</BitOffs>
+            <BitOffs>1298139328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -78338,7 +78523,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132736</BitOffs>
+            <BitOffs>1298139392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -78351,7 +78536,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132752</BitOffs>
+            <BitOffs>1298139408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -78363,7 +78548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298145856</BitOffs>
+            <BitOffs>1298152512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -78386,7 +78571,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153792</BitOffs>
+            <BitOffs>1298160448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -78409,7 +78594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153800</BitOffs>
+            <BitOffs>1298160456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -78432,7 +78617,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153808</BitOffs>
+            <BitOffs>1298160464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -78455,7 +78640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153824</BitOffs>
+            <BitOffs>1298160480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -78468,7 +78653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153856</BitOffs>
+            <BitOffs>1298160512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -78481,7 +78666,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153920</BitOffs>
+            <BitOffs>1298160576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -78494,7 +78679,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153936</BitOffs>
+            <BitOffs>1298160592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -78506,7 +78691,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298167040</BitOffs>
+            <BitOffs>1298173696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -78529,7 +78714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298174976</BitOffs>
+            <BitOffs>1298181632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -78552,7 +78737,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298174984</BitOffs>
+            <BitOffs>1298181640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -78575,7 +78760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298174992</BitOffs>
+            <BitOffs>1298181648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -78598,7 +78783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298175008</BitOffs>
+            <BitOffs>1298181664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -78611,7 +78796,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298175040</BitOffs>
+            <BitOffs>1298181696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -78624,7 +78809,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298175104</BitOffs>
+            <BitOffs>1298181760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -78637,7 +78822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298175120</BitOffs>
+            <BitOffs>1298181776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -78649,7 +78834,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298188224</BitOffs>
+            <BitOffs>1298194880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -78672,7 +78857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196160</BitOffs>
+            <BitOffs>1298202816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -78695,7 +78880,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196168</BitOffs>
+            <BitOffs>1298202824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -78718,7 +78903,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196176</BitOffs>
+            <BitOffs>1298202832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -78741,7 +78926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196192</BitOffs>
+            <BitOffs>1298202848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -78754,7 +78939,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196224</BitOffs>
+            <BitOffs>1298202880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -78767,7 +78952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196288</BitOffs>
+            <BitOffs>1298202944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -78780,7 +78965,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196304</BitOffs>
+            <BitOffs>1298202960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -78792,7 +78977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298209408</BitOffs>
+            <BitOffs>1298216064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -78815,7 +79000,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217344</BitOffs>
+            <BitOffs>1298224000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -78838,7 +79023,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217352</BitOffs>
+            <BitOffs>1298224008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -78861,7 +79046,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217360</BitOffs>
+            <BitOffs>1298224016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -78884,7 +79069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217376</BitOffs>
+            <BitOffs>1298224032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -78897,7 +79082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217408</BitOffs>
+            <BitOffs>1298224064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -78910,7 +79095,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217472</BitOffs>
+            <BitOffs>1298224128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -78923,7 +79108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217488</BitOffs>
+            <BitOffs>1298224144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -78935,7 +79120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298230592</BitOffs>
+            <BitOffs>1298237248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -78958,7 +79143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238528</BitOffs>
+            <BitOffs>1298245184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -78981,7 +79166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238536</BitOffs>
+            <BitOffs>1298245192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -79004,7 +79189,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238544</BitOffs>
+            <BitOffs>1298245200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -79027,7 +79212,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238560</BitOffs>
+            <BitOffs>1298245216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -79040,7 +79225,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238592</BitOffs>
+            <BitOffs>1298245248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -79053,7 +79238,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238656</BitOffs>
+            <BitOffs>1298245312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -79066,7 +79251,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238672</BitOffs>
+            <BitOffs>1298245328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -79078,7 +79263,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298251776</BitOffs>
+            <BitOffs>1298258432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -79101,7 +79286,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259712</BitOffs>
+            <BitOffs>1298266368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -79124,7 +79309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259720</BitOffs>
+            <BitOffs>1298266376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -79147,7 +79332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259728</BitOffs>
+            <BitOffs>1298266384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -79170,7 +79355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259744</BitOffs>
+            <BitOffs>1298266400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -79183,7 +79368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259776</BitOffs>
+            <BitOffs>1298266432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -79196,7 +79381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259840</BitOffs>
+            <BitOffs>1298266496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -79209,7 +79394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259856</BitOffs>
+            <BitOffs>1298266512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79221,7 +79406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298274496</BitOffs>
+            <BitOffs>1298281152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -79233,7 +79418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298600384</BitOffs>
+            <BitOffs>1298607040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -79256,7 +79441,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608320</BitOffs>
+            <BitOffs>1298614976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -79279,7 +79464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608328</BitOffs>
+            <BitOffs>1298614984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -79302,7 +79487,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608336</BitOffs>
+            <BitOffs>1298614992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -79325,7 +79510,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608352</BitOffs>
+            <BitOffs>1298615008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -79338,7 +79523,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608384</BitOffs>
+            <BitOffs>1298615040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -79351,7 +79536,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608448</BitOffs>
+            <BitOffs>1298615104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -79364,7 +79549,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608464</BitOffs>
+            <BitOffs>1298615120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79376,7 +79561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298623104</BitOffs>
+            <BitOffs>1298629760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -79388,7 +79573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298948992</BitOffs>
+            <BitOffs>1298955648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -79411,7 +79596,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298956928</BitOffs>
+            <BitOffs>1298963584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -79434,7 +79619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298956936</BitOffs>
+            <BitOffs>1298963592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -79457,7 +79642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298956944</BitOffs>
+            <BitOffs>1298963600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -79480,7 +79665,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298956960</BitOffs>
+            <BitOffs>1298963616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -79493,7 +79678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298956992</BitOffs>
+            <BitOffs>1298963648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -79506,7 +79691,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298957056</BitOffs>
+            <BitOffs>1298963712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -79519,7 +79704,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298957072</BitOffs>
+            <BitOffs>1298963728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79531,7 +79716,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298971712</BitOffs>
+            <BitOffs>1298978368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -79543,7 +79728,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299297600</BitOffs>
+            <BitOffs>1299304256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -79566,7 +79751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305536</BitOffs>
+            <BitOffs>1299312192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -79589,7 +79774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305544</BitOffs>
+            <BitOffs>1299312200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -79612,7 +79797,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305552</BitOffs>
+            <BitOffs>1299312208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -79635,7 +79820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305568</BitOffs>
+            <BitOffs>1299312224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -79648,7 +79833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305600</BitOffs>
+            <BitOffs>1299312256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -79661,7 +79846,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305664</BitOffs>
+            <BitOffs>1299312320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -79674,7 +79859,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305680</BitOffs>
+            <BitOffs>1299312336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79686,7 +79871,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299320320</BitOffs>
+            <BitOffs>1299326976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -79698,7 +79883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299646208</BitOffs>
+            <BitOffs>1299652864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -79721,7 +79906,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654144</BitOffs>
+            <BitOffs>1299660800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -79744,7 +79929,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654152</BitOffs>
+            <BitOffs>1299660808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -79767,7 +79952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654160</BitOffs>
+            <BitOffs>1299660816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -79790,7 +79975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654176</BitOffs>
+            <BitOffs>1299660832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -79803,7 +79988,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654208</BitOffs>
+            <BitOffs>1299660864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -79816,7 +80001,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654272</BitOffs>
+            <BitOffs>1299660928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -79829,7 +80014,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654288</BitOffs>
+            <BitOffs>1299660944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79841,7 +80026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299668928</BitOffs>
+            <BitOffs>1299675584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -79853,7 +80038,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299994816</BitOffs>
+            <BitOffs>1300001472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -79876,7 +80061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002752</BitOffs>
+            <BitOffs>1300009408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -79899,7 +80084,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002760</BitOffs>
+            <BitOffs>1300009416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -79922,7 +80107,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002768</BitOffs>
+            <BitOffs>1300009424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -79945,7 +80130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002784</BitOffs>
+            <BitOffs>1300009440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -79958,7 +80143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002816</BitOffs>
+            <BitOffs>1300009472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -79971,7 +80156,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002880</BitOffs>
+            <BitOffs>1300009536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -79984,7 +80169,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002896</BitOffs>
+            <BitOffs>1300009552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79996,7 +80181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300017536</BitOffs>
+            <BitOffs>1300024192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -80008,7 +80193,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300343424</BitOffs>
+            <BitOffs>1300350080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -80031,7 +80216,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351360</BitOffs>
+            <BitOffs>1300358016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -80054,7 +80239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351368</BitOffs>
+            <BitOffs>1300358024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -80077,7 +80262,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351376</BitOffs>
+            <BitOffs>1300358032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -80100,7 +80285,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351392</BitOffs>
+            <BitOffs>1300358048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -80113,7 +80298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351424</BitOffs>
+            <BitOffs>1300358080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -80126,7 +80311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351488</BitOffs>
+            <BitOffs>1300358144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -80139,7 +80324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351504</BitOffs>
+            <BitOffs>1300358160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80151,7 +80336,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300366144</BitOffs>
+            <BitOffs>1300372800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -80163,7 +80348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300692032</BitOffs>
+            <BitOffs>1300698688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -80186,7 +80371,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300699968</BitOffs>
+            <BitOffs>1300706624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -80209,7 +80394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300699976</BitOffs>
+            <BitOffs>1300706632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -80232,7 +80417,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300699984</BitOffs>
+            <BitOffs>1300706640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -80255,7 +80440,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300700000</BitOffs>
+            <BitOffs>1300706656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -80268,7 +80453,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300700032</BitOffs>
+            <BitOffs>1300706688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -80281,7 +80466,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300700096</BitOffs>
+            <BitOffs>1300706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -80294,7 +80479,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300700112</BitOffs>
+            <BitOffs>1300706768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80306,7 +80491,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300714752</BitOffs>
+            <BitOffs>1300721408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -80318,7 +80503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301040640</BitOffs>
+            <BitOffs>1301047296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -80341,7 +80526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048576</BitOffs>
+            <BitOffs>1301055232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -80364,7 +80549,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048584</BitOffs>
+            <BitOffs>1301055240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -80387,7 +80572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048592</BitOffs>
+            <BitOffs>1301055248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -80410,7 +80595,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048608</BitOffs>
+            <BitOffs>1301055264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -80423,7 +80608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048640</BitOffs>
+            <BitOffs>1301055296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -80436,7 +80621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048704</BitOffs>
+            <BitOffs>1301055360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -80449,7 +80634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048720</BitOffs>
+            <BitOffs>1301055376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80461,7 +80646,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301063360</BitOffs>
+            <BitOffs>1301070016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -80473,7 +80658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301389248</BitOffs>
+            <BitOffs>1301395904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -80496,7 +80681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397184</BitOffs>
+            <BitOffs>1301403840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -80519,7 +80704,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397192</BitOffs>
+            <BitOffs>1301403848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -80542,7 +80727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397200</BitOffs>
+            <BitOffs>1301403856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -80565,7 +80750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397216</BitOffs>
+            <BitOffs>1301403872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -80578,7 +80763,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397248</BitOffs>
+            <BitOffs>1301403904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -80591,7 +80776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397312</BitOffs>
+            <BitOffs>1301403968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -80604,7 +80789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397328</BitOffs>
+            <BitOffs>1301403984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80616,7 +80801,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301411968</BitOffs>
+            <BitOffs>1301418624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -80628,7 +80813,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301737856</BitOffs>
+            <BitOffs>1301744512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -80651,7 +80836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745792</BitOffs>
+            <BitOffs>1301752448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -80674,7 +80859,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745800</BitOffs>
+            <BitOffs>1301752456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -80697,7 +80882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745808</BitOffs>
+            <BitOffs>1301752464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -80720,7 +80905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745824</BitOffs>
+            <BitOffs>1301752480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -80733,7 +80918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745856</BitOffs>
+            <BitOffs>1301752512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -80746,7 +80931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745920</BitOffs>
+            <BitOffs>1301752576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -80759,7 +80944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745936</BitOffs>
+            <BitOffs>1301752592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80771,7 +80956,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301760576</BitOffs>
+            <BitOffs>1301767232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -80783,7 +80968,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302086464</BitOffs>
+            <BitOffs>1302093120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -80806,7 +80991,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094400</BitOffs>
+            <BitOffs>1302101056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -80829,7 +81014,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094408</BitOffs>
+            <BitOffs>1302101064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -80852,7 +81037,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094416</BitOffs>
+            <BitOffs>1302101072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -80875,7 +81060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094432</BitOffs>
+            <BitOffs>1302101088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -80888,7 +81073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094464</BitOffs>
+            <BitOffs>1302101120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -80901,7 +81086,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094528</BitOffs>
+            <BitOffs>1302101184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -80914,7 +81099,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094544</BitOffs>
+            <BitOffs>1302101200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80926,7 +81111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302109184</BitOffs>
+            <BitOffs>1302115840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -80938,7 +81123,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302435072</BitOffs>
+            <BitOffs>1302441728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -80961,7 +81146,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443008</BitOffs>
+            <BitOffs>1302449664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -80984,7 +81169,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443016</BitOffs>
+            <BitOffs>1302449672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -81007,7 +81192,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443024</BitOffs>
+            <BitOffs>1302449680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -81030,7 +81215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443040</BitOffs>
+            <BitOffs>1302449696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -81043,7 +81228,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443072</BitOffs>
+            <BitOffs>1302449728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -81056,7 +81241,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443136</BitOffs>
+            <BitOffs>1302449792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -81069,7 +81254,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443152</BitOffs>
+            <BitOffs>1302449808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81081,7 +81266,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302457792</BitOffs>
+            <BitOffs>1302464448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -81096,66 +81281,14 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310995072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310995648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310996224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310996800</BitOffs>
+            <BitOffs>1302789248</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
-          <AreaNo AreaType="OutputSrc" CreateSymbols="true">49</AreaNo>
+          <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
-          <ContextId>3</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ContextId>4</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -81166,7 +81299,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1272902016</BitOffs>
+            <BitOffs>1273036480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower01</Name>
@@ -81192,7 +81325,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273235408</BitOffs>
+            <BitOffs>1273369872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower02</Name>
@@ -81217,7 +81350,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273235416</BitOffs>
+            <BitOffs>1273369880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81229,7 +81362,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273237056</BitOffs>
+            <BitOffs>1273371520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower03</Name>
@@ -81254,7 +81387,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273563168</BitOffs>
+            <BitOffs>1273697632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower04</Name>
@@ -81279,7 +81412,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273563176</BitOffs>
+            <BitOffs>1273697640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nMR1K1_Y_ENC_PMPS</Name>
@@ -81296,7 +81429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273568320</BitOffs>
+            <BitOffs>1273702784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81308,7 +81441,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1281421056</BitOffs>
+            <BitOffs>1281555520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81320,7 +81453,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1281756032</BitOffs>
+            <BitOffs>1281890496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower01</Name>
@@ -81345,7 +81478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089424</BitOffs>
+            <BitOffs>1282223888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower02</Name>
@@ -81370,7 +81503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089432</BitOffs>
+            <BitOffs>1282223896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower03</Name>
@@ -81395,7 +81528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089440</BitOffs>
+            <BitOffs>1282223904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bFanOn</Name>
@@ -81419,7 +81552,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089448</BitOffs>
+            <BitOffs>1282223912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bLEDPower</Name>
@@ -81444,7 +81577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282089456</BitOffs>
+            <BitOffs>1282223920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81456,7 +81589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282091072</BitOffs>
+            <BitOffs>1282225536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81468,7 +81601,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282418496</BitOffs>
+            <BitOffs>1282552960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81480,7 +81613,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282745920</BitOffs>
+            <BitOffs>1282880384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81492,7 +81625,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283073344</BitOffs>
+            <BitOffs>1283207808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81504,7 +81637,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283400768</BitOffs>
+            <BitOffs>1283535232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81516,7 +81649,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283728192</BitOffs>
+            <BitOffs>1283862656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81528,7 +81661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284379392</BitOffs>
+            <BitOffs>1284383744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81540,7 +81673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284706816</BitOffs>
+            <BitOffs>1284711168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81552,7 +81685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285034240</BitOffs>
+            <BitOffs>1285038592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81564,7 +81697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285361664</BitOffs>
+            <BitOffs>1285366016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81576,7 +81709,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285689088</BitOffs>
+            <BitOffs>1285693440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.iIlluminatorINT</Name>
@@ -81588,7 +81721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710464</BitOffs>
+            <BitOffs>1286714816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.bGigePower</Name>
@@ -81608,7 +81741,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710480</BitOffs>
+            <BitOffs>1286714832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbSetIllPercent.iRaw</Name>
@@ -81621,7 +81754,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286711552</BitOffs>
+            <BitOffs>1286715904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81633,7 +81766,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714176</BitOffs>
+            <BitOffs>1286718528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -81649,7 +81782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287043936</BitOffs>
+            <BitOffs>1287048288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -81669,7 +81802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293419240</BitOffs>
+            <BitOffs>1293425896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -81689,7 +81822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293943592</BitOffs>
+            <BitOffs>1293950248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -81701,7 +81834,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294468096</BitOffs>
+            <BitOffs>1294474752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -81724,7 +81857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294477080</BitOffs>
+            <BitOffs>1294483736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81736,7 +81869,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294490816</BitOffs>
+            <BitOffs>1294497472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -81748,7 +81881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294816704</BitOffs>
+            <BitOffs>1294823360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -81771,7 +81904,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294825688</BitOffs>
+            <BitOffs>1294832344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81783,7 +81916,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294839424</BitOffs>
+            <BitOffs>1294846080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -81795,7 +81928,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295165312</BitOffs>
+            <BitOffs>1295171968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -81818,7 +81951,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295174296</BitOffs>
+            <BitOffs>1295180952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81830,7 +81963,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295188032</BitOffs>
+            <BitOffs>1295194688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -81842,7 +81975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295513920</BitOffs>
+            <BitOffs>1295520576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -81865,7 +81998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295522904</BitOffs>
+            <BitOffs>1295529560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81877,7 +82010,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295536640</BitOffs>
+            <BitOffs>1295543296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -81889,7 +82022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295862528</BitOffs>
+            <BitOffs>1295869184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -81912,7 +82045,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295871512</BitOffs>
+            <BitOffs>1295878168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -81924,7 +82057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295883712</BitOffs>
+            <BitOffs>1295890368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -81947,7 +82080,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295892696</BitOffs>
+            <BitOffs>1295899352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -81959,7 +82092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295904896</BitOffs>
+            <BitOffs>1295911552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -81982,7 +82115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295913880</BitOffs>
+            <BitOffs>1295920536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -81994,7 +82127,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295926080</BitOffs>
+            <BitOffs>1295932736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -82017,7 +82150,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295935064</BitOffs>
+            <BitOffs>1295941720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -82029,7 +82162,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295947264</BitOffs>
+            <BitOffs>1295953920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -82052,7 +82185,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295956248</BitOffs>
+            <BitOffs>1295962904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -82064,7 +82197,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295968448</BitOffs>
+            <BitOffs>1295975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -82087,7 +82220,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295977432</BitOffs>
+            <BitOffs>1295984088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -82099,7 +82232,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295989632</BitOffs>
+            <BitOffs>1295996288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -82122,7 +82255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295998616</BitOffs>
+            <BitOffs>1296005272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -82134,7 +82267,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296010816</BitOffs>
+            <BitOffs>1296017472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -82157,7 +82290,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296019800</BitOffs>
+            <BitOffs>1296026456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82169,7 +82302,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296033536</BitOffs>
+            <BitOffs>1296040192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -82181,7 +82314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296359424</BitOffs>
+            <BitOffs>1296366080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -82204,7 +82337,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296368408</BitOffs>
+            <BitOffs>1296375064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82216,7 +82349,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296382144</BitOffs>
+            <BitOffs>1296388800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -82228,7 +82361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296708032</BitOffs>
+            <BitOffs>1296714688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -82251,7 +82384,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717016</BitOffs>
+            <BitOffs>1296723672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82263,7 +82396,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296730752</BitOffs>
+            <BitOffs>1296737408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -82275,7 +82408,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297056640</BitOffs>
+            <BitOffs>1297063296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -82298,7 +82431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297065624</BitOffs>
+            <BitOffs>1297072280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82310,7 +82443,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297079360</BitOffs>
+            <BitOffs>1297086016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -82322,7 +82455,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297405248</BitOffs>
+            <BitOffs>1297411904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -82345,7 +82478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297414232</BitOffs>
+            <BitOffs>1297420888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -82357,7 +82490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297426432</BitOffs>
+            <BitOffs>1297433088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -82380,7 +82513,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297435416</BitOffs>
+            <BitOffs>1297442072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82392,7 +82525,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297449152</BitOffs>
+            <BitOffs>1297455808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -82404,7 +82537,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297775040</BitOffs>
+            <BitOffs>1297781696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -82427,7 +82560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297784024</BitOffs>
+            <BitOffs>1297790680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82439,7 +82572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297797760</BitOffs>
+            <BitOffs>1297804416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -82451,7 +82584,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298123648</BitOffs>
+            <BitOffs>1298130304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -82474,7 +82607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298132632</BitOffs>
+            <BitOffs>1298139288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -82486,7 +82619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298144832</BitOffs>
+            <BitOffs>1298151488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -82509,7 +82642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298153816</BitOffs>
+            <BitOffs>1298160472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -82521,7 +82654,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298166016</BitOffs>
+            <BitOffs>1298172672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -82544,7 +82677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298175000</BitOffs>
+            <BitOffs>1298181656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -82556,7 +82689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298187200</BitOffs>
+            <BitOffs>1298193856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -82579,7 +82712,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298196184</BitOffs>
+            <BitOffs>1298202840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -82591,7 +82724,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298208384</BitOffs>
+            <BitOffs>1298215040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -82614,7 +82747,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298217368</BitOffs>
+            <BitOffs>1298224024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -82626,7 +82759,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298229568</BitOffs>
+            <BitOffs>1298236224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -82649,7 +82782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298238552</BitOffs>
+            <BitOffs>1298245208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -82661,7 +82794,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298250752</BitOffs>
+            <BitOffs>1298257408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -82684,7 +82817,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298259736</BitOffs>
+            <BitOffs>1298266392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82696,7 +82829,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298273472</BitOffs>
+            <BitOffs>1298280128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -82708,7 +82841,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298599360</BitOffs>
+            <BitOffs>1298606016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -82731,7 +82864,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298608344</BitOffs>
+            <BitOffs>1298615000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82743,7 +82876,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298622080</BitOffs>
+            <BitOffs>1298628736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -82755,7 +82888,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298947968</BitOffs>
+            <BitOffs>1298954624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -82778,7 +82911,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298956952</BitOffs>
+            <BitOffs>1298963608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82790,7 +82923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298970688</BitOffs>
+            <BitOffs>1298977344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -82802,7 +82935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299296576</BitOffs>
+            <BitOffs>1299303232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -82825,7 +82958,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299305560</BitOffs>
+            <BitOffs>1299312216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82837,7 +82970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299319296</BitOffs>
+            <BitOffs>1299325952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -82849,7 +82982,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299645184</BitOffs>
+            <BitOffs>1299651840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -82872,7 +83005,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299654168</BitOffs>
+            <BitOffs>1299660824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82884,7 +83017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299667904</BitOffs>
+            <BitOffs>1299674560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -82896,7 +83029,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299993792</BitOffs>
+            <BitOffs>1300000448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -82919,7 +83052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300002776</BitOffs>
+            <BitOffs>1300009432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82931,7 +83064,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300016512</BitOffs>
+            <BitOffs>1300023168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -82943,7 +83076,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300342400</BitOffs>
+            <BitOffs>1300349056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -82966,7 +83099,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300351384</BitOffs>
+            <BitOffs>1300358040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82978,7 +83111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300365120</BitOffs>
+            <BitOffs>1300371776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -82990,7 +83123,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300691008</BitOffs>
+            <BitOffs>1300697664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -83013,7 +83146,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300699992</BitOffs>
+            <BitOffs>1300706648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83025,7 +83158,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300713728</BitOffs>
+            <BitOffs>1300720384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -83037,7 +83170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301039616</BitOffs>
+            <BitOffs>1301046272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -83060,7 +83193,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301048600</BitOffs>
+            <BitOffs>1301055256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83072,7 +83205,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301062336</BitOffs>
+            <BitOffs>1301068992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -83084,7 +83217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301388224</BitOffs>
+            <BitOffs>1301394880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -83107,7 +83240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301397208</BitOffs>
+            <BitOffs>1301403864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83119,7 +83252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301410944</BitOffs>
+            <BitOffs>1301417600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -83131,7 +83264,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301736832</BitOffs>
+            <BitOffs>1301743488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -83154,7 +83287,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745816</BitOffs>
+            <BitOffs>1301752472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83166,7 +83299,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301759552</BitOffs>
+            <BitOffs>1301766208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -83178,7 +83311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302085440</BitOffs>
+            <BitOffs>1302092096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -83201,7 +83334,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302094424</BitOffs>
+            <BitOffs>1302101080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83213,7 +83346,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302108160</BitOffs>
+            <BitOffs>1302114816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -83225,7 +83358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302434048</BitOffs>
+            <BitOffs>1302440704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -83248,7 +83381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302443032</BitOffs>
+            <BitOffs>1302449688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83260,14 +83393,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302456768</BitOffs>
+            <BitOffs>1302463424</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
-          <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
+          <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
-          <ContextId>3</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ContextId>4</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -90342,10 +90475,29 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264816640</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1264936272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1264936288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1264936304</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265041984</BitOffs>
+            <BitOffs>1265827136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -90358,32 +90510,13 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265042112</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265048016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265048032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265048048</BitOffs>
+            <BitOffs>1265827264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
             <BitSize>5798336</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>1265828800</BitOffs>
+            <BitOffs>1265833152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1</Name>
@@ -90406,7 +90539,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1271651008</BitOffs>
+            <BitOffs>1271785472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbYRMSErrorM1K1</Name>
@@ -90421,19 +90554,19 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1271674560</BitOffs>
+            <BitOffs>1271809024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxYRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272062080</BitOffs>
+            <BitOffs>1272196544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMinYRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272062144</BitOffs>
+            <BitOffs>1272196608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbXRMSErrorM1K1</Name>
@@ -90447,19 +90580,19 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1272062208</BitOffs>
+            <BitOffs>1272196672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxXRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272449728</BitOffs>
+            <BitOffs>1272584192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMinXRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272449792</BitOffs>
+            <BitOffs>1272584256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbPitchRMSErrorM1K1</Name>
@@ -90473,38 +90606,38 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1272449856</BitOffs>
+            <BitOffs>1272584320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxPitchRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272837376</BitOffs>
+            <BitOffs>1272971840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMinPitchRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272837440</BitOffs>
+            <BitOffs>1272971904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1272837504</BitOffs>
+            <BitOffs>1272971968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1273235392</BitOffs>
+            <BitOffs>1273369856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1273235400</BitOffs>
+            <BitOffs>1273369864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntYupM1K1</Name>
@@ -90521,7 +90654,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273235424</BitOffs>
+            <BitOffs>1273369888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16</Name>
@@ -90530,7 +90663,7 @@ Emergency Stop for MR1K1</Comment>
  Using stepper only for now</Comment>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1273235456</BitOffs>
+            <BitOffs>1273369920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntYdwnM1K1</Name>
@@ -90546,7 +90679,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273562880</BitOffs>
+            <BitOffs>1273697344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntXupM1K1</Name>
@@ -90562,7 +90695,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273562912</BitOffs>
+            <BitOffs>1273697376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntXdwnM1K1</Name>
@@ -90578,7 +90711,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273562944</BitOffs>
+            <BitOffs>1273697408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntPitchM1K1</Name>
@@ -90594,7 +90727,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273562976</BitOffs>
+            <BitOffs>1273697440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefYupM1K1</Name>
@@ -90611,7 +90744,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273563008</BitOffs>
+            <BitOffs>1273697472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefYdwnM1K1</Name>
@@ -90627,7 +90760,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273563040</BitOffs>
+            <BitOffs>1273697504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefXupM1K1</Name>
@@ -90643,7 +90776,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273563072</BitOffs>
+            <BitOffs>1273697536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefXdwnM1K1</Name>
@@ -90659,7 +90792,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273563104</BitOffs>
+            <BitOffs>1273697568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefPitchM1K1</Name>
@@ -90675,20 +90808,20 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273563136</BitOffs>
+            <BitOffs>1273697600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.mcReadParameterPitchM1K1</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1273563200</BitOffs>
+            <BitOffs>1273697664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fEncRefPitchM1K1_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1273568192</BitOffs>
+            <BitOffs>1273702656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fEncLeverArm_mm</Name>
@@ -90698,7 +90831,7 @@ Emergency Stop for MR1K1</Comment>
             <Default>
               <Value>410</Value>
             </Default>
-            <BitOffs>1273568256</BitOffs>
+            <BitOffs>1273702720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncRefBendUSM1K1</Name>
@@ -90716,7 +90849,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273568352</BitOffs>
+            <BitOffs>1273702816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_1</Name>
@@ -90729,7 +90862,7 @@ MR1K1 BEND US ENC REF</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1273568384</BitOffs>
+            <BitOffs>1273702848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_1_val</Name>
@@ -90745,7 +90878,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273568896</BitOffs>
+            <BitOffs>1273703360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_2</Name>
@@ -90757,7 +90890,7 @@ MR1K1 BEND US ENC REF</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1273568960</BitOffs>
+            <BitOffs>1273703424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_2_val</Name>
@@ -90773,7 +90906,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273569472</BitOffs>
+            <BitOffs>1273703936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Press_1</Name>
@@ -90785,7 +90918,7 @@ MR1K1 BEND US ENC REF</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1273569536</BitOffs>
+            <BitOffs>1273704000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Press_1_val</Name>
@@ -90801,7 +90934,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273570048</BitOffs>
+            <BitOffs>1273704512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
@@ -90817,19 +90950,19 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273570112</BitOffs>
+            <BitOffs>1273704576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1273957632</BitOffs>
+            <BitOffs>1274092096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMinBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1273957696</BitOffs>
+            <BitOffs>1274092160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
@@ -90844,19 +90977,19 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273957760</BitOffs>
+            <BitOffs>1274092224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendDSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1274345280</BitOffs>
+            <BitOffs>1274479744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMinBendDSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1274345344</BitOffs>
+            <BitOffs>1274479808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncRefBendDSM1K1</Name>
@@ -90873,7 +91006,7 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345408</BitOffs>
+            <BitOffs>1274479872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncCntBendUSM1K1</Name>
@@ -90891,7 +91024,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345440</BitOffs>
+            <BitOffs>1274479904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncCntBendDSM1K1</Name>
@@ -90908,7 +91041,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345472</BitOffs>
+            <BitOffs>1274479936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_1</Name>
@@ -90927,7 +91060,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345536</BitOffs>
+            <BitOffs>1274480000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_2</Name>
@@ -90944,7 +91077,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345568</BitOffs>
+            <BitOffs>1274480032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_3</Name>
@@ -90961,7 +91094,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345600</BitOffs>
+            <BitOffs>1274480064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_1</Name>
@@ -90979,7 +91112,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345632</BitOffs>
+            <BitOffs>1274480096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_2</Name>
@@ -90996,7 +91129,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345664</BitOffs>
+            <BitOffs>1274480128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_3</Name>
@@ -91013,32 +91146,32 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274345696</BitOffs>
+            <BitOffs>1274480160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorMR1K1</Name>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
-            <BitOffs>1274345760</BitOffs>
+            <BitOffs>1274480224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1274345776</BitOffs>
+            <BitOffs>1274480240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1274345784</BitOffs>
+            <BitOffs>1274480248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbLogHandler</Name>
             <Comment> Logging</Comment>
             <BitSize>5798336</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>1274345792</BitOffs>
+            <BitOffs>1274480256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.ffBenderRange</Name>
@@ -91063,7 +91196,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>1026</Value>
               </SubItem>
             </Default>
-            <BitOffs>1280144128</BitOffs>
+            <BitOffs>1280278592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2</Name>
@@ -91086,7 +91219,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280170048</BitOffs>
+            <BitOffs>1280304512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
@@ -91101,19 +91234,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280193600</BitOffs>
+            <BitOffs>1280328064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1280581120</BitOffs>
+            <BitOffs>1280715584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1280581184</BitOffs>
+            <BitOffs>1280715648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
@@ -91127,19 +91260,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280581248</BitOffs>
+            <BitOffs>1280715712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1280968768</BitOffs>
+            <BitOffs>1281103232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1280968832</BitOffs>
+            <BitOffs>1281103296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
@@ -91153,26 +91286,26 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280968896</BitOffs>
+            <BitOffs>1281103360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281356416</BitOffs>
+            <BitOffs>1281490880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281356480</BitOffs>
+            <BitOffs>1281490944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1281356544</BitOffs>
+            <BitOffs>1281491008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -91180,7 +91313,7 @@ M1K1 BEND US ENC CNT</Comment>
  Using stepper only for now</Comment>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1281754432</BitOffs>
+            <BitOffs>1281888896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fYRoll_urad</Name>
@@ -91197,7 +91330,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282081856</BitOffs>
+            <BitOffs>1282216320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYleftM1K2</Name>
@@ -91214,7 +91347,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282081920</BitOffs>
+            <BitOffs>1282216384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYrightM1K2</Name>
@@ -91230,7 +91363,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282081952</BitOffs>
+            <BitOffs>1282216416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXupM1K2</Name>
@@ -91246,7 +91379,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282081984</BitOffs>
+            <BitOffs>1282216448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXdwnM1K2</Name>
@@ -91262,7 +91395,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082016</BitOffs>
+            <BitOffs>1282216480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntPitchM1K2</Name>
@@ -91278,7 +91411,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082048</BitOffs>
+            <BitOffs>1282216512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYleftM1K2</Name>
@@ -91295,7 +91428,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082080</BitOffs>
+            <BitOffs>1282216544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYrightM1K2</Name>
@@ -91311,7 +91444,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082112</BitOffs>
+            <BitOffs>1282216576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXupM1K2</Name>
@@ -91327,7 +91460,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082144</BitOffs>
+            <BitOffs>1282216608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXdwnM1K2</Name>
@@ -91343,7 +91476,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082176</BitOffs>
+            <BitOffs>1282216640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefPitchM1K2</Name>
@@ -91359,20 +91492,20 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282082208</BitOffs>
+            <BitOffs>1282216672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.mcReadParameterPitchM1K2</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1282082240</BitOffs>
+            <BitOffs>1282216704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncRefPitchM1K2_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282087232</BitOffs>
+            <BitOffs>1282221696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncLeverArm_mm</Name>
@@ -91382,7 +91515,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>391</Value>
             </Default>
-            <BitOffs>1282087296</BitOffs>
+            <BitOffs>1282221760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1</Name>
@@ -91395,7 +91528,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1282087360</BitOffs>
+            <BitOffs>1282221824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1_val</Name>
@@ -91411,7 +91544,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282087872</BitOffs>
+            <BitOffs>1282222336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2</Name>
@@ -91423,7 +91556,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1282087936</BitOffs>
+            <BitOffs>1282222400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2_val</Name>
@@ -91439,7 +91572,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282088448</BitOffs>
+            <BitOffs>1282222912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1</Name>
@@ -91451,7 +91584,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1282088512</BitOffs>
+            <BitOffs>1282222976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1_val</Name>
@@ -91467,7 +91600,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282089024</BitOffs>
+            <BitOffs>1282223488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bInit</Name>
@@ -91476,43 +91609,43 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1282089464</BitOffs>
+            <BitOffs>1282223928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1282089472</BitOffs>
+            <BitOffs>1282223936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1282416896</BitOffs>
+            <BitOffs>1282551360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1282744320</BitOffs>
+            <BitOffs>1282878784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283071744</BitOffs>
+            <BitOffs>1283206208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283399168</BitOffs>
+            <BitOffs>1283533632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283726592</BitOffs>
+            <BitOffs>1283861056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upeurad</Name>
@@ -91527,7 +91660,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284054272</BitOffs>
+            <BitOffs>1284188736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upeurad</Name>
@@ -91542,7 +91675,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284054336</BitOffs>
+            <BitOffs>1284188800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1</Name>
@@ -91565,7 +91698,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E13]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054400</BitOffs>
+            <BitOffs>1284188864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2</Name>
@@ -91587,7 +91720,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E13]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054656</BitOffs>
+            <BitOffs>1284189120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3</Name>
@@ -91609,7 +91742,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284054912</BitOffs>
+            <BitOffs>1284189376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4</Name>
@@ -91631,7 +91764,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055168</BitOffs>
+            <BitOffs>1284189632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5</Name>
@@ -91653,7 +91786,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055424</BitOffs>
+            <BitOffs>1284189888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6</Name>
@@ -91675,7 +91808,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055680</BitOffs>
+            <BitOffs>1284190144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7</Name>
@@ -91697,7 +91830,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284055936</BitOffs>
+            <BitOffs>1284190400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8</Name>
@@ -91719,7 +91852,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284056192</BitOffs>
+            <BitOffs>1284190656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_read</Name>
@@ -91735,7 +91868,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284056448</BitOffs>
+            <BitOffs>1284190912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_set</Name>
@@ -91750,7 +91883,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284056512</BitOffs>
+            <BitOffs>1284190976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_FFO</Name>
@@ -91770,7 +91903,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>4368</Value>
               </SubItem>
             </Default>
-            <BitOffs>1284056576</BitOffs>
+            <BitOffs>1284191040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_e_pmps</Name>
@@ -91779,7 +91912,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>74000.29</Value>
             </Default>
-            <BitOffs>1284082496</BitOffs>
+            <BitOffs>1284216960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1</Name>
@@ -91792,7 +91925,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1284082560</BitOffs>
+            <BitOffs>1284217024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1_val</Name>
@@ -91808,7 +91941,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284083072</BitOffs>
+            <BitOffs>1284217536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2</Name>
@@ -91820,7 +91953,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1284083136</BitOffs>
+            <BitOffs>1284217600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2_val</Name>
@@ -91836,7 +91969,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284083648</BitOffs>
+            <BitOffs>1284218112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1</Name>
@@ -91848,7 +91981,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1284083712</BitOffs>
+            <BitOffs>1284218176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1_val</Name>
@@ -91864,79 +91997,14 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284084224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fGpiEncoderPosDiff</Name>
-            <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1284084288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.afGpiPosDiffBuffer</Name>
-            <BitSize>64000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1000</Elements>
-            </ArrayInfo>
-            <BitOffs>1284084352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.afGpiExtraBuffer</Name>
-            <BitSize>64000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1000</Elements>
-            </ArrayInfo>
-            <BitOffs>1284148352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGpiPosDiffCollect</Name>
-            <BitSize>448</BitSize>
-            <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
-            <BitOffs>1284212352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGpiPosDiffStats</Name>
-            <BitSize>1152</BitSize>
-            <BaseType Namespace="LCLS_General">FB_BasicStats</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:G_PI:ENCDIFF
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284212800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fGpiRangeMax</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1284213952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.rtNewGpiMove</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1284214016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.tonNewGpiMove</Name>
-            <BitSize>256</BitSize>
-            <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1284214144</BitOffs>
+            <BitOffs>1284218688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fMpiEncoderPosDiff</Name>
             <Comment> SP1K1 Mirror Pitch Mono Vibration Stats</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1284214400</BitOffs>
+            <BitOffs>1284218752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.afMpiPosDiffBuffer</Name>
@@ -91946,7 +92014,7 @@ M1K1 BEND US ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>1000</Elements>
             </ArrayInfo>
-            <BitOffs>1284214464</BitOffs>
+            <BitOffs>1284218816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.afMpiExtraBuffer</Name>
@@ -91956,13 +92024,13 @@ M1K1 BEND US ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>1000</Elements>
             </ArrayInfo>
-            <BitOffs>1284278464</BitOffs>
+            <BitOffs>1284282816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMpiPosDiffCollect</Name>
             <BitSize>448</BitSize>
             <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
-            <BitOffs>1284342464</BitOffs>
+            <BitOffs>1284346816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMpiPosDiffStats</Name>
@@ -91976,7 +92044,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284342912</BitOffs>
+            <BitOffs>1284347264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -91996,37 +92064,37 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>3664</Value>
               </SubItem>
             </Default>
-            <BitOffs>1284351872</BitOffs>
+            <BitOffs>1284356224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284377792</BitOffs>
+            <BitOffs>1284382144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284705216</BitOffs>
+            <BitOffs>1284709568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285032640</BitOffs>
+            <BitOffs>1285036992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285360064</BitOffs>
+            <BitOffs>1285364416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285687488</BitOffs>
+            <BitOffs>1285691840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbStates</Name>
@@ -92041,7 +92109,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286014912</BitOffs>
+            <BitOffs>1286019264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP</Name>
@@ -92062,7 +92130,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_1]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709376</BitOffs>
+            <BitOffs>1286713728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM</Name>
@@ -92083,7 +92151,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_2]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709632</BitOffs>
+            <BitOffs>1286713984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG</Name>
@@ -92104,7 +92172,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_4]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286709888</BitOffs>
+            <BitOffs>1286714240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync</Name>
@@ -92125,7 +92193,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_3]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710144</BitOffs>
+            <BitOffs>1286714496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige</Name>
@@ -92144,7 +92212,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bGigePower := TIIB[EL2004_SL1K2]^Channel 3^Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286710400</BitOffs>
+            <BitOffs>1286714752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter</Name>
@@ -92174,7 +92242,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3052_SL1K2_FWM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1286711744</BitOffs>
+            <BitOffs>1286716096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fSmallDelta</Name>
@@ -92184,7 +92252,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.01</Value>
             </Default>
-            <BitOffs>1286712256</BitOffs>
+            <BitOffs>1286716608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fBigDelta</Name>
@@ -92193,7 +92261,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>10</Value>
             </Default>
-            <BitOffs>1286712320</BitOffs>
+            <BitOffs>1286716672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fMaxVelocity</Name>
@@ -92202,7 +92270,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.5</Value>
             </Default>
-            <BitOffs>1286712384</BitOffs>
+            <BitOffs>1286716736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fHighAccel</Name>
@@ -92211,7 +92279,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.8</Value>
             </Default>
-            <BitOffs>1286712448</BitOffs>
+            <BitOffs>1286716800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fLowAccel</Name>
@@ -92220,25 +92288,25 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1286712512</BitOffs>
+            <BitOffs>1286716864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286712576</BitOffs>
+            <BitOffs>1286716928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO</Name>
             <BitSize>145024</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>1287041216</BitOffs>
+            <BitOffs>1287045568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>1287186240</BitOffs>
+            <BitOffs>1287190592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ff2_ff1_link_optics</Name>
@@ -92262,7 +92330,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>65535</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287214592</BitOffs>
+            <BitOffs>1287218944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX01</Name>
@@ -92287,7 +92355,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62729</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287240512</BitOffs>
+            <BitOffs>1287244864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX02</Name>
@@ -92311,7 +92379,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62736</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287266432</BitOffs>
+            <BitOffs>1287270784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX05</Name>
@@ -92335,7 +92403,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62737</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287292352</BitOffs>
+            <BitOffs>1287296704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.delta</Name>
@@ -92344,7 +92412,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1287318272</BitOffs>
+            <BitOffs>1287322624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
@@ -92360,7 +92428,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287318304</BitOffs>
+            <BitOffs>1287322656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
@@ -92376,7 +92444,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287318312</BitOffs>
+            <BitOffs>1287322664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOS_IN</Name>
@@ -92392,7 +92460,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287318320</BitOffs>
+            <BitOffs>1287322672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOB_on_Lower_Stopper</Name>
@@ -92408,7 +92476,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287318328</BitOffs>
+            <BitOffs>1287322680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeam</Name>
@@ -92433,7 +92501,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287318336</BitOffs>
+            <BitOffs>1287322688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
@@ -92449,7 +92517,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287344256</BitOffs>
+            <BitOffs>1287348608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
@@ -92465,7 +92533,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287344264</BitOffs>
+            <BitOffs>1287348616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.nMachineMode</Name>
@@ -92483,7 +92551,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287344272</BitOffs>
+            <BitOffs>1287348624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefXM2K2</Name>
@@ -92501,110 +92569,110 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1287344288</BitOffs>
+            <BitOffs>1287348640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344320</BitOffs>
+            <BitOffs>1287348672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344384</BitOffs>
+            <BitOffs>1287348736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344448</BitOffs>
+            <BitOffs>1287348800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344512</BitOffs>
+            <BitOffs>1287348864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.HZos</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344576</BitOffs>
+            <BitOffs>1287348928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344640</BitOffs>
+            <BitOffs>1287348992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344704</BitOffs>
+            <BitOffs>1287349056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344768</BitOffs>
+            <BitOffs>1287349120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344832</BitOffs>
+            <BitOffs>1287349184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344896</BitOffs>
+            <BitOffs>1287349248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287344960</BitOffs>
+            <BitOffs>1287349312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hb0m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345024</BitOffs>
+            <BitOffs>1287349376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm3</Name>
             <Comment>fixed calc</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345088</BitOffs>
+            <BitOffs>1287349440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hpiv</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345152</BitOffs>
+            <BitOffs>1287349504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345216</BitOffs>
+            <BitOffs>1287349568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345280</BitOffs>
+            <BitOffs>1287349632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345344</BitOffs>
+            <BitOffs>1287349696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Delta</Name>
@@ -92620,13 +92688,13 @@ MR2K2 X ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287345408</BitOffs>
+            <BitOffs>1287349760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Ans</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287345472</BitOffs>
+            <BitOffs>1287349824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeamExitSlits</Name>
@@ -92650,7 +92718,7 @@ MR2K2 X ENC REF</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287345536</BitOffs>
+            <BitOffs>1287349888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hi2</Name>
@@ -92660,7 +92728,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>1.4</Value>
             </Default>
-            <BitOffs>1287371456</BitOffs>
+            <BitOffs>1287375808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zi2</Name>
@@ -92670,7 +92738,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>731.613</Value>
             </Default>
-            <BitOffs>1287371520</BitOffs>
+            <BitOffs>1287375872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta0</Name>
@@ -92679,7 +92747,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>1287371584</BitOffs>
+            <BitOffs>1287375936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zm1</Name>
@@ -92689,7 +92757,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>733.772</Value>
             </Default>
-            <BitOffs>1287371648</BitOffs>
+            <BitOffs>1287376000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zmon</Name>
@@ -92699,7 +92767,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>739.622</Value>
             </Default>
-            <BitOffs>1287371712</BitOffs>
+            <BitOffs>1287376064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zpiv</Name>
@@ -92709,7 +92777,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>739.762</Value>
             </Default>
-            <BitOffs>1287371776</BitOffs>
+            <BitOffs>1287376128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zzos</Name>
@@ -92719,7 +92787,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>741.422</Value>
             </Default>
-            <BitOffs>1287371840</BitOffs>
+            <BitOffs>1287376192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1Offset</Name>
@@ -92728,7 +92796,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>18081.1</Value>
             </Default>
-            <BitOffs>1287371904</BitOffs>
+            <BitOffs>1287376256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2Offset</Name>
@@ -92737,7 +92805,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>-90603</Value>
             </Default>
-            <BitOffs>1287371968</BitOffs>
+            <BitOffs>1287376320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3Offset</Name>
@@ -92747,7 +92815,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>-63300</Value>
             </Default>
-            <BitOffs>1287372032</BitOffs>
+            <BitOffs>1287376384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
@@ -92761,19 +92829,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1287372096</BitOffs>
+            <BitOffs>1287376448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287759616</BitOffs>
+            <BitOffs>1287763968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287759680</BitOffs>
+            <BitOffs>1287764032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
@@ -92786,19 +92854,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1287759744</BitOffs>
+            <BitOffs>1287764096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288147264</BitOffs>
+            <BitOffs>1288151616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288147328</BitOffs>
+            <BitOffs>1288151680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
@@ -92811,19 +92879,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1288147392</BitOffs>
+            <BitOffs>1288151744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288534912</BitOffs>
+            <BitOffs>1288539264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288534976</BitOffs>
+            <BitOffs>1288539328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefYM2K2</Name>
@@ -92840,7 +92908,7 @@ MR2K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288535040</BitOffs>
+            <BitOffs>1288539392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefrXM2K2</Name>
@@ -92857,7 +92925,7 @@ MR2K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288535072</BitOffs>
+            <BitOffs>1288539424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntXM2K2</Name>
@@ -92875,7 +92943,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288535104</BitOffs>
+            <BitOffs>1288539456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntYM2K2</Name>
@@ -92892,7 +92960,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288535136</BitOffs>
+            <BitOffs>1288539488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntrXM2K2</Name>
@@ -92909,7 +92977,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288535168</BitOffs>
+            <BitOffs>1288539520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1</Name>
@@ -92922,7 +92990,7 @@ M2K2 FLAT X ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535232</BitOffs>
+            <BitOffs>1288539584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1_val</Name>
@@ -92938,7 +93006,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288535744</BitOffs>
+            <BitOffs>1288540096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2</Name>
@@ -92950,7 +93018,7 @@ M2K2 FLAT X ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1288535808</BitOffs>
+            <BitOffs>1288540160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2_val</Name>
@@ -92966,7 +93034,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288536320</BitOffs>
+            <BitOffs>1288540672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Press_1</Name>
@@ -92978,7 +93046,7 @@ M2K2 FLAT X ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1288536384</BitOffs>
+            <BitOffs>1288540736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMR2K2_Press_1_val</Name>
@@ -92994,7 +93062,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288536896</BitOffs>
+            <BitOffs>1288541248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
@@ -93008,19 +93076,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1288536960</BitOffs>
+            <BitOffs>1288541312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288924480</BitOffs>
+            <BitOffs>1288928832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288924544</BitOffs>
+            <BitOffs>1288928896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
@@ -93033,19 +93101,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1288924608</BitOffs>
+            <BitOffs>1288928960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289312128</BitOffs>
+            <BitOffs>1289316480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289312192</BitOffs>
+            <BitOffs>1289316544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
@@ -93058,19 +93126,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1289312256</BitOffs>
+            <BitOffs>1289316608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289699776</BitOffs>
+            <BitOffs>1289704128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289699840</BitOffs>
+            <BitOffs>1289704192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
@@ -93083,19 +93151,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1289699904</BitOffs>
+            <BitOffs>1289704256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290087424</BitOffs>
+            <BitOffs>1290091776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290087488</BitOffs>
+            <BitOffs>1290091840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
@@ -93108,19 +93176,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1290087552</BitOffs>
+            <BitOffs>1290091904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290475072</BitOffs>
+            <BitOffs>1290479424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290475136</BitOffs>
+            <BitOffs>1290479488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefXM3K2</Name>
@@ -93138,7 +93206,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475200</BitOffs>
+            <BitOffs>1290479552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefYM3K2</Name>
@@ -93155,7 +93223,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475232</BitOffs>
+            <BitOffs>1290479584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefrYM3K2</Name>
@@ -93172,7 +93240,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475264</BitOffs>
+            <BitOffs>1290479616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefUSM3K2</Name>
@@ -93189,7 +93257,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475296</BitOffs>
+            <BitOffs>1290479648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefDSM3K2</Name>
@@ -93206,7 +93274,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475328</BitOffs>
+            <BitOffs>1290479680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntXM3K2</Name>
@@ -93224,7 +93292,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475360</BitOffs>
+            <BitOffs>1290479712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntYM3K2</Name>
@@ -93241,7 +93309,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475392</BitOffs>
+            <BitOffs>1290479744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntrYM3K2</Name>
@@ -93258,7 +93326,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475424</BitOffs>
+            <BitOffs>1290479776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntUSM3K2</Name>
@@ -93275,7 +93343,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475456</BitOffs>
+            <BitOffs>1290479808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntDSM3K2</Name>
@@ -93292,7 +93360,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475488</BitOffs>
+            <BitOffs>1290479840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_1</Name>
@@ -93311,7 +93379,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475520</BitOffs>
+            <BitOffs>1290479872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_2</Name>
@@ -93328,7 +93396,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475552</BitOffs>
+            <BitOffs>1290479904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
@@ -93345,7 +93413,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475584</BitOffs>
+            <BitOffs>1290479936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
@@ -93363,7 +93431,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475616</BitOffs>
+            <BitOffs>1290479968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
@@ -93380,7 +93448,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475648</BitOffs>
+            <BitOffs>1290480000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -93397,7 +93465,64 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290475680</BitOffs>
+            <BitOffs>1290480032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1</Name>
+            <Comment> MR3K2 Flow Sensors</Comment>
+            <BitSize>512</BitSize>
+            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290480128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1_val</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBH:FWM:1
+        field: EGU lpm
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290480640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1</Name>
+            <BitSize>512</BitSize>
+            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290480704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1_val</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBH:PRSM:1
+        field: EGU bar
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290481216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
@@ -93411,19 +93536,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475776</BitOffs>
+            <BitOffs>1290481280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290863296</BitOffs>
+            <BitOffs>1290868800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290863360</BitOffs>
+            <BitOffs>1290868864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
@@ -93436,19 +93561,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1290863424</BitOffs>
+            <BitOffs>1290868928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291250944</BitOffs>
+            <BitOffs>1291256448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291251008</BitOffs>
+            <BitOffs>1291256512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
@@ -93461,19 +93586,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1291251072</BitOffs>
+            <BitOffs>1291256576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291638592</BitOffs>
+            <BitOffs>1291644096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291638656</BitOffs>
+            <BitOffs>1291644160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
@@ -93486,19 +93611,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1291638720</BitOffs>
+            <BitOffs>1291644224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292026240</BitOffs>
+            <BitOffs>1292031744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292026304</BitOffs>
+            <BitOffs>1292031808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
@@ -93511,19 +93636,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1292026368</BitOffs>
+            <BitOffs>1292031872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292413888</BitOffs>
+            <BitOffs>1292419392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292413952</BitOffs>
+            <BitOffs>1292419456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -93541,7 +93666,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414016</BitOffs>
+            <BitOffs>1292419520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -93558,7 +93683,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414048</BitOffs>
+            <BitOffs>1292419552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -93575,7 +93700,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414080</BitOffs>
+            <BitOffs>1292419584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -93592,7 +93717,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414112</BitOffs>
+            <BitOffs>1292419616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -93609,7 +93734,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414144</BitOffs>
+            <BitOffs>1292419648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -93627,7 +93752,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414176</BitOffs>
+            <BitOffs>1292419680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -93644,7 +93769,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414208</BitOffs>
+            <BitOffs>1292419712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -93661,7 +93786,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414240</BitOffs>
+            <BitOffs>1292419744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -93678,7 +93803,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414272</BitOffs>
+            <BitOffs>1292419776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -93695,7 +93820,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414304</BitOffs>
+            <BitOffs>1292419808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -93714,7 +93839,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414336</BitOffs>
+            <BitOffs>1292419840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -93731,7 +93856,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414368</BitOffs>
+            <BitOffs>1292419872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -93748,7 +93873,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414400</BitOffs>
+            <BitOffs>1292419904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -93766,7 +93891,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414432</BitOffs>
+            <BitOffs>1292419936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -93783,7 +93908,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414464</BitOffs>
+            <BitOffs>1292419968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -93800,7 +93925,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414496</BitOffs>
+            <BitOffs>1292420000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -93823,7 +93948,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414528</BitOffs>
+            <BitOffs>1292420032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -93846,7 +93971,64 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292414784</BitOffs>
+            <BitOffs>1292420288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1</Name>
+            <Comment> MR4K2 Flow Sensors</Comment>
+            <BitSize>512</BitSize>
+            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292420608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1_val</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR4K2:KBV:FWM:1
+        field: EGU lpm
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292421120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1</Name>
+            <BitSize>512</BitSize>
+            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292421184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1_val</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR4K2:KBV:PRSM:1
+        field: EGU bar
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292421696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -93881,7 +94063,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292420160</BitOffs>
+            <BitOffs>1292426816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -93896,7 +94078,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292422656</BitOffs>
+            <BitOffs>1292429312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -93910,7 +94092,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292422720</BitOffs>
+            <BitOffs>1292429376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -93925,7 +94107,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292422784</BitOffs>
+            <BitOffs>1292429440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -93940,7 +94122,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292422848</BitOffs>
+            <BitOffs>1292429504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -93955,7 +94137,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292422912</BitOffs>
+            <BitOffs>1292429568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -93970,7 +94152,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292422976</BitOffs>
+            <BitOffs>1292429632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -93986,7 +94168,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423104</BitOffs>
+            <BitOffs>1292429760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -94000,7 +94182,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423168</BitOffs>
+            <BitOffs>1292429824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -94014,7 +94196,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423232</BitOffs>
+            <BitOffs>1292429888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -94028,7 +94210,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292423296</BitOffs>
+            <BitOffs>1292429952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -94043,7 +94225,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292425856</BitOffs>
+            <BitOffs>1292432512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -94058,7 +94240,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292425920</BitOffs>
+            <BitOffs>1292432576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -94073,7 +94255,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292425984</BitOffs>
+            <BitOffs>1292432640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -94089,7 +94271,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426048</BitOffs>
+            <BitOffs>1292432704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -94103,7 +94285,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426112</BitOffs>
+            <BitOffs>1292432768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -94117,7 +94299,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426176</BitOffs>
+            <BitOffs>1292432832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -94132,7 +94314,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426240</BitOffs>
+            <BitOffs>1292432896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -94147,7 +94329,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426304</BitOffs>
+            <BitOffs>1292432960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -94163,7 +94345,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426496</BitOffs>
+            <BitOffs>1292433152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -94177,7 +94359,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426560</BitOffs>
+            <BitOffs>1292433216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -94191,7 +94373,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426624</BitOffs>
+            <BitOffs>1292433280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -94206,7 +94388,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426688</BitOffs>
+            <BitOffs>1292433344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -94221,7 +94403,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426752</BitOffs>
+            <BitOffs>1292433408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -94236,7 +94418,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426816</BitOffs>
+            <BitOffs>1292433472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -94251,7 +94433,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426880</BitOffs>
+            <BitOffs>1292433536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -94266,7 +94448,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426944</BitOffs>
+            <BitOffs>1292433600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -94281,7 +94463,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427008</BitOffs>
+            <BitOffs>1292433664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -94297,7 +94479,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427136</BitOffs>
+            <BitOffs>1292433792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -94311,7 +94493,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427200</BitOffs>
+            <BitOffs>1292433856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -94325,7 +94507,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427264</BitOffs>
+            <BitOffs>1292433920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -94339,7 +94521,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427328</BitOffs>
+            <BitOffs>1292433984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -94354,7 +94536,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427392</BitOffs>
+            <BitOffs>1292434048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -94365,7 +94547,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427424</BitOffs>
+            <BitOffs>1292434080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -94383,7 +94565,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292427456</BitOffs>
+            <BitOffs>1292434112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -94401,7 +94583,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292923200</BitOffs>
+            <BitOffs>1292929856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -94430,7 +94612,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293418944</BitOffs>
+            <BitOffs>1293425600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -94459,7 +94641,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293943296</BitOffs>
+            <BitOffs>1293949952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -94496,7 +94678,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294468032</BitOffs>
+            <BitOffs>1294474688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -94507,7 +94689,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294489216</BitOffs>
+            <BitOffs>1294495872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -94544,7 +94726,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294816640</BitOffs>
+            <BitOffs>1294823296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -94555,7 +94737,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294837824</BitOffs>
+            <BitOffs>1294844480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -94592,7 +94774,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295165248</BitOffs>
+            <BitOffs>1295171904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -94603,7 +94785,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295186432</BitOffs>
+            <BitOffs>1295193088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -94640,7 +94822,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295513856</BitOffs>
+            <BitOffs>1295520512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -94651,7 +94833,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295535040</BitOffs>
+            <BitOffs>1295541696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -94688,7 +94870,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295862464</BitOffs>
+            <BitOffs>1295869120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -94726,7 +94908,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295883648</BitOffs>
+            <BitOffs>1295890304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -94764,7 +94946,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295926016</BitOffs>
+            <BitOffs>1295932672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -94802,7 +94984,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295947200</BitOffs>
+            <BitOffs>1295953856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -94839,7 +95021,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295968384</BitOffs>
+            <BitOffs>1295975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -94871,7 +95053,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295989568</BitOffs>
+            <BitOffs>1295996224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -94909,7 +95091,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296010752</BitOffs>
+            <BitOffs>1296017408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -94920,7 +95102,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296031936</BitOffs>
+            <BitOffs>1296038592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -94957,7 +95139,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296359360</BitOffs>
+            <BitOffs>1296366016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -94968,7 +95150,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296380544</BitOffs>
+            <BitOffs>1296387200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -95005,7 +95187,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296707968</BitOffs>
+            <BitOffs>1296714624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -95016,7 +95198,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296729152</BitOffs>
+            <BitOffs>1296735808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -95053,7 +95235,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297056576</BitOffs>
+            <BitOffs>1297063232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -95064,7 +95246,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297077760</BitOffs>
+            <BitOffs>1297084416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -95102,7 +95284,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297405184</BitOffs>
+            <BitOffs>1297411840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -95135,7 +95317,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297426368</BitOffs>
+            <BitOffs>1297433024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -95146,7 +95328,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297447552</BitOffs>
+            <BitOffs>1297454208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -95180,7 +95362,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297774976</BitOffs>
+            <BitOffs>1297781632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -95191,7 +95373,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297796160</BitOffs>
+            <BitOffs>1297802816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -95225,7 +95407,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298123584</BitOffs>
+            <BitOffs>1298130240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -95259,7 +95441,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298144768</BitOffs>
+            <BitOffs>1298151424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -95293,7 +95475,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298165952</BitOffs>
+            <BitOffs>1298172608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -95327,7 +95509,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298187136</BitOffs>
+            <BitOffs>1298193792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -95361,7 +95543,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298208320</BitOffs>
+            <BitOffs>1298214976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -95390,7 +95572,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298229504</BitOffs>
+            <BitOffs>1298236160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -95422,7 +95604,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298250688</BitOffs>
+            <BitOffs>1298257344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -95433,7 +95615,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298271872</BitOffs>
+            <BitOffs>1298278528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -95465,7 +95647,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298599296</BitOffs>
+            <BitOffs>1298605952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -95476,7 +95658,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298620480</BitOffs>
+            <BitOffs>1298627136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -95508,7 +95690,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298947904</BitOffs>
+            <BitOffs>1298954560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -95519,7 +95701,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298969088</BitOffs>
+            <BitOffs>1298975744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -95551,7 +95733,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299296512</BitOffs>
+            <BitOffs>1299303168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -95562,7 +95744,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299317696</BitOffs>
+            <BitOffs>1299324352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -95594,7 +95776,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299645120</BitOffs>
+            <BitOffs>1299651776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -95605,7 +95787,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299666304</BitOffs>
+            <BitOffs>1299672960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -95637,7 +95819,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299993728</BitOffs>
+            <BitOffs>1300000384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -95648,7 +95830,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300014912</BitOffs>
+            <BitOffs>1300021568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -95680,7 +95862,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300342336</BitOffs>
+            <BitOffs>1300348992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -95691,7 +95873,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300363520</BitOffs>
+            <BitOffs>1300370176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -95723,7 +95905,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300690944</BitOffs>
+            <BitOffs>1300697600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -95734,7 +95916,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300712128</BitOffs>
+            <BitOffs>1300718784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -95766,7 +95948,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301039552</BitOffs>
+            <BitOffs>1301046208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -95777,7 +95959,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301060736</BitOffs>
+            <BitOffs>1301067392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -95809,7 +95991,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301388160</BitOffs>
+            <BitOffs>1301394816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -95820,7 +96002,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301409344</BitOffs>
+            <BitOffs>1301416000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -95852,7 +96034,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301736768</BitOffs>
+            <BitOffs>1301743424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -95863,7 +96045,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301757952</BitOffs>
+            <BitOffs>1301764608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -95895,7 +96077,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302085376</BitOffs>
+            <BitOffs>1302092032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -95906,7 +96088,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302106560</BitOffs>
+            <BitOffs>1302113216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -95938,7 +96120,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302433984</BitOffs>
+            <BitOffs>1302440640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -95949,7 +96131,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302455168</BitOffs>
+            <BitOffs>1302461824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -95960,7 +96142,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782608</BitOffs>
+            <BitOffs>1302789264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -95975,7 +96157,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782624</BitOffs>
+            <BitOffs>1302789280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -95990,7 +96172,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782632</BitOffs>
+            <BitOffs>1302789288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -96020,7 +96202,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782640</BitOffs>
+            <BitOffs>1302789296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -96050,7 +96232,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782704</BitOffs>
+            <BitOffs>1302789360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -96065,7 +96247,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782768</BitOffs>
+            <BitOffs>1302789424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -96080,7 +96262,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782784</BitOffs>
+            <BitOffs>1302789440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -96095,7 +96277,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782800</BitOffs>
+            <BitOffs>1302789456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -96109,7 +96291,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782808</BitOffs>
+            <BitOffs>1302789464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -96124,7 +96306,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782816</BitOffs>
+            <BitOffs>1302789472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -96139,7 +96321,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782848</BitOffs>
+            <BitOffs>1302789504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -96260,56 +96442,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302782880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302791264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302791296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
-            <BitSize>896</BitSize>
-            <BaseType>_Implicit_Task_Info</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.dwVersion</Name>
-                <Value>2</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcContextName</Name>
-                <Value>PlcTask</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302794048</BitOffs>
+            <BitOffs>1302789536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -96381,7 +96514,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302811968</BitOffs>
+            <BitOffs>1302807584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -96453,7 +96586,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302812096</BitOffs>
+            <BitOffs>1302807712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -96525,7 +96658,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302812224</BitOffs>
+            <BitOffs>1302807840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -96597,7 +96730,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302812352</BitOffs>
+            <BitOffs>1302807968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -96669,7 +96802,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302812480</BitOffs>
+            <BitOffs>1302808096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -96741,7 +96874,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302812608</BitOffs>
+            <BitOffs>1302808224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -96767,128 +96900,63 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302845632</BitOffs>
+            <BitOffs>1302841248</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1</Name>
-            <Comment> MR3K2 Flow Sensors</Comment>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
             <Properties>
               <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310995008</BitOffs>
+            <BitOffs>1302857696</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
+            <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR3K2:KBH:FWM:1
-        field: EGU lpm
-        io: i
-    </Value>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310995520</BitOffs>
+            <BitOffs>1302857728</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
+            <BitSize>896</BitSize>
+            <BaseType>_Implicit_Task_Info</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.dwVersion</Name>
+                <Value>2</Value>
+              </SubItem>
+            </Default>
             <Properties>
               <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
+                <Name>TcContextName</Name>
+                <Value>PlcTask</Value>
               </Property>
-            </Properties>
-            <BitOffs>1310995584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR3K2:KBH:PRSM:1
-        field: EGU bar
-        io: i
-    </Value>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310996096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1</Name>
-            <Comment> MR4K2 Flow Sensors</Comment>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310996160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR4K2:KBV:FWM:1
-        field: EGU lpm
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310996672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310996736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR4K2:KBV:PRSM:1
-        field: EGU bar
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310997248</BitOffs>
+            <BitOffs>1302861376</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
-          <AreaNo AreaType="RetainSrc" CreateSymbols="true">52</AreaNo>
+          <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
-          <ContextId>3</ContextId>
-          <ByteSize>164036608</ByteSize>
+          <ContextId>4</ContextId>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -96968,15 +97036,15 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-01-17T14:36:43</Value>
+          <Value>2024-01-30T11:21:31</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>974848</Value>
+          <Value>978944</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>162504704</Value>
+          <Value>162648064</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Beckhoff recommended we match the task cycle time of the NC block to the task cycle time doing the stats calculation. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Still trying to understand why the NC readback has a smaller STD Deviation than a direct encoder count calculation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running on PLC

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
