### PR TITLE
ENH: move flow/pressure calls to the optics library

### DIFF
--- a/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
@@ -1440,7 +1440,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="3" Time="0.2"/>
+				<PosDiffControl Range="10" Time="0.2"/>
 				<PID PosKp="7" PosTn="0.001" PosIOutputLimit="0.0005" PosDOutputLimit="0" PosIDisableWhenMoving="true" PosExtKp="8" PosExtVelo="0.0001" DeadBandPosition="0.02"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D63D7E12-56AF-1AB1-BC80-3163170A85A6}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{59E3669E-D1DA-ED54-7F83-ABBB45EA4F77}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{59E3669E-D1DA-ED54-7F83-ABBB45EA4F77}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{09BF2CD2-8525-B6F1-2E3E-E7CCEA6380AC}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{09BF2CD2-8525-B6F1-2E3E-E7CCEA6380AC}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{E3C294DB-8219-B920-2780-EBADF1F16FAF}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1393,61 +1393,6 @@ External Setpoint Generation:
 			</Vars>
 			<Vars VarGrpType="1" ContextId="4" AreaNo="64">
 				<Name>PlcTask Inputs</Name>
-				<Var>
-					<Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
-					<Comment><![CDATA[ STO Button]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
-					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
@@ -1518,56 +1463,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
-					<Comment><![CDATA[ STO Button]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
-					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -1883,21 +1778,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
 					<Comment><![CDATA[ RTD error bit]]></Comment>
 					<Type>BOOL</Type>
@@ -1930,16 +1810,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -2017,16 +1887,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
 					<Type>INT</Type>
 				</Var>
@@ -2034,11 +1894,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
 					<Comment><![CDATA[ M1K1 DS RTDs]]></Comment>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -2056,11 +1911,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -3644,13 +3494,159 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
+				<Var>
+					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
+					<Comment><![CDATA[ STO Button]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
+					<Comment><![CDATA[ STO Button]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
 			</Vars>
 			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
-				<Var>
-					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
@@ -3676,10 +3672,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>PRG_MR1K1_BEND.nMR1K1_Y_ENC_PMPS</Name>
 					<Comment><![CDATA[////////////////////////////////////]]></Comment>
 					<Type>UDINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -4201,6 +4193,14 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -847,12 +847,12 @@ External Setpoint Generation:
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
+			<Name GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_EL5042_Status</Name>
 			<BitSize>0</BitSize>
 			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
 		</DataType>
 		<DataType>
-			<Name GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Name GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
 			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
 			<BitSize>128</BitSize>
 			<SubItem>
@@ -870,7 +870,7 @@ External Setpoint Generation:
 			</SubItem>
 			<SubItem>
 				<Name>Status</Name>
-				<Type GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
+				<Type GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
 				<Comment><![CDATA[ Status struct placeholder]]></Comment>
 				<BitSize>0</BitSize>
 				<BitOffs>64</BitOffs>
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{AF746F3C-18E1-BB13-C597-9DE0DD4AE3BE}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D63D7E12-56AF-1AB1-BC80-3163170A85A6}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1370,10 +1370,6 @@ External Setpoint Generation:
 			</Vars>
 			<Vars VarGrpType="1" ContextId="1" AreaNo="16">
 				<Name>StatsTask Inputs</Name>
-				<Var>
-					<Name>Main.M6.Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
 				<Var>
 					<Name>Main.M7.Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
@@ -1398,7 +1394,7 @@ External Setpoint Generation:
 			<Vars VarGrpType="1" ContextId="4" AreaNo="64">
 				<Name>PlcTask Inputs</Name>
 				<Var>
-					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+					<Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
 					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
@@ -1414,19 +1410,19 @@ External Setpoint Generation:
 				<Var>
 					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
 					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -1465,6 +1461,16 @@ External Setpoint Generation:
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable1</Name>
+					<Comment><![CDATA[Emergency Stop for MR1K1
+Emergency Stop for MR1K1]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR1K1_BEND.fM1K1_Flow_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
 					<Type>INT</Type>
@@ -1478,16 +1484,6 @@ External Setpoint Generation:
 					<Name>PRG_MR1K1_BEND.fM1K1_Press_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable1</Name>
-					<Comment><![CDATA[Emergency Stop for MR1K1
-Emergency Stop for MR1K1]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable2</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_1_Err</Name>
@@ -1515,6 +1511,15 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
+					<Comment><![CDATA[ Where is the STO]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
 					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
@@ -1526,19 +1531,19 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
 					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -1584,15 +1589,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
-					<Comment><![CDATA[ Where is the STO]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
@@ -1618,11 +1614,11 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K1_MONO.mpi_upe</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K1_MONO.gpi_upe</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K1_MONO.RTD1.bError</Name>
@@ -1887,6 +1883,21 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
 					<Comment><![CDATA[ RTD error bit]]></Comment>
 					<Type>BOOL</Type>
@@ -1894,21 +1905,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fMR2K2_Press_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
@@ -1936,6 +1932,16 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
 					<Comment><![CDATA[ RTD error bit]]></Comment>
 					<Type>BOOL</Type>
@@ -1945,14 +1951,12 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
+					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
+					<Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -1987,14 +1991,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
 					<Type>BOOL</Type>
 				</Var>
@@ -2017,17 +2013,17 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -2035,14 +2031,14 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
 					<Comment><![CDATA[ M1K1 DS RTDs]]></Comment>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -2058,13 +2054,13 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
 					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
-					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -2111,6 +2107,10 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>Main.sio_current</Name>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.sio_load</Name>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
@@ -2323,6 +2323,10 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.M5.nRawEncoderINT</Name>
 					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M6.Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitForwardEnable</Name>
@@ -3640,15 +3644,15 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
-				<Var>
-					<Name>Main.sio_load</Name>
-					<Type>UINT</Type>
-				</Var>
 			</Vars>
 			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
 				<Var>
 					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
@@ -3659,10 +3663,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR1K1_BEND.bLEDPower02</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.bLEDPower03</Name>
@@ -3684,26 +3684,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower01</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower02</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower03</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SL1K2_EXIT.bFanOn</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SL1K2_EXIT.bLEDPower</Name>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -3728,6 +3708,26 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bLEDPower01</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bLEDPower02</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bLEDPower03</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SL1K2_EXIT.bFanOn</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SL1K2_EXIT.bLEDPower</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -4691,9 +4691,9 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR2K2^EL3054_MR2K2_FWM_PRSM">
-				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.fMR2K2_Flow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.fMR2K2_Flow_2.iRaw" VarB="AI Standard Channel 3^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.fMR2K2_Press_1.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw" VarB="AI Standard Channel 3^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR2K2^EL5042_M2K2X_M2K2Y">
 				<Link VarA="PlcTask Inputs^Main.M25.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -4762,10 +4762,10 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^Main.M31.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 322 (EK1122)^EK1100_MR4K2^EL3054_MR3_4K2_FWM_PRSM">
-				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw" VarB="AI Standard Channel 3^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw" VarB="AI Standard Channel 3^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 322 (EK1122)^EK1100_MR4K2^EL5042_M4K2X_M4K2Y">
 				<Link VarA="PlcTask Inputs^Main.M33.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -4957,8 +4957,8 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Outputs^Main.M8.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^m_pi">
+				<Link VarA="PlcTask Inputs^Main.M6.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M6.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
-				<Link VarA="StatsTask Inputs^Main.M6.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^s_io">
 				<Link VarA="PlcTask Inputs^Main.M10.Axis.NcToPlc" VarB="Outputs^ToPlc"/>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</TargetSelect>
-					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
+					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -18,7 +18,7 @@
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:YLEFT
     '}
-    M1 : DUT_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yleft
+    M1 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yleft
     fbMotionStage_m1 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
@@ -26,7 +26,7 @@
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:YRIGHT
     '}
-    M2 : DUT_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yright
+    M2 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yright
     fbMotionStage_m2 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
@@ -34,7 +34,7 @@
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:XUP
     '}
-    M3 : DUT_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xup
+    M3 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xup
     fbMotionStage_m3 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
@@ -42,7 +42,7 @@
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:XDWN
     '}
-    M4 : DUT_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xdwn
+    M4 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xdwn
     fbMotionStage_m4 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
@@ -50,7 +50,7 @@
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:PITCH
     '}
-    M5 : DUT_MotionStage := (fVelocity:=30.0, nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=True); // M1K2 Pitch Stepper
+    M5 : ST_MotionStage := (fVelocity:=30.0, nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=True); // M1K2 Pitch Stepper
 
 
     (*SP1K1-Mono*)
@@ -60,39 +60,39 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position'}
-    M6: DUT_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.ALWAYS, fVelocity:=200.0, bPowerSelf:=True); // M_PI, urad
+    M6: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.ALWAYS, fVelocity:=200.0, bPowerSelf:=True); // M_PI, urad
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:MMS:G_PI
     '}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[g_pi_m]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[g_pi_m]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[g_pi_up_dwn_e]^FB Inputs Channel 1^Position'}
-    M7: DUT_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.ALWAYS, fVelocity:=200.0, bPowerSelf:=True); // G_PI, urad
+    M7: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.ALWAYS, fVelocity:=200.0, bPowerSelf:=True); // G_PI, urad
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:MMS:M_H
     '}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position'}
-    M8: DUT_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=500.0, bPowerSelf:=True); // M_H, um
+    M8: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=500.0, bPowerSelf:=True); // M_H, um
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:MMS:G_H
     '}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position'}
-    M9: DUT_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=1000.0, bPowerSelf:=True); // G_H, um
+    M9: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=1000.0, bPowerSelf:=True); // G_H, um
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:MMS:SD_V
     '}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2'}
-    M10: DUT_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=500.0, bPowerSelf:=True); // SD_V, um
+    M10: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=500.0, bPowerSelf:=True); // SD_V, um
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:MMS:SD_ROT
     '}
     // no limits on this motion
-    M11: DUT_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=500.0, bPowerSelf:=True); // SD_R, urad
+    M11: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=500.0, bPowerSelf:=True); // SD_R, urad
 
     (*MR1K1*)
     // Should move before MR1K2 and re-number each motor, lots of work
@@ -105,7 +105,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:YUP
     '}
-    M12 : DUT_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Yup
+    M12 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Yup
     fbMotionStage_m12 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
@@ -113,7 +113,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:YDWN
     '}
-    M13 : DUT_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Ydwn
+    M13 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Ydwn
     fbMotionStage_m13 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
@@ -121,7 +121,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:XUP
     '}
-    M14 : DUT_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Xup
+    M14 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Xup
     fbMotionStage_m14 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
@@ -129,7 +129,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:XDWN
     '}
-    M15 : DUT_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Xdwn
+    M15 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Xdwn
     fbMotionStage_m15 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
@@ -138,7 +138,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:PITCH
     '}
-    M16 : DUT_MotionStage := (fVelocity:=30.0, nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=True); // M1K1 Pitch Stepper
+    M16 : ST_MotionStage := (fVelocity:=30.0, nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=True); // M1K1 Pitch Stepper
 
     {attribute 'TcLinkTo' := '.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position'}
@@ -146,7 +146,7 @@
     pv: MR1K1:BEND:MMS:US
     '}
     // unlinking this .bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 1;
-    M17 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR1K1 US BEND
+    M17 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR1K1 US BEND
     fbMotionStage_m17 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
@@ -155,7 +155,7 @@
     {attribute 'pytmc' := '
     pv: MR1K1:BEND:MMS:DS
     '}
-    M18 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR1K1 DS BEND
+    M18 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR1K1 DS BEND
     fbMotionStage_m18 : FB_MotionStage;
 
     (*SL1K2*)
@@ -166,7 +166,7 @@
     {attribute 'pytmc' := '
         pv: SL1K2:EXIT:MMS:PITCH
     '}
-    M19 : DUT_MotionStage := (sName:= 'SL1K2:EXIT:MMS:PITCH',fVelocity :=0.12);// Air Pitch
+    M19 : ST_MotionStage := (sName:= 'SL1K2:EXIT:MMS:PITCH',fVelocity :=0.12);// Air Pitch
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
@@ -174,7 +174,7 @@
     {attribute 'pytmc' := '
         pv: SL1K2:EXIT:MMS:VERT
     '}
-    M20 : DUT_MotionStage := (sName:= 'SL1K2:EXIT:MMS:VERT',fVelocity :=0.3); // Air Vertical
+    M20 : ST_MotionStage := (sName:= 'SL1K2:EXIT:MMS:VERT',fVelocity :=0.3); // Air Vertical
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
                               .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
@@ -182,7 +182,7 @@
     {attribute 'pytmc' := '
         pv: SL1K2:EXIT:MMS:ROLL
     '}
-    M21 : DUT_MotionStage := (sName:= 'SL1K2:EXIT:MMS:ROLL',fVelocity :=0.24); // Air Roll
+    M21 : ST_MotionStage := (sName:= 'SL1K2:EXIT:MMS:ROLL',fVelocity :=0.24); // Air Roll
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
@@ -190,7 +190,7 @@
     {attribute 'pytmc' := '
         pv: SL1K2:EXIT:MMS:GAP
     '}
-    M22 : DUT_MotionStage := (sName:= 'SL1K2:EXIT:MMS:GAP',fVelocity :=0.1); // GAP
+    M22 : ST_MotionStage := (sName:= 'SL1K2:EXIT:MMS:GAP',fVelocity :=0.1); // GAP
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
@@ -198,7 +198,7 @@
     {attribute 'pytmc' := '
         pv: SL1K2:EXIT:MMS:YAG
     '}
-    M23 : DUT_MotionStage := (sName:= 'SL1K2:EXIT:MMS:YAG',fVelocity :=0.5); // YAG
+    M23 : ST_MotionStage := (sName:= 'SL1K2:EXIT:MMS:YAG',fVelocity :=0.5); // YAG
 
 
     // ST1K1-ZOS-MMS
@@ -207,26 +207,26 @@
                               .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
                               .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output'}
-    M24: DUT_MotionStage := (sName := 'ST1K1:ZOS:MMS');
+    M24: ST_MotionStage := (sName := 'ST1K1:ZOS:MMS');
 
     // MR2K2-FLAT axes
     {attribute 'pytmc' := 'pv: MR2K2:FLAT:MMS:X'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position'}
-    M25 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
+    M25 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
        fbMotionStageM25 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR2K2:FLAT:MMS:Y'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position'}
-    M26 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
+    M26 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
     fbMotionStageM26 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR2K2:FLAT:MMS:PITCH'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
                               .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
                               .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position'}
-    M27 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Pitch mot
+    M27 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Pitch mot
     fbMotionStageM27 : FB_MotionStage;
 
     // MR3K2-KBH axes
@@ -234,31 +234,31 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position'}
-    M28 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
+    M28 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
     fbMotionStageM28 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR3K2:KBH:MMS:Y'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position'}
-    M29 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
+    M29 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
     fbMotionStageM29 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR3K2:KBH:MMS:PITCH'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position'}
-    M30 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Pitch mot
+    M30 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Pitch mot
     fbMotionStageM30 : FB_MotionStage;
     {attribute 'pytmc' := '	pv: MR3K2:KBH:MMS:BEND:US'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position'}
-    M31 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR3K2 US BEND
+    M31 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR3K2 US BEND
     fbMotionStageM31 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR3K2:KBH:MMS:BEND:DS'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position'}
-    M32 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR3K2 DS BEND
+    M32 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR3K2 DS BEND
     fbMotionStageM32 : FB_MotionStage;
 
 
@@ -267,31 +267,31 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position'}
-    M33 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
+    M33 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
     fbMotionStageM33 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR4K2:KBV:MMS:Y'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position'}
-    M34 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
+    M34 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
     fbMotionStageM34 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR4K2:KBV:MMS:PITCH'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position'}
-    M35 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Pitch mot
+    M35 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Pitch mot
     fbMotionStageM35 : FB_MotionStage;
     {attribute 'pytmc' := '	pv: MR4K2:KBV:MMS:BEND:US'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position'}
-    M36 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR4K2 US BEND
+    M36 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR4K2 US BEND
     fbMotionStageM36 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR4K2:KBV:MMS:BEND:DS'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position'}
-    M37 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR4K2 DS BEND
+    M37 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, bPowerSelf:=TRUE); //MR4K2 DS BEND
     fbMotionStageM37 : FB_MotionStage;
 
 

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/DAQ Comm/FB_AssembleChannel.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/DAQ Comm/FB_AssembleChannel.TcPOU
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_AssembleChannel" Id="{5ef2e007-6efe-4b71-ad1b-59044bb806ba}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_AssembleChannel
 VAR_INPUT
-    // Raw count from the encoder, taken from DUT_MotionStage.nEncoderCount
+    // Raw count from the encoder, taken from ST_MotionStage.nEncoderCount
     nEncCount : UDINT;
     // Latched rising edge timestamp from EL1252-0050 terminal.
     nTiming : ULINT;
-    // Scale as reported in DUT_MotionStage.stAxisParameters.fEncScaleFactorNumerator
+    // Scale as reported in ST_MotionStage.stAxisParameters.fEncScaleFactorNumerator
     fScale : LREAL;
     // Serial number of the encoder
     sHardwareID : STRING(15);
@@ -17,7 +17,7 @@ VAR_INPUT
     nError : USINT;
     // Selector for acquisition mode (currently unused)
     nMode : USINT;
-    // Scale denominator as reported in DUT_MotionStage.stAxisParameters.fEncScaleFactorDenominator
+    // Scale denominator as reported in ST_MotionStage.stAxisParameters.fEncScaleFactorDenominator
     fScaleDenominator: LREAL;
 END_VAR
 VAR_OUTPUT

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR2K2_FLAT.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR2K2_FLAT.TcPOU
@@ -72,33 +72,14 @@ VAR
     M2K2FLATbSTOEnable1 AT %I* : BOOL;
     {attribute 'TcLinkTo' := 'TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR2K2^EL1004_M2K2_STO^Channel 2^Input'}
     M2K2FLATbSTOEnable2 AT %I* : BOOL;
-
-    // MR2K2 Flow Press Sensors
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value'}
-    fMR2K2_Flow_1 : FB_AnalogInput;
-    {attribute 'pytmc' := '
-        pv: MR2K2:FLAT:FWM:1
-        field: EGU lpm
-        io: i
+    {attribute 'TcLinkTo' := '.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
+                                 .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
     '}
-    fMR2K2_Flow_1_val : LREAL;
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value'}
-    fMR2K2_Flow_2 : FB_AnalogInput;
     {attribute 'pytmc' := '
-        pv: MR2K2:FLAT:FWM:2
-        field: EGU lpm
-        io: i
+        pv: MR2K2:FLAT
     '}
-    fMR2K2_Flow_2_val : LREAL;
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value'}
-    fMR2K2_Press_1 : FB_AnalogInput;
-    {attribute 'pytmc' := '
-        pv: MR2K2:FLAT:PRSM:1
-        field: EGU bar
-        io: i
-    '}
-    fMR2K2_Press_1_val : LREAL;
-
+    fbCoolingPanel : FB_Axilon_Cooling_2f1p;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[//FB_Motion stages for MR2K2 Axes
@@ -136,14 +117,8 @@ nEncCntXM2K2  := ULINT_TO_UDINT(M25.nRawEncoderULINT);
 nEncCntYM2K2  := ULINT_TO_UDINT(M26.nRawEncoderULINT);
 nEncCntrXM2K2  := ULINT_TO_UDINT(M27.nRawEncoderULINT);
 
-fMR2K2_Flow_1(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
-fMR2K2_Flow_1_val := fMR2K2_Flow_1.fReal;
-
-fMR2K2_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
-fMR2K2_Flow_2_val := fMR2K2_Flow_2.fReal;
-
-fMR2K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fMR2K2_Press_1_val := fMR2K2_Press_1.fReal;]]></ST>
+// Axilon Cooling Panel
+fbCoolingPanel();]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -164,25 +164,14 @@ VAR
         M3K2KBHbSTOEnable1 AT %I* : BOOL;
         {attribute 'TcLinkTo' := 'TIIB[EL1004_M3K2_STO]^Channel 2^Input'}
         M3K2KBHbSTOEnable2 AT %I* : BOOL;
-
+    {attribute 'TcLinkTo' := '.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    '}
+    {attribute 'pytmc' := '
+        pv: MR3K2:KBH
+    '}
     // MR3K2 Flow Sensors
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value'}
-    fMR3K2_Flow_1 : FB_AnalogInput;
-    {attribute 'pytmc' := '
-        pv: MR3K2:KBH:FWM:1
-        field: EGU lpm
-        io: i
-    '}
-    fMR3K2_Flow_1_val : LREAL;
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value'}
-    fMR3K2_Press_1 : FB_AnalogInput;
-    {attribute 'pytmc' := '
-        pv: MR3K2:KBH:PRSM:1
-        field: EGU bar
-        io: i
-    '}
-    fMR3K2_Press_1_val : LREAL;
-
+    fbCoolingPanel : FB_Axilon_Cooling_1f1p;
 (*
     // PMPS
         ffBenderRange : FB_FastFault := (
@@ -266,11 +255,8 @@ bM3K2DS_RTD_3_Err := fM3K2DS_RTD_3 = 0;
 M31.bHardwareEnable R= fM3K2US_RTD_1 > 9000 OR bM3K2US_RTD_1_Err;
 M32.bHardwareEnable R= fM3K2DS_RTD_1 > 9000 OR bM3K2DS_RTD_1_Err;
 
-fMR3K2_Flow_1(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
-fMR3K2_Flow_1_val := fMR3K2_Flow_1.fReal;
-
-fMR3K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fMR3K2_Press_1_val := fMR3K2_Press_1.fReal;
+// Axilon Cooling Panel
+fbCoolingPanel();
 (*
 //PMPS
 ffBenderRange.i_xOK :=

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
@@ -186,23 +186,13 @@ VAR
         M4K2KBVbSTOEnable2 AT %I* : BOOL;
 
     // MR4K2 Flow Sensors
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value'}
-    fMR4K2_Flow_1 : FB_AnalogInput;
-    {attribute 'pytmc' := '
-        pv: MR4K2:KBV:FWM:1
-        field: EGU lpm
-        io: i
+    {attribute 'TcLinkTo' := '.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
     '}
-    fMR4K2_Flow_1_val : LREAL;
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value'}
-    fMR4K2_Press_1 : FB_AnalogInput;
     {attribute 'pytmc' := '
-        pv: MR4K2:KBV:PRSM:1
-        field: EGU bar
-        io: i
+        pv: MR4K2:KBV
     '}
-    fMR4K2_Press_1_val : LREAL;
-
+    fbCoolingPanel : FB_Axilon_Cooling_1f1p;
 
 (*
     // PMPS
@@ -290,12 +280,8 @@ M37.bHardwareEnable R= fM4K2DS_RTD_1 > 9000 OR bM4K2DS_RTD_1_Err;
 nM4K2_Chin_Right_RTD();
 nM4K2_Chin_Left_RTD();
 
-fMR4K2_Flow_1(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
-fMR4K2_Flow_1_val := fMR4K2_Flow_1.fReal;
-
-fMR4K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fMR4K2_Press_1_val := fMR4K2_Press_1.fReal;
-
+// Axilon Cooling Panel
+fbCoolingPanel();
 (*
 //PMPS
 ffBenderRange.i_xOK :=

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -205,9 +205,9 @@
       <DefaultResolution>LCLS General, * (SLAC)</DefaultResolution>
       <Namespace>LCLS_General</Namespace>
     </PlaceholderReference>
-    <PlaceholderReference Include="lcls-twincat-optics-nrw">
-      <DefaultResolution>lcls-twincat-optics-nrw, * (SLAC)</DefaultResolution>
-      <Namespace>lcls_twincat_optics_nrw</Namespace>
+    <PlaceholderReference Include="lcls-twincat-optics">
+      <DefaultResolution>lcls-twincat-optics, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_optics</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="lcls2-cc-lib">
       <DefaultResolution>lcls2-cc-lib, * (SLAC)</DefaultResolution>
@@ -263,6 +263,9 @@
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 4.0.5 (SLAC)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="lcls-twincat-optics">
+      <Resolution>lcls-twincat-optics, 0.7.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls2-cc-lib">
       <Resolution>lcls2-cc-lib, 2.0.0 (SLAC)</Resolution>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -205,6 +205,10 @@
       <DefaultResolution>LCLS General, * (SLAC)</DefaultResolution>
       <Namespace>LCLS_General</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="lcls-twincat-optics-nrw">
+      <DefaultResolution>lcls-twincat-optics-nrw, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_optics_nrw</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="lcls2-cc-lib">
       <DefaultResolution>lcls2-cc-lib, * (SLAC)</DefaultResolution>
       <Namespace>lcls2_cc_lib</Namespace>
@@ -249,11 +253,8 @@
     </PlaceholderReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryReference Include="lcls-twincat-motion,2.0.1,SLAC">
+    <LibraryReference Include="lcls-twincat-motion,4.0.5,SLAC">
       <Namespace>lcls_twincat_motion</Namespace>
-    </LibraryReference>
-    <LibraryReference Include="lcls-twincat-optics,0.6.1,SLAC">
-      <Namespace>lcls_twincat_optics</Namespace>
     </LibraryReference>
   </ItemGroup>
   <ItemGroup>
@@ -261,7 +262,7 @@
       <Resolution>LCLS General, 2.10.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 2.0.1 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, 4.0.5 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls2-cc-lib">
       <Resolution>lcls2-cc-lib, 2.0.0 (SLAC)</Resolution>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D63D7E12-56AF-1AB1-BC80-3163170A85A6}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{59E3669E-D1DA-ED54-7F83-ABBB45EA4F77}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -60027,6 +60027,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Name>pytmc</Name>
             <Value>
         pv: FWM:1
+        autosave_pass0: HIGH HIHI LOW LOLO
         field: EGU lpm
         field: HIGH 2.3
         field: HIHI 3.0
@@ -60050,6 +60051,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Property>
             <Name>pytmc</Name>
             <Value>
+        autosave_pass0: LOW
         pv: PRSM:1
         field: EGU bar
         field: LOW 0.1
@@ -60095,6 +60097,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Name>pytmc</Name>
             <Value>
         pv: FWM:2
+        autosave_pass0: HIGH HIHI LOW LOLO
         field: EGU lpm
         field: HIGH 2.3
         field: HIHI 3.0
@@ -91485,9 +91488,9 @@ MR3K2 X ENC REF</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
-   							  .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
-		                      .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
-	</Value>
+                                 .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -91910,8 +91913,8 @@ MR4K2 X ENC REF</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
-		                      .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
-	</Value>
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -92355,15 +92358,15 @@ M4K2 KBV X ENC CNT</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
-            <Comment> MR4K2 Flow Sensors	</Comment>
+            <Comment> MR4K2 Flow Sensors</Comment>
             <BitSize>1216</BitSize>
             <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
-		                      .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
-	</Value>
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -95380,7 +95383,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-05T16:47:57</Value>
+          <Value>2024-02-05T17:55:20</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{AF746F3C-18E1-BB13-C597-9DE0DD4AE3BE}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D63D7E12-56AF-1AB1-BC80-3163170A85A6}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -3635,7 +3635,85 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Name>
+      <Name Namespace="LCLS_General">DUT_EPS</Name>
+      <BitSize>1344</BitSize>
+      <SubItem>
+        <Name>nFlags</Name>
+        <Type>UDINT</Type>
+        <Comment> Contains EPS flags</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>4294967295</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: nFlags
+        io: i
+        field: DESC Contains EPS flags
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sFlagDesc</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Desciption of values nFlags contains</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: sFlagDesc
+        io: i
+        field: DESC semicolon-delimited nFlag variable
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Name to use for log messages.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>680</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: sMessage
+        io: i
+        field: DESC Message from EPS to usr
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEPS_OK</Name>
+        <Type>BOOL</Type>
+        <Comment> Keep Track if nFlags are all true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1328</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: bEPS_OK
+        io: i
+        field: DESC check if nFlags are all true
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">E_StageEnableMode</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -3663,7 +3741,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Name>
+      <Name Namespace="lcls_twincat_motion">E_StageBrakeMode</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -3691,7 +3769,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Name>
+      <Name Namespace="lcls_twincat_motion">E_EpicsHomeCmd</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -4443,8 +4521,8 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
-      <BitSize>21184</BitSize>
+      <Name Namespace="lcls_twincat_motion">ST_MotionStage</Name>
+      <BitSize>25216</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2">AXIS_REF</Type>
@@ -4461,16 +4539,6 @@ External Setpoint Generation:
         <BitOffs>9024</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-          </Property>
-          <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
           </Property>
@@ -4483,16 +4551,6 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9032</BitOffs>
         <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-          </Property>
           <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
@@ -4507,16 +4565,6 @@ External Setpoint Generation:
         <BitOffs>9040</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-          </Property>
-          <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
           </Property>
@@ -4529,16 +4577,6 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9048</BitOffs>
         <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-          </Property>
           <Property>
             <Name>TcAddressType</Name>
             <Value>Output</Value>
@@ -4617,18 +4655,6 @@ External Setpoint Generation:
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move forward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bAllBackwardEnable</Name>
@@ -4639,18 +4665,6 @@ External Setpoint Generation:
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move backward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bAllEnable</Name>
@@ -4661,18 +4675,6 @@ External Setpoint Generation:
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to have power
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryForwardEnable</Name>
@@ -4683,18 +4685,6 @@ External Setpoint Generation:
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move forward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryBackwardEnable</Name>
@@ -4705,18 +4695,6 @@ External Setpoint Generation:
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move backward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nEncoderCount</Name>
@@ -4736,133 +4714,120 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Settings 
- Name to use for log messages, fast faults, etc.</Comment>
-        <BitSize>648</BitSize>
+        <Name>stEPSForwardEnable</Name>
+        <Type Namespace="LCLS_General">DUT_EPS</Type>
+        <Comment> Forward Enable EPS struct</Comment>
+        <BitSize>1344</BitSize>
         <BitOffs>9280</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: PLC:sName
+        pv: PLC:stEPSF
         io: i
-        field: DESC PLC program name
+        field: DESC Forward Enable Interlocks
     </Value>
           </Property>
         </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEPSBackwardEnable</Name>
+        <Type Namespace="LCLS_General">DUT_EPS</Type>
+        <Comment> Backward Enable EPS struct</Comment>
+        <BitSize>1344</BitSize>
+        <BitOffs>10624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:stEPSB
+        io: i
+        field: DESC Backward Enable Interlocks
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEPSPowerEnable</Name>
+        <Type Namespace="LCLS_General">DUT_EPS</Type>
+        <Comment> Power Enable EPS struct</Comment>
+        <BitSize>1344</BitSize>
+        <BitOffs>11968</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PLC:stEPSP
+        io: i
+        field: DESC Power Interlocks
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Settings 
+ Name to use for log messages, fast faults, etc.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>13312</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPowerSelf</Name>
         <Type>BOOL</Type>
         <Comment> If TRUE, we want to enable the motor independently of PMPS or other safety systems.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9928</BitOffs>
+        <BitOffs>13960</BitOffs>
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bPowerSelf
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if axis is in PMPS
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nEnableMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Type>
+        <Type Namespace="lcls_twincat_motion">E_StageEnableMode</Type>
         <Comment> Determines when we automatically enable the motor</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9936</BitOffs>
+        <BitOffs>13968</BitOffs>
         <Default>
-          <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+          <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nEnableMode
-        io: i
-        field: DESC Describes when the axis will automatically get power
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nBrakeMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Type>
+        <Type Namespace="lcls_twincat_motion">E_StageBrakeMode</Type>
         <Comment> Determines when we automatically disengage the brake</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9952</BitOffs>
+        <BitOffs>13984</BitOffs>
         <Default>
-          <EnumText>ENUM_StageBrakeMode.IF_ENABLED</EnumText>
+          <EnumText>E_StageBrakeMode.IF_ENABLED</EnumText>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nBrakeMode
-        io: i
-        field: DESC Describes when the brake will be released
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nHomingMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Type>
+        <Type Namespace="lcls_twincat_motion">E_EpicsHomeCmd</Type>
         <Comment> Determines our encoder homing strategy</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>9968</BitOffs>
+        <BitOffs>14000</BitOffs>
         <Default>
-          <EnumText>ENUM_EpicsHomeCmd.NONE</EnumText>
+          <EnumText>E_EpicsHomeCmd.NONE</EnumText>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nHomingMode
-        io: i
-        field: DESC Describes our homing strategy
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryAxis</Name>
         <Type>BOOL</Type>
         <Comment> Set true to activate gantry EPS</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>9984</BitOffs>
+        <BitOffs>14016</BitOffs>
         <Default>
           <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryAxis
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry EPS active
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nGantryTol</Name>
         <Type>LINT</Type>
         <Comment> Set to gantry difference tolerance</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10048</BitOffs>
+        <BitOffs>14080</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4872,7 +4837,7 @@ External Setpoint Generation:
         <Type>ULINT</Type>
         <Comment> Encoder count at which this axis is aligned with other axis</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10112</BitOffs>
+        <BitOffs>14144</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -4883,26 +4848,14 @@ External Setpoint Generation:
         <Comment> Commands 
  Used internally to request enables</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnable
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally to request enables
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14208</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bReset</Name>
         <Type>BOOL</Type>
         <Comment> Used internally to reset errors and other state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10184</BitOffs>
+        <BitOffs>14216</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -4921,26 +4874,14 @@ External Setpoint Generation:
         <Type>BOOL</Type>
         <Comment> Used internally and by the IOC to start or stop a move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bExecute
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally and by the IOC to start or stop
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14224</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bUserEnable</Name>
         <Type>BOOL</Type>
         <Comment> Used by the IOC to disable an axis</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10200</BitOffs>
+        <BitOffs>14232</BitOffs>
         <Default>
           <Bool>1</Bool>
         </Default>
@@ -4963,24 +4904,14 @@ External Setpoint Generation:
         <Comment> Shortcut Commands 
  Start a move to fPosition with fVelocity</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bMoveCmd
-        io: io
-        field: DESC Start a move
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14240</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bHomeCmd</Name>
         <Type>BOOL</Type>
         <Comment> Start the homing routine</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10216</BitOffs>
+        <BitOffs>14248</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -4998,109 +4929,49 @@ External Setpoint Generation:
         <Comment> Command Args 
  Used internally and by the IOC to pick what kind of move to do</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>10224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCommand
-        io: io
-        field: DESC Used internally and by the IOC to pick move type
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nCmdData</Name>
         <Type>INT</Type>
         <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>10240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCmdData
-        io: io
-        field: DESC Used internally and by the IOC to pass extra args
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14272</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fPosition</Name>
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fPosition
-        io: io
-        field: DESC Used internally and by the IOC as the set position
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14336</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fVelocity</Name>
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move velocity</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10368</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fVelocity
-        io: io
-        field: DESC Used internally and by the IOC to set velocity
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14400</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fAcceleration</Name>
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fAcceleration
-        io: io
-        field: DESC Used internally and by the IOC to set acceleration
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14464</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fDeceleration</Name>
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fDeceleration
-        io: io
-        field: DESC Used internally and by the IOC to set deceleration
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14528</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fHomePosition</Name>
         <Type>LREAL</Type>
         <Comment> Used internally and by the IOC to pick a home position</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>10560</BitOffs>
+        <BitOffs>14592</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5118,20 +4989,10 @@ External Setpoint Generation:
         <Comment> Info 
  Unique ID assigned to each axis in the NC</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>10624</BitOffs>
+        <BitOffs>14656</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nMotionAxisID
-        io: i
-        field: DESC Unique ID assigned to each axis in the NC
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bEnableDone</Name>
@@ -5139,100 +5000,42 @@ External Setpoint Generation:
         <Comment> Returns 
  TRUE if done enabling</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10656</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnableDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if done enabling
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14688</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <Comment> TRUE if in the middle of a command</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10664</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBusy
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if in the middle of a command
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14696</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bDone</Name>
         <Type>BOOL</Type>
         <Comment> TRUE if we've done a command and it has finished</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10672</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if command finished successfully
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14704</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bHomed</Name>
         <Type>BOOL</Type>
         <Comment> TRUE if the motor has been homed, or does not need to be homed</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10680</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHomed
-        io: i
-        field: DESC TRUE if the motor has been homed
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14712</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bSafetyReady</Name>
         <Type>BOOL</Type>
         <Comment> TRUE if we have safety permission to move</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10688</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bSafetyReady
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if safe to start a move
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>14720</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <Comment> TRUE if we're in an error state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>10696</BitOffs>
+        <BitOffs>14728</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5252,7 +5055,7 @@ External Setpoint Generation:
         <Type>UDINT</Type>
         <Comment> Error code if nonzero</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>10720</BitOffs>
+        <BitOffs>14752</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5270,7 +5073,7 @@ External Setpoint Generation:
         <Type>STRING(80)</Type>
         <Comment> Message to identify the error state</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>10752</BitOffs>
+        <BitOffs>14784</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5288,28 +5091,28 @@ External Setpoint Generation:
         <Type>STRING(80)</Type>
         <Comment> Internal hook for custom error messages</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>11400</BitOffs>
+        <BitOffs>15432</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisParameters</Name>
         <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
         <Comment> MC_ReadParameterSet Output</Comment>
         <BitSize>8192</BitSize>
-        <BitOffs>12096</BitOffs>
+        <BitOffs>16128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bAxisParamsInit</Name>
         <Type>BOOL</Type>
         <Comment> True if we've updated stAxisParameters at least once</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>20288</BitOffs>
+        <BitOffs>24320</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisStatus</Name>
         <Type Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Type>
         <Comment> Misc axis status information for the IOC</Comment>
         <BitSize>768</BitSize>
-        <BitOffs>20352</BitOffs>
+        <BitOffs>24384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fPosDiff</Name>
@@ -5317,7 +5120,7 @@ External Setpoint Generation:
         <Comment> Other status information for users of the IOC 
  Position lag difference</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>21120</BitOffs>
+        <BitOffs>25152</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -5337,7 +5140,7 @@ External Setpoint Generation:
       <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
       <BitSize>384</BitSize>
       <SubItem>
         <Name>tCtrlCycleTime</Name>
@@ -5411,7 +5214,7 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">ST_PiezoAxis</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Name>
       <BitSize>2240</BitSize>
       <SubItem>
         <Name>sIdn</Name>
@@ -5458,7 +5261,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>sAxis</Name>
         <Type>STRING(80)</Type>
-        <Comment>Axis, e.g. A, B, C...A if single unit	</Comment>
+        <Comment>Axis, e.g. A, B, C...A if single unit</Comment>
         <BitSize>648</BitSize>
         <BitOffs>800</BitOffs>
         <Default>
@@ -5540,7 +5343,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>stPIParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
         <BitSize>384</BitSize>
         <BitOffs>1792</BitOffs>
         <Default>
@@ -6994,7 +6797,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Name>
       <BitSize>35200</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -7288,7 +7091,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</Name>
       <BitSize>112640</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -7391,7 +7194,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>iq_stPiezoAxis</Name>
-        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">ST_PiezoAxis</Type>
         <BitSize>64</BitSize>
         <BitOffs>67008</BitOffs>
         <Properties>
@@ -7451,7 +7254,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbPITransaction</Name>
-        <Type Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Type>
         <BitSize>35200</BitSize>
         <BitOffs>68160</BitOffs>
       </SubItem>
@@ -7496,11 +7299,11 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">HOMS_PitchMechanism</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</Name>
       <BitSize>2496</BitSize>
       <SubItem>
         <Name>Piezo</Name>
-        <Type Namespace="lcls_twincat_optics">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Type>
         <Comment>Piezo</Comment>
         <BitSize>2240</BitSize>
         <BitOffs>0</BitOffs>
@@ -7524,8 +7327,8 @@ External Setpoint Generation:
         <Comment> Hard limits, egu INC 
  These are discovered during installation, and represent encoder ticks, unbiased 
  We changed to these when our pitch mechanism limit switches were insufficient for
-	good control. They had too much hysteresis/ lack of precision. At this point the limit
-	switches are ignored, and instead their function is carried out by these. </Comment>
+    good control. They had too much hysteresis/ lack of precision. At this point the limit
+    switches are ignored, and instead their function is carried out by these. </Comment>
         <BitSize>64</BitSize>
         <BitOffs>2304</BitOffs>
       </SubItem>
@@ -10027,7 +9830,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>nEncCount</Name>
         <Type>UDINT</Type>
-        <Comment> Raw count from the encoder, taken from DUT_MotionStage.nEncoderCount</Comment>
+        <Comment> Raw count from the encoder, taken from ST_MotionStage.nEncoderCount</Comment>
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -10053,7 +9856,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fScale</Name>
         <Type>LREAL</Type>
-        <Comment> Scale as reported in DUT_MotionStage.stAxisParameters.fEncScaleFactorNumerator</Comment>
+        <Comment> Scale as reported in ST_MotionStage.stAxisParameters.fEncScaleFactorNumerator</Comment>
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
         <Properties>
@@ -10118,7 +9921,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fScaleDenominator</Name>
         <Type>LREAL</Type>
-        <Comment> Scale denominator as reported in DUT_MotionStage.stAxisParameters.fEncScaleFactorDenominator</Comment>
+        <Comment> Scale denominator as reported in ST_MotionStage.stAxisParameters.fEncScaleFactorDenominator</Comment>
         <BitSize>64</BitSize>
         <BitOffs>448</BitOffs>
         <Properties>
@@ -10391,31 +10194,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162885272</GetCodeOffs>
+        <GetCodeOffs>163192152</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162885344</GetCodeOffs>
+        <GetCodeOffs>163192224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162885360</GetCodeOffs>
+        <GetCodeOffs>163192240</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162885320</GetCodeOffs>
+        <GetCodeOffs>163192200</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162885352</GetCodeOffs>
+        <GetCodeOffs>163192232</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11667,15 +11470,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162885144</GetCodeOffs>
-        <SetCodeOffs>162885192</SetCodeOffs>
+        <GetCodeOffs>163192024</GetCodeOffs>
+        <SetCodeOffs>163192072</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162885224</GetCodeOffs>
-        <SetCodeOffs>162885248</SetCodeOffs>
+        <GetCodeOffs>163192104</GetCodeOffs>
+        <SetCodeOffs>163192128</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11916,31 +11719,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>162885456</GetCodeOffs>
+        <GetCodeOffs>163192336</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>162885416</GetCodeOffs>
+        <GetCodeOffs>163192296</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162885592</GetCodeOffs>
+        <GetCodeOffs>163192472</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162885600</GetCodeOffs>
+        <GetCodeOffs>163192480</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162885512</GetCodeOffs>
+        <GetCodeOffs>163192392</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11952,7 +11755,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162885608</GetCodeOffs>
+        <GetCodeOffs>163192488</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12545,7 +12348,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>162885664</GetCodeOffs>
+        <GetCodeOffs>163192544</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -27333,6 +27136,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <SubItem>
         <Name>io_fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -27424,10 +27228,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bExecute</Name>
+        <Name>bReadPmpsDb</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>1472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtEnable</Name>
@@ -36764,7 +36580,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Name>
       <BitSize>128</BitSize>
       <SubItem>
         <Name>bInterpretCycleTimeAsTicks</Name>
@@ -36944,7 +36760,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>162897288</GetCodeOffs>
+        <GetCodeOffs>163204176</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -38872,31 +38688,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162896688</GetCodeOffs>
+        <GetCodeOffs>163203576</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>162896776</GetCodeOffs>
+        <GetCodeOffs>163203664</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162896704</GetCodeOffs>
+        <GetCodeOffs>163203592</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>162896752</GetCodeOffs>
+        <GetCodeOffs>163203640</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>162896792</GetCodeOffs>
+        <GetCodeOffs>163203680</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -41031,7 +40847,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">EL5042_Status</Name>
+      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
       <BitSize>0</BitSize>
     </DataType>
     <DataType>
@@ -41053,7 +40869,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>Status</Name>
-        <Type Namespace="lcls_twincat_motion">EL5042_Status</Type>
+        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
         <Comment> Status struct placeholder</Comment>
         <BitSize>0</BitSize>
         <BitOffs>64</BitOffs>
@@ -42193,7 +42009,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <BitSize>128</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -42239,7 +42055,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>Master</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
         <Properties>
@@ -42263,7 +42079,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>Slave</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>320</BitOffs>
         <Properties>
@@ -42347,7 +42163,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_RunHOMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Name>
       <BitSize>23296</BitSize>
       <SubItem>
         <Name>nYupEncRef</Name>
@@ -42482,7 +42298,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>stYup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <Comment> Motor Structs</Comment>
         <BitSize>64</BitSize>
         <BitOffs>640</BitOffs>
@@ -42495,7 +42311,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>stYdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>704</BitOffs>
         <Properties>
@@ -42507,7 +42323,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>stXup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>768</BitOffs>
         <Properties>
@@ -42519,7 +42335,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>stXdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>832</BitOffs>
         <Properties>
@@ -42531,7 +42347,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>stPitch</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>896</BitOffs>
         <Properties>
@@ -42685,11 +42501,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">DUT_HOMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">DUT_HOMS</Name>
       <BitSize>23552</BitSize>
       <SubItem>
         <Name>fbRunHOMS</Name>
-        <Type Namespace="lcls_twincat_optics">FB_RunHOMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Type>
         <Comment> System initializiation</Comment>
         <BitSize>23296</BitSize>
         <BitOffs>0</BitOffs>
@@ -42704,9 +42520,9 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: COUPLE_Y
-		io: o
-	</Value>
+        pv: COUPLE_Y
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42719,9 +42535,9 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: DECOUPLE_Y
-		io: o
-	</Value>
+        pv: DECOUPLE_Y
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42734,9 +42550,9 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: COUPLE_X
-		io: o
-	</Value>
+        pv: COUPLE_X
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42749,9 +42565,9 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: DECOUPLE_X
-		io: o
-	</Value>
+        pv: DECOUPLE_X
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42765,10 +42581,10 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: ALREADY_COUPLED_Y
-		io: i
+        pv: ALREADY_COUPLED_Y
+        io: i
         field: ZSV MAJOR
-	</Value>
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42781,10 +42597,10 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: ALREADY_COUPLED_X
-		io: i
+        pv: ALREADY_COUPLED_X
+        io: i
         field: ZSV MAJOR
-	</Value>
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42812,10 +42628,10 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: GANTRY_Y
-		field: EGU um
-		io: i
-	</Value>
+        pv: GANTRY_Y
+        field: EGU um
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42829,10 +42645,10 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: GANTRY_X
-		field: EGU um
-		io: i
-	</Value>
+        pv: GANTRY_X
+        field: EGU um
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -42918,7 +42734,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</Name>
       <BitSize>387520</BitSize>
       <SubItem>
         <Name>fMaxRMSError</Name>
@@ -42954,7 +42770,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </SubItem>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
         <Properties>
@@ -43046,8 +42862,8 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: MEAN
-		io: i
+        pv: MEAN
+        io: i
     </Value>
           </Property>
         </Properties>
@@ -43061,8 +42877,8 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: STDEV
-		io: i
+        pv: STDEV
+        io: i
     </Value>
           </Property>
         </Properties>
@@ -43079,8 +42895,8 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: RMS
-		io: i
+        pv: RMS
+        io: i
     </Value>
           </Property>
         </Properties>
@@ -43123,8 +42939,8 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: ACTPOSARRAY
-		io: i
+        pv: ACTPOSARRAY
+        io: i
     </Value>
           </Property>
         </Properties>
@@ -43142,9 +42958,9 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: SETPOSARRAY
-		io: i
-	</Value>
+        pv: SETPOSARRAY
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -43312,7 +43128,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_MotionRequest</Name>
+      <Name Namespace="lcls_twincat_motion">E_MotionRequest</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -43341,7 +43157,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>1920</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <Comment> Motor to move</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
@@ -43380,12 +43196,12 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
         <Comment> Define behavior for when the motor is already moving</Comment>
         <BitSize>16</BitSize>
         <BitOffs>144</BitOffs>
         <Default>
-          <EnumText>ENUM_MotionRequest.WAIT</EnumText>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -50194,7 +50010,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>51584</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -50449,7 +50265,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>3264</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -50580,7 +50396,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>87488</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -50644,7 +50460,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>128</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -50801,7 +50617,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>2560</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -50886,7 +50702,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>327424</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -51048,7 +50864,18 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">E_PiezoControl</Name>
+      <Name Namespace="lcls_twincat_motion">ENUM_MotionRequest</Name>
+      <BitSize>16</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">E_MotionRequest</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use E_MotionRequest</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics_nrw">E_PiezoControl</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -51082,7 +50909,7 @@ Use this thing to have a simple indexer with rollover.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -51132,7 +50959,7 @@ Use this thing to have a simple indexer with rollover.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -51192,7 +51019,7 @@ Use this thing to have a simple indexer with rollover.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -51951,7 +51778,7 @@ Use this thing to have a simple indexer with rollover.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_PI</Name>
       <BitSize>2240</BitSize>
       <SubItem>
         <Name>fSetpointValue</Name>
@@ -52007,7 +51834,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
         <Comment> operating mode </Comment>
         <BitSize>16</BitSize>
         <BitOffs>272</BitOffs>
@@ -52059,7 +51886,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
         <Comment> current state of the function block </Comment>
         <BitSize>16</BitSize>
         <BitOffs>400</BitOffs>
@@ -52072,7 +51899,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
         <Comment> error code </Comment>
         <BitSize>16</BitSize>
         <BitOffs>416</BitOffs>
@@ -52098,7 +51925,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_PI_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_PI_PARAMS</Type>
         <Comment> parameter structure </Comment>
         <BitSize>64</BitSize>
         <BitOffs>448</BitOffs>
@@ -52111,13 +51938,13 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stInternalParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
         <BitSize>384</BitSize>
         <BitOffs>512</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stInternalCycleTimeInterpretation</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
         <BitSize>128</BitSize>
         <BitOffs>896</BitOffs>
       </SubItem>
@@ -52255,7 +52082,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
         <BitSize>16</BitSize>
         <BitOffs>2048</BitOffs>
       </SubItem>
@@ -52312,7 +52139,7 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</Name>
       <BitSize>192</BitSize>
       <SubItem>
         <Name>tTaskCycleTime</Name>
@@ -52344,12 +52171,12 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Name>
       <BitSize>192</BitSize>
-      <BaseType Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</BaseType>
+      <BaseType Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Name>
       <BitSize>1280</BitSize>
       <SubItem>
         <Name>fStartValue</Name>
@@ -52405,7 +52232,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
         <Comment> operating mode </Comment>
         <BitSize>16</BitSize>
         <BitOffs>272</BitOffs>
@@ -52457,7 +52284,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
         <Comment> current state of the function block </Comment>
         <BitSize>16</BitSize>
         <BitOffs>464</BitOffs>
@@ -52470,7 +52297,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
         <Comment> error code </Comment>
         <BitSize>16</BitSize>
         <BitOffs>480</BitOffs>
@@ -52496,7 +52323,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
         <Comment> parameter structure </Comment>
         <BitSize>64</BitSize>
         <BitOffs>512</BitOffs>
@@ -52536,13 +52363,13 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stInternalParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
         <BitSize>192</BitSize>
         <BitOffs>832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stInternalCycleTimeInterpretation</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
         <BitSize>128</BitSize>
         <BitOffs>1024</BitOffs>
       </SubItem>
@@ -52560,7 +52387,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
         <BitSize>16</BitSize>
         <BitOffs>1216</BitOffs>
       </SubItem>
@@ -52602,11 +52429,11 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Name>
       <BitSize>768</BitSize>
       <SubItem>
         <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
         <Comment> operating mode </Comment>
         <BitSize>16</BitSize>
         <BitOffs>64</BitOffs>
@@ -52645,7 +52472,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
         <Comment> current state of the function block </Comment>
         <BitSize>16</BitSize>
         <BitOffs>144</BitOffs>
@@ -52658,7 +52485,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
         <Comment> error code </Comment>
         <BitSize>16</BitSize>
         <BitOffs>160</BitOffs>
@@ -52741,7 +52568,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
         <BitSize>16</BitSize>
         <BitOffs>704</BitOffs>
       </SubItem>
@@ -52768,11 +52595,11 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PiezoControl</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_PiezoControl</Name>
       <BitSize>6720</BitSize>
       <SubItem>
         <Name>iq_Piezo</Name>
-        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">ST_PiezoAxis</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -52887,7 +52714,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>E_State</Name>
-        <Type Namespace="lcls_twincat_optics">E_PiezoControl</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">E_PiezoControl</Type>
         <Comment>ENUM for Piezo Control State</Comment>
         <BitSize>16</BitSize>
         <BitOffs>192</BitOffs>
@@ -52940,13 +52767,13 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>fbPI</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_PI</Type>
         <BitSize>2240</BitSize>
         <BitOffs>640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbRamp</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Type>
         <BitSize>1280</BitSize>
         <BitOffs>2880</BitOffs>
       </SubItem>
@@ -52959,7 +52786,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>fbGetCycleTime</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Type>
         <Comment>Get cycle time for control FBs</Comment>
         <BitSize>768</BitSize>
         <BitOffs>4224</BitOffs>
@@ -53104,7 +52931,7 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">E_PitchControl</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">E_PitchControl</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -53168,11 +52995,11 @@ Use this thing to have a simple indexer with rollover.
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PitchControl</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_PitchControl</Name>
       <BitSize>397888</BitSize>
       <SubItem>
         <Name>Pitch</Name>
-        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">HOMS_PitchMechanism</Type>
+        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">HOMS_PitchMechanism</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -53184,7 +53011,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>Stepper</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -53197,7 +53024,7 @@ Use this thing to have a simple indexer with rollover.
       <SubItem>
         <Name>lrCurrentSetpoint</Name>
         <Type>LREAL</Type>
-        <Comment> Setpoint: Epics writes to DUT_MotionStage which gets fed into this</Comment>
+        <Comment> Setpoint: Epics writes to ST_MotionStage which gets fed into this</Comment>
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
         <Properties>
@@ -53365,7 +53192,7 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>16</BitSize>
         <BitOffs>390704</BitOffs>
         <Default>
-          <EnumText>ENUM_MotionRequest.WAIT</EnumText>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -53383,7 +53210,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>fbPiezoControl</Name>
-        <Type Namespace="lcls_twincat_optics">FB_PiezoControl</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">FB_PiezoControl</Type>
         <BitSize>6720</BitSize>
         <BitOffs>390976</BitOffs>
       </SubItem>
@@ -53395,7 +53222,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>PC_State</Name>
-        <Type Namespace="lcls_twincat_optics">E_PitchControl</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">E_PitchControl</Type>
         <Comment> State Machine</Comment>
         <BitSize>16</BitSize>
         <BitOffs>397824</BitOffs>
@@ -54937,7 +54764,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_PositionState</Name>
+      <Name Namespace="lcls_twincat_motion">ST_PositionState</Name>
       <BitSize>3648</BitSize>
       <SubItem>
         <Name>sName</Name>
@@ -54998,17 +54825,6 @@ Use this thing to have a simple indexer with rollover.
         <Comment> Maximum allowable deviation from fPosition while at the state</Comment>
         <BitSize>64</BitSize>
         <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DELTA
-        io: io
-        field: DRVL 0.0
-        field: DESC Max deviation from position at this state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fVelocity</Name>
@@ -55033,16 +54849,6 @@ Use this thing to have a simple indexer with rollover.
         <Comment> (optional) Acceleration to use for moves to this state</Comment>
         <BitSize>64</BitSize>
         <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ACCL
-        io: io
-        field: DESC Acceleration to use for moves to this state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fDecel</Name>
@@ -55050,16 +54856,6 @@ Use this thing to have a simple indexer with rollover.
         <Comment> (optional) Deceleration to use for moves to this state</Comment>
         <BitSize>64</BitSize>
         <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DCCL
-        io: io
-        field: DESC Deceleration to use for moves to this state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bMoveOk</Name>
@@ -55086,18 +54882,6 @@ Use this thing to have a simple indexer with rollover.
         <Comment> Signifies to FB_PositionStateLock that this state should be immutable</Comment>
         <BitSize>8</BitSize>
         <BitOffs>1096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: LOCKED
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if state is immutable
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bValid</Name>
@@ -55105,18 +54889,6 @@ Use this thing to have a simple indexer with rollover.
         <Comment> Set this to TRUE when you make your state. This defaults to FALSE so that uninitialized states can never be moved to</Comment>
         <BitSize>8</BitSize>
         <BitOffs>1104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: VALID
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if this is a real state
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bUseRawCounts</Name>
@@ -55138,22 +54910,14 @@ Use this thing to have a simple indexer with rollover.
         <Comment> We give this a state name and it is used to load parameters from the pmps database.</Comment>
         <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
-      <BitSize>2944</BitSize>
+      <BitSize>3200</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <Comment> Motor to move</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
@@ -55166,7 +54930,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
         <Comment> State to move to</Comment>
         <BitSize>64</BitSize>
         <BitOffs>128</BitOffs>
@@ -55229,12 +54993,12 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
         <Comment> Define behavior for when a move is already active</Comment>
         <BitSize>16</BitSize>
         <BitOffs>208</BitOffs>
         <Default>
-          <EnumText>ENUM_MotionRequest.WAIT</EnumText>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -55352,7 +55116,7 @@ Use this thing to have a simple indexer with rollover.
       <SubItem>
         <Name>bDone</Name>
         <Type>BOOL</Type>
-        <Comment> TRUE if we are note moving and we reached a state successfully on our last move</Comment>
+        <Comment> TRUE if we are not moving and we reached a state successfully on our last move</Comment>
         <BitSize>8</BitSize>
         <BitOffs>944</BitOffs>
         <Properties>
@@ -55378,10 +55142,34 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>960</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>3008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerExec</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3136</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>bAllowMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>2880</BitOffs>
+        <BitOffs>3144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLatchAllowErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3168</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -55509,7 +55297,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>3904</BitSize>
       <SubItem>
         <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -55533,7 +55321,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stCachedPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
@@ -55558,7 +55346,7 @@ Use this thing to have a simple indexer with rollover.
       <BitSize>12672</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -55570,7 +55358,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
         <BitSize>64</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -55601,10 +55389,10 @@ Use this thing to have a simple indexer with rollover.
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
-      <BitSize>256256</BitSize>
+      <BitSize>256512</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <Comment> Motor to move</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
@@ -55758,7 +55546,7 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <ArrayInfo>
           <LBound>1</LBound>
           <Elements>15</Elements>
@@ -55806,20 +55594,20 @@ Use this thing to have a simple indexer with rollover.
       </SubItem>
       <SubItem>
         <Name>stUnknown</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
         <BitOffs>55680</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stGoal</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
         <BitOffs>59328</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbStateMove</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
-        <BitSize>2944</BitSize>
+        <BitSize>3200</BitSize>
         <BitOffs>62976</BitOffs>
       </SubItem>
       <SubItem>
@@ -55830,43 +55618,43 @@ Use this thing to have a simple indexer with rollover.
           <Elements>15</Elements>
         </ArrayInfo>
         <BitSize>190080</BitSize>
-        <BitOffs>65920</BitOffs>
+        <BitOffs>66176</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nIndex</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>256000</BitOffs>
+        <BitOffs>256256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNewGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>256016</BitOffs>
+        <BitOffs>256272</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bInnerExec</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>256024</BitOffs>
+        <BitOffs>256280</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bInnerReset</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>256032</BitOffs>
+        <BitOffs>256288</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtReset</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>128</BitSize>
-        <BitOffs>256064</BitOffs>
+        <BitOffs>256320</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bMoveRequested</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>256192</BitOffs>
+        <BitOffs>256448</BitOffs>
       </SubItem>
       <Action>
         <Name>Exec</Name>
@@ -55878,6 +55666,10 @@ Use this thing to have a simple indexer with rollover.
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionState1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -57207,7 +56999,7 @@ ELSE:
       <BitSize>20096</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -57219,7 +57011,7 @@ ELSE:
       </SubItem>
       <SubItem>
         <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <ArrayInfo ReferenceTo="true">
           <LBound>1</LBound>
           <Elements>15</Elements>
@@ -57419,7 +57211,7 @@ ELSE:
       </SubItem>
       <SubItem>
         <Name>stTransitionState</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
         <BitOffs>4672</BitOffs>
       </SubItem>
@@ -57482,7 +57274,7 @@ ELSE:
       </SubItem>
       <SubItem>
         <Name>stStateReq</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
         <BitOffs>9344</BitOffs>
       </SubItem>
@@ -57512,7 +57304,7 @@ ELSE:
       </SubItem>
       <SubItem>
         <Name>stGoalState</Name>
-        <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
         <BitOffs>14144</BitOffs>
       </SubItem>
@@ -57599,7 +57391,7 @@ ELSE:
         </Parameter>
         <Local>
           <Name>stState</Name>
-          <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
+          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
           <BitSize>3648</BitSize>
         </Local>
       </Method>
@@ -57615,7 +57407,7 @@ ELSE:
       </Method>
       <Method>
         <Name>GetStateStruct</Name>
-        <ReturnType Namespace="lcls_twincat_motion">DUT_PositionState</ReturnType>
+        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
         <ReturnBitSize>3648</ReturnBitSize>
         <Parameter>
           <Name>nState</Name>
@@ -57627,6 +57419,10 @@ ELSE:
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -58636,7 +58432,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>nBPIndex</Name>
-        <Type>INT</Type>
+        <Type>UINT</Type>
         <BitSize>16</BitSize>
         <BitOffs>63360</BitOffs>
       </SubItem>
@@ -58732,7 +58528,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </SubItem>
       <SubItem>
         <Name>nIter</Name>
-        <Type>INT</Type>
+        <Type>UINT</Type>
         <BitSize>16</BitSize>
         <BitOffs>395984</BitOffs>
       </SubItem>
@@ -58756,6 +58552,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
+        </Property>
       </Properties>
     </DataType>
     <DataType>
@@ -58763,7 +58563,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <BitSize>28800</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <Comment> Motion stage to monitor</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
@@ -58892,15 +58692,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>960</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bNCError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>968</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stBeamParams</Name>
@@ -58932,7 +58723,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <BitSize>29056</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <Comment> Motion stage to monitor</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
@@ -59024,13 +58815,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</Name>
-      <BitSize>683008</BitSize>
+      <BitSize>683264</BitSize>
       <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase</ExtendsType>
       <SubItem>
         <Name>fbArbiter</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
         <BitSize>64</BitSize>
-        <BitOffs>256256</BitOffs>
+        <BitOffs>256512</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59042,7 +58833,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
         <BitSize>64</BitSize>
-        <BitOffs>256320</BitOffs>
+        <BitOffs>256576</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59054,7 +58845,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>sPmpsDeviceName</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>256384</BitOffs>
+        <BitOffs>256640</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59066,7 +58857,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>sTransitionKey</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>257032</BitOffs>
+        <BitOffs>257288</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59078,7 +58869,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bArbiterEnabled</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>257680</BitOffs>
+        <BitOffs>257936</BitOffs>
         <Default>
           <Bool>true</Bool>
         </Default>
@@ -59100,7 +58891,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>tArbiterTimeout</Name>
         <Type>TIME</Type>
         <BitSize>32</BitSize>
-        <BitOffs>257696</BitOffs>
+        <BitOffs>257952</BitOffs>
         <Default>
           <DateTime>T#1s</DateTime>
         </Default>
@@ -59115,7 +58906,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bMoveOnArbiterTimeout</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>257728</BitOffs>
+        <BitOffs>257984</BitOffs>
         <Default>
           <Bool>true</Bool>
         </Default>
@@ -59130,7 +58921,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fStateBoundaryDeadband</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>257792</BitOffs>
+        <BitOffs>258048</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -59145,7 +58936,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bBPOKAutoReset</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>257856</BitOffs>
+        <BitOffs>258112</BitOffs>
         <Default>
           <Bool>false</Bool>
         </Default>
@@ -59160,7 +58951,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbStatePMPS</Name>
         <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Type>
         <BitSize>396032</BitSize>
-        <BitOffs>257920</BitOffs>
+        <BitOffs>258176</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -59172,7 +58963,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fbEncErrFFO</Name>
         <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
         <BitSize>29056</BitSize>
-        <BitOffs>653952</BitOffs>
+        <BitOffs>654208</BitOffs>
       </SubItem>
       <Action>
         <Name>Exec</Name>
@@ -59184,6 +58975,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -59217,14 +59012,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion">DUT_PositionState</Name>
+      <BitSize>3648</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>DUT_PositionState has been renamed to ST_PositionState</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name>FB_XS_YAG_States</Name>
-      <BitSize>694464</BitSize>
+      <BitSize>694720</BitSize>
       <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStateBase_WithPMPS</ExtendsType>
       <SubItem>
         <Name>enumSet</Name>
         <Type>ENUM_XS_YAG_States</Type>
         <BitSize>16</BitSize>
-        <BitOffs>683008</BitOffs>
+        <BitOffs>683264</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59243,7 +59049,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>stOut</Name>
         <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>683072</BitOffs>
+        <BitOffs>683328</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59255,7 +59061,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>stYag1</Name>
         <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>686720</BitOffs>
+        <BitOffs>686976</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59267,7 +59073,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>stYag2</Name>
         <Type Namespace="lcls_twincat_motion">DUT_PositionState</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>690368</BitOffs>
+        <BitOffs>690624</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59279,7 +59085,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bStatesLock</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>694016</BitOffs>
+        <BitOffs>694272</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59291,7 +59097,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>enumGet</Name>
         <Type>ENUM_XS_YAG_States</Type>
         <BitSize>16</BitSize>
-        <BitOffs>694032</BitOffs>
+        <BitOffs>694288</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59310,7 +59116,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bXSInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>694048</BitOffs>
+        <BitOffs>694304</BitOffs>
         <Default>
           <Bool>true</Bool>
         </Default>
@@ -59319,7 +59125,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fInDelta</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>694080</BitOffs>
+        <BitOffs>694336</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -59328,7 +59134,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDelta</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>694144</BitOffs>
+        <BitOffs>694400</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -59337,7 +59143,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fInVelocity</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>694208</BitOffs>
+        <BitOffs>694464</BitOffs>
         <Default>
           <Value>0.5</Value>
         </Default>
@@ -59346,7 +59152,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutVelocity</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>694272</BitOffs>
+        <BitOffs>694528</BitOffs>
         <Default>
           <Value>0.5</Value>
         </Default>
@@ -59355,7 +59161,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fAccel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>694336</BitOffs>
+        <BitOffs>694592</BitOffs>
         <Default>
           <Value>100</Value>
         </Default>
@@ -59364,7 +59170,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>fOutDecel</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>694400</BitOffs>
+        <BitOffs>694656</BitOffs>
         <Default>
           <Value>25</Value>
         </Default>
@@ -60196,6 +60002,115 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</Name>
+      <BitSize>1216</BitSize>
+      <SubItem>
+        <Name>fFlow_1_val</Name>
+        <Type>LREAL</Type>
+        <Comment> Mirrors with 1 Cooling Flow Meter and 1 Pressure Meter</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM:1
+        field: EGU lpm
+        field: HIGH 2.3
+        field: HIHI 3.0
+        field: LOW 1.7
+        field: LOLO 1.5
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPress_1_val</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PRSM:1
+        field: EGU bar
+        field: LOW 0.1
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlow_1</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPress_1</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</Name>
+      <BitSize>1792</BitSize>
+      <ExtendsType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</ExtendsType>
+      <SubItem>
+        <Name>fFlow_2_val</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM:2
+        field: EGU lpm
+        field: HIGH 2.3
+        field: HIHI 3.0
+        field: LOW 1.7
+        field: LOLO 1.5
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlow_2</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -72326,7 +72241,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72342,14 +72257,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294474304</BitOffs>
+            <BitOffs>1296779424</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72363,19 +72278,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294474496</BitOffs>
+            <BitOffs>1296779616</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
             <BaseType Namespace="Tc2_SerialCom">SerialLineControl</BaseType>
-            <BitOffs>1271636288</BitOffs>
+            <BitOffs>1271636352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_RXBuffer_M1K2</Name>
@@ -72387,7 +72302,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292421760</BitOffs>
+            <BitOffs>1294726912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -72398,7 +72313,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292424272</BitOffs>
+            <BitOffs>1294729424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -72412,7 +72327,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302850272</BitOffs>
+            <BitOffs>1305245920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -72426,7 +72341,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302850304</BitOffs>
+            <BitOffs>1305245952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -72440,7 +72355,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857472</BitOffs>
+            <BitOffs>1305253120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -72461,26 +72376,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857792</BitOffs>
+            <BitOffs>1305253440</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164364288</ByteSize>
-          <Symbol>
-            <Name>Main.M6.Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1295891392</BitOffs>
-          </Symbol>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72491,26 +72394,46 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295912576</BitOffs>
+            <BitOffs>1298241920</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1271647680</BitOffs>
+            <BitOffs>1271647744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afGpiPosDiffBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1271647808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afGpiExtraBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1272287808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.fbGpiPosDiffCollect</Name>
             <BitSize>448</BitSize>
             <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
-            <BitOffs>1271775744</BitOffs>
+            <BitOffs>1272927808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.fbGpiPosDiffStats</Name>
@@ -72524,73 +72447,35 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1271776192</BitOffs>
+            <BitOffs>1272928256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.fGpiRangeMax</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1271777344</BitOffs>
+            <BitOffs>1272929408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.rtNewGpiMove</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1271777408</BitOffs>
+            <BitOffs>1272929472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.tonNewGpiMove</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1271777536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6</Name>
-            <Comment> M_PI, urad</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_PI
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1295890304</BitOffs>
+            <BitOffs>1272929600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
             <Comment> G_PI, urad</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -72618,7 +72503,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295911488</BitOffs>
+            <BitOffs>1298240832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -72632,7 +72517,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857504</BitOffs>
+            <BitOffs>1305253152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -72646,7 +72531,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857536</BitOffs>
+            <BitOffs>1305253184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -72667,47 +72552,27 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302858688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_Stats.afGpiPosDiffBuffer</Name>
-            <BitSize>640000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>10000</Elements>
-            </ArrayInfo>
-            <BitOffs>1310820160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_Stats.afGpiExtraBuffer</Name>
-            <BitSize>640000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>10000</Elements>
-            </ArrayInfo>
-            <BitOffs>1311460160</BitOffs>
+            <BitOffs>1305254336</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265714496</BitOffs>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</BaseType>
+            <BitOffs>1265714560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
             <Comment> Pitch Mechanism:
  Currently Unused</Comment>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -72735,7 +72600,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292430016</BitOffs>
+            <BitOffs>1294735168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -72749,7 +72614,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857568</BitOffs>
+            <BitOffs>1305253216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -72763,7 +72628,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857600</BitOffs>
+            <BitOffs>1305253248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -72784,14 +72649,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302859584</BitOffs>
+            <BitOffs>1305255232</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72807,7 +72672,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934400</BitOffs>
+            <BitOffs>1264934464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -72823,7 +72688,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934464</BitOffs>
+            <BitOffs>1264934528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -72839,14 +72704,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934528</BitOffs>
+            <BitOffs>1264934592</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72971,7 +72836,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1264813360</BitOffs>
+            <BitOffs>1264813408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bSendToTest</Name>
@@ -72980,7 +72845,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1264813368</BitOffs>
+            <BitOffs>1264813416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <BitOffs>1264813424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <BitOffs>1264813432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.sTestHost</Name>
@@ -72990,129 +72873,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1264934592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <BitOffs>1264935240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <BitOffs>1264935248</BitOffs>
+            <BitOffs>1264934656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1264935256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <DateTime>T#8ms</DateTime>
-            </Default>
-            <BitOffs>1264935264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
-            <Comment> Outputs</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <BitOffs>1264935296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <BitOffs>1264935360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.iMinTime</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>10000000000</Value>
-            </Default>
-            <BitOffs>1264935424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1264935488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <BitOffs>1264935552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:DAQ:TRIG_RATE
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1264935616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
-            <BitSize>256</BitSize>
-            <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1264935680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <BitOffs>1264935936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1264936000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>10000000</Value>
-            </Default>
-            <BitOffs>1264936064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <BitOffs>1264936128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <BitOffs>1264936192</BitOffs>
+            <BitOffs>1264935304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -73127,6 +72895,103 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
+            <BitOffs>1264935312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <DateTime>T#8ms</DateTime>
+            </Default>
+            <BitOffs>1264935328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
+            <Comment> Outputs</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <BitOffs>1264935360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <BitOffs>1264935424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.iMinTime</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>10000000000</Value>
+            </Default>
+            <BitOffs>1264935488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1264935552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <BitOffs>1264935616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:DAQ:TRIG_RATE
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1264935680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="Tc2_Standard">TON</BaseType>
+            <BitOffs>1264935744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <BitOffs>1264936000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1264936064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>10000000</Value>
+            </Default>
+            <BitOffs>1264936128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <BitOffs>1264936192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
             <BitOffs>1264936256</BitOffs>
           </Symbol>
           <Symbol>
@@ -73234,7 +73099,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711360</BitOffs>
+            <BitOffs>1265711424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -73249,7 +73114,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711392</BitOffs>
+            <BitOffs>1265711456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -73267,7 +73132,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302852352</BitOffs>
+            <BitOffs>1305248000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -73281,7 +73146,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857632</BitOffs>
+            <BitOffs>1305253280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -73295,7 +73160,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302857664</BitOffs>
+            <BitOffs>1305253312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -73316,16 +73181,16 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302860480</BitOffs>
+            <BitOffs>1305256128</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
-            <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+            <Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
             <BitSize>64</BitSize>
             <BaseType>LINT</BaseType>
@@ -73335,7 +73200,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264816000</BitOffs>
+            <BitOffs>1264816064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
@@ -73348,7 +73213,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271786688</BitOffs>
+            <BitOffs>1274220416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
@@ -73360,7 +73225,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271786696</BitOffs>
+            <BitOffs>1274220424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
@@ -73373,7 +73238,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271786752</BitOffs>
+            <BitOffs>1274220480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
@@ -73385,7 +73250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271786880</BitOffs>
+            <BitOffs>1274220608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
@@ -73397,7 +73262,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271787008</BitOffs>
+            <BitOffs>1274220736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
@@ -73409,7 +73274,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271787136</BitOffs>
+            <BitOffs>1274220864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -73422,7 +73287,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271787904</BitOffs>
+            <BitOffs>1274221632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -73435,7 +73300,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271788032</BitOffs>
+            <BitOffs>1274221760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -73448,7 +73313,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271798656</BitOffs>
+            <BitOffs>1274232384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -73461,7 +73326,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1271798784</BitOffs>
+            <BitOffs>1274232512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73473,7 +73338,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273037504</BitOffs>
+            <BitOffs>1275471232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73485,7 +73350,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273372544</BitOffs>
+            <BitOffs>1275806208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bMR1K1_Y_ENC_Ready</Name>
@@ -73501,7 +73366,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273697648</BitOffs>
+            <BitOffs>1276136512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bMR1K1_Y_ENC_TxPDO</Name>
@@ -73517,46 +73382,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1273697656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fM1K1_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1273702912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fM1K1_Flow_2.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1273703488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fM1K1_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1273704064</BitOffs>
+            <BitOffs>1276136520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable1</Name>
@@ -73574,7 +73400,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274479968</BitOffs>
+            <BitOffs>1276136528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable2</Name>
@@ -73590,7 +73416,46 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274479976</BitOffs>
+            <BitOffs>1276136536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fM1K1_Flow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1276136640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fM1K1_Flow_2.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1276137216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fM1K1_Press_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1276137792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_1_Err</Name>
@@ -73603,7 +73468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274479984</BitOffs>
+            <BitOffs>1276913888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_2_Err</Name>
@@ -73615,7 +73480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274479992</BitOffs>
+            <BitOffs>1276913896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_3_Err</Name>
@@ -73627,7 +73492,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274480192</BitOffs>
+            <BitOffs>1276913904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_1_Err</Name>
@@ -73639,7 +73504,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274480200</BitOffs>
+            <BitOffs>1276913912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_2_Err</Name>
@@ -73651,7 +73516,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274480208</BitOffs>
+            <BitOffs>1276913920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_3_Err</Name>
@@ -73663,196 +73528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1274480216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
-            <Comment> STO Button</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280305728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280305736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
-            <Comment> Encoders</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280305792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280305920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280306048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280306176</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280306944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280307072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280317696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1280317824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1281556544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1281891520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282221888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282222464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282223040</BitOffs>
+            <BitOffs>1276913928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
@@ -73869,7 +73545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223872</BitOffs>
+            <BitOffs>1276913968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
@@ -73885,7 +73561,196 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223880</BitOffs>
+            <BitOffs>1276913976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
+            <Comment> STO Button</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
+            <Comment> Encoders</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282740672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282740800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282751424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282751552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283990272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284325248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284655616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284656192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284656768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73897,7 +73762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282226560</BitOffs>
+            <BitOffs>1284660224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73909,7 +73774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282553984</BitOffs>
+            <BitOffs>1284987648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73921,7 +73786,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282881408</BitOffs>
+            <BitOffs>1285315072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73933,7 +73798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283208832</BitOffs>
+            <BitOffs>1285642496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73945,7 +73810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283536256</BitOffs>
+            <BitOffs>1285969920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73957,7 +73822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283863680</BitOffs>
+            <BitOffs>1286297344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upe</Name>
@@ -73979,7 +73844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284188480</BitOffs>
+            <BitOffs>1286622144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upe</Name>
@@ -74001,7 +73866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284188608</BitOffs>
+            <BitOffs>1286622272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bError</Name>
@@ -74025,7 +73890,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189064</BitOffs>
+            <BitOffs>1286622728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bUnderrange</Name>
@@ -74037,7 +73902,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189072</BitOffs>
+            <BitOffs>1286622736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bOverrange</Name>
@@ -74049,7 +73914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189080</BitOffs>
+            <BitOffs>1286622744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.iRaw</Name>
@@ -74061,7 +73926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189088</BitOffs>
+            <BitOffs>1286622752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bError</Name>
@@ -74085,7 +73950,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189320</BitOffs>
+            <BitOffs>1286622984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bUnderrange</Name>
@@ -74097,7 +73962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189328</BitOffs>
+            <BitOffs>1286622992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bOverrange</Name>
@@ -74109,7 +73974,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189336</BitOffs>
+            <BitOffs>1286623000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.iRaw</Name>
@@ -74121,7 +73986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189344</BitOffs>
+            <BitOffs>1286623008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bError</Name>
@@ -74145,7 +74010,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189576</BitOffs>
+            <BitOffs>1286623240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bUnderrange</Name>
@@ -74157,7 +74022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189584</BitOffs>
+            <BitOffs>1286623248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bOverrange</Name>
@@ -74169,7 +74034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189592</BitOffs>
+            <BitOffs>1286623256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.iRaw</Name>
@@ -74181,7 +74046,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189600</BitOffs>
+            <BitOffs>1286623264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bError</Name>
@@ -74205,7 +74070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189832</BitOffs>
+            <BitOffs>1286623496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bUnderrange</Name>
@@ -74217,7 +74082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189840</BitOffs>
+            <BitOffs>1286623504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bOverrange</Name>
@@ -74229,7 +74094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189848</BitOffs>
+            <BitOffs>1286623512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.iRaw</Name>
@@ -74241,7 +74106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189856</BitOffs>
+            <BitOffs>1286623520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bError</Name>
@@ -74265,7 +74130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190088</BitOffs>
+            <BitOffs>1286623752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bUnderrange</Name>
@@ -74277,7 +74142,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190096</BitOffs>
+            <BitOffs>1286623760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bOverrange</Name>
@@ -74289,7 +74154,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190104</BitOffs>
+            <BitOffs>1286623768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.iRaw</Name>
@@ -74301,7 +74166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190112</BitOffs>
+            <BitOffs>1286623776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bError</Name>
@@ -74325,7 +74190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190344</BitOffs>
+            <BitOffs>1286624008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bUnderrange</Name>
@@ -74337,7 +74202,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190352</BitOffs>
+            <BitOffs>1286624016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bOverrange</Name>
@@ -74349,7 +74214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190360</BitOffs>
+            <BitOffs>1286624024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.iRaw</Name>
@@ -74361,7 +74226,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190368</BitOffs>
+            <BitOffs>1286624032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bError</Name>
@@ -74385,7 +74250,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190600</BitOffs>
+            <BitOffs>1286624264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bUnderrange</Name>
@@ -74397,7 +74262,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190608</BitOffs>
+            <BitOffs>1286624272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bOverrange</Name>
@@ -74409,7 +74274,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190616</BitOffs>
+            <BitOffs>1286624280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.iRaw</Name>
@@ -74421,7 +74286,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190624</BitOffs>
+            <BitOffs>1286624288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bError</Name>
@@ -74445,7 +74310,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190856</BitOffs>
+            <BitOffs>1286624520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bUnderrange</Name>
@@ -74457,7 +74322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190864</BitOffs>
+            <BitOffs>1286624528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bOverrange</Name>
@@ -74469,7 +74334,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190872</BitOffs>
+            <BitOffs>1286624536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.iRaw</Name>
@@ -74481,7 +74346,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190880</BitOffs>
+            <BitOffs>1286624544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw</Name>
@@ -74494,7 +74359,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284217088</BitOffs>
+            <BitOffs>1286650816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2.iRaw</Name>
@@ -74507,7 +74372,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284217664</BitOffs>
+            <BitOffs>1286651392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
@@ -74520,7 +74385,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284218240</BitOffs>
+            <BitOffs>1286651968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74532,7 +74397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284384768</BitOffs>
+            <BitOffs>1286688832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74544,7 +74409,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284712192</BitOffs>
+            <BitOffs>1287016256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74556,7 +74421,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285039616</BitOffs>
+            <BitOffs>1287343680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74568,7 +74433,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285367040</BitOffs>
+            <BitOffs>1287671104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74580,7 +74445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285694464</BitOffs>
+            <BitOffs>1287998528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bError</Name>
@@ -74604,7 +74469,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286713928</BitOffs>
+            <BitOffs>1289018248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bUnderrange</Name>
@@ -74616,7 +74481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286713936</BitOffs>
+            <BitOffs>1289018256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bOverrange</Name>
@@ -74628,7 +74493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286713944</BitOffs>
+            <BitOffs>1289018264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.iRaw</Name>
@@ -74640,7 +74505,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286713952</BitOffs>
+            <BitOffs>1289018272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bError</Name>
@@ -74664,7 +74529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714184</BitOffs>
+            <BitOffs>1289018504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bUnderrange</Name>
@@ -74676,7 +74541,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714192</BitOffs>
+            <BitOffs>1289018512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bOverrange</Name>
@@ -74688,7 +74553,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714200</BitOffs>
+            <BitOffs>1289018520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.iRaw</Name>
@@ -74700,7 +74565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714208</BitOffs>
+            <BitOffs>1289018528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bError</Name>
@@ -74724,7 +74589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714440</BitOffs>
+            <BitOffs>1289018760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bUnderrange</Name>
@@ -74736,7 +74601,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714448</BitOffs>
+            <BitOffs>1289018768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bOverrange</Name>
@@ -74748,7 +74613,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714456</BitOffs>
+            <BitOffs>1289018776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.iRaw</Name>
@@ -74760,7 +74625,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714464</BitOffs>
+            <BitOffs>1289018784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bError</Name>
@@ -74784,7 +74649,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714696</BitOffs>
+            <BitOffs>1289019016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bUnderrange</Name>
@@ -74796,7 +74661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714704</BitOffs>
+            <BitOffs>1289019024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bOverrange</Name>
@@ -74808,7 +74673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714712</BitOffs>
+            <BitOffs>1289019032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.iRaw</Name>
@@ -74820,7 +74685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714720</BitOffs>
+            <BitOffs>1289019040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbGetIllPercent.iRaw</Name>
@@ -74833,7 +74698,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286715008</BitOffs>
+            <BitOffs>1289019328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter.iRaw</Name>
@@ -74846,7 +74711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286716160</BitOffs>
+            <BitOffs>1289020480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74858,7 +74723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286719552</BitOffs>
+            <BitOffs>1289023872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -74874,7 +74739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287046528</BitOffs>
+            <BitOffs>1289350848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -74895,7 +74760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287050048</BitOffs>
+            <BitOffs>1289354368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -74916,7 +74781,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287050049</BitOffs>
+            <BitOffs>1289354369</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable1</Name>
@@ -74933,7 +74798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288539552</BitOffs>
+            <BitOffs>1289652944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2</Name>
@@ -74949,7 +74814,46 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288539560</BitOffs>
+            <BitOffs>1289652952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290844800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290845312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290845888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
@@ -74962,7 +74866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288539568</BitOffs>
+            <BitOffs>1292785056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
@@ -74974,46 +74878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288539576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288539648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288540224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288540800</BitOffs>
+            <BitOffs>1292785064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
@@ -75025,7 +74890,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480064</BitOffs>
+            <BitOffs>1292785072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
@@ -75037,7 +74902,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480072</BitOffs>
+            <BitOffs>1292785080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
@@ -75049,7 +74914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480080</BitOffs>
+            <BitOffs>1292785088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -75061,7 +74926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480088</BitOffs>
+            <BitOffs>1292785096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -75078,7 +74943,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480096</BitOffs>
+            <BitOffs>1292785104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -75094,7 +74959,33 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480104</BitOffs>
+            <BitOffs>1292785112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292785408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292785920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -75107,7 +74998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480112</BitOffs>
+            <BitOffs>1294725088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -75119,33 +75010,31 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480120</BitOffs>
+            <BitOffs>1294725096</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480192</BitOffs>
+            <BitOffs>1294725104</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290480768</BitOffs>
+            <BitOffs>1294725112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -75169,7 +75058,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420232</BitOffs>
+            <BitOffs>1294725320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -75181,7 +75070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420240</BitOffs>
+            <BitOffs>1294725328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -75193,7 +75082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420248</BitOffs>
+            <BitOffs>1294725336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -75205,7 +75094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420256</BitOffs>
+            <BitOffs>1294725344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -75229,7 +75118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420488</BitOffs>
+            <BitOffs>1294725576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -75241,7 +75130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420496</BitOffs>
+            <BitOffs>1294725584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -75253,7 +75142,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420504</BitOffs>
+            <BitOffs>1294725592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -75265,31 +75154,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292420544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292420552</BitOffs>
+            <BitOffs>1294725600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -75301,7 +75166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420560</BitOffs>
+            <BitOffs>1294725632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -75313,7 +75178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420568</BitOffs>
+            <BitOffs>1294725640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -75330,7 +75195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420576</BitOffs>
+            <BitOffs>1294725648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -75346,7 +75211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292420584</BitOffs>
+            <BitOffs>1294725656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -75366,33 +75231,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292420592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292420672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292421248</BitOffs>
+            <BitOffs>1294725664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -75411,7 +75250,33 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426784</BitOffs>
+            <BitOffs>1294725680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294725952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294726464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -75430,20 +75295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292429248</BitOffs>
+            <BitOffs>1294731936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -75463,7 +75315,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429696</BitOffs>
+            <BitOffs>1294731952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294734400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -75482,7 +75347,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429712</BitOffs>
+            <BitOffs>1294734848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -75501,7 +75366,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429728</BitOffs>
+            <BitOffs>1294734864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -75521,20 +75386,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292432448</BitOffs>
+            <BitOffs>1294734880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -75553,7 +75405,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433024</BitOffs>
+            <BitOffs>1294734896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294737600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -75572,7 +75437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433040</BitOffs>
+            <BitOffs>1294738176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -75592,7 +75457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433056</BitOffs>
+            <BitOffs>1294738192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -75611,7 +75476,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433072</BitOffs>
+            <BitOffs>1294738208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -75630,7 +75495,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433088</BitOffs>
+            <BitOffs>1294738224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -75650,7 +75515,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433104</BitOffs>
+            <BitOffs>1294738816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -75669,7 +75534,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433120</BitOffs>
+            <BitOffs>1294738832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -75688,7 +75553,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433136</BitOffs>
+            <BitOffs>1294738848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -75708,7 +75573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433728</BitOffs>
+            <BitOffs>1294738864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -75727,7 +75592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433744</BitOffs>
+            <BitOffs>1294738880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -75746,7 +75611,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433760</BitOffs>
+            <BitOffs>1294738896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -75761,7 +75626,22 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433776</BitOffs>
+            <BitOffs>1296779808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.sio_load</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1296779824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -75773,7 +75653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294475776</BitOffs>
+            <BitOffs>1296780928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -75782,21 +75662,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483712</BitOffs>
+            <BitOffs>1296788864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -75805,21 +75675,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483720</BitOffs>
+            <BitOffs>1296788872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -75828,21 +75688,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483728</BitOffs>
+            <BitOffs>1296788880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -75865,7 +75715,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483744</BitOffs>
+            <BitOffs>1296788896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -75878,7 +75728,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483776</BitOffs>
+            <BitOffs>1296788928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -75891,7 +75741,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483840</BitOffs>
+            <BitOffs>1296788992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -75904,7 +75754,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483856</BitOffs>
+            <BitOffs>1296789008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75916,7 +75766,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294498496</BitOffs>
+            <BitOffs>1296807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -75928,7 +75778,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294824384</BitOffs>
+            <BitOffs>1297133568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -75937,21 +75787,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832320</BitOffs>
+            <BitOffs>1297141504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -75960,21 +75800,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832328</BitOffs>
+            <BitOffs>1297141512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -75983,21 +75813,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832336</BitOffs>
+            <BitOffs>1297141520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -76020,7 +75840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832352</BitOffs>
+            <BitOffs>1297141536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -76033,7 +75853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832384</BitOffs>
+            <BitOffs>1297141568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -76046,7 +75866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832448</BitOffs>
+            <BitOffs>1297141632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -76059,7 +75879,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832464</BitOffs>
+            <BitOffs>1297141648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76071,7 +75891,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294847104</BitOffs>
+            <BitOffs>1297160320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -76083,7 +75903,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295172992</BitOffs>
+            <BitOffs>1297486208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -76092,21 +75912,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295180928</BitOffs>
+            <BitOffs>1297494144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -76115,21 +75925,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295180936</BitOffs>
+            <BitOffs>1297494152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -76138,21 +75938,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295180944</BitOffs>
+            <BitOffs>1297494160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -76175,7 +75965,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295180960</BitOffs>
+            <BitOffs>1297494176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -76188,7 +75978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295180992</BitOffs>
+            <BitOffs>1297494208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -76201,7 +75991,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295181056</BitOffs>
+            <BitOffs>1297494272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -76214,7 +76004,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295181072</BitOffs>
+            <BitOffs>1297494288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76226,7 +76016,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295195712</BitOffs>
+            <BitOffs>1297512960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -76238,7 +76028,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295521600</BitOffs>
+            <BitOffs>1297838848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -76247,21 +76037,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529536</BitOffs>
+            <BitOffs>1297846784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -76270,21 +76050,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529544</BitOffs>
+            <BitOffs>1297846792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -76293,21 +76063,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529552</BitOffs>
+            <BitOffs>1297846800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -76330,7 +76090,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529568</BitOffs>
+            <BitOffs>1297846816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -76343,7 +76103,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529600</BitOffs>
+            <BitOffs>1297846848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -76356,7 +76116,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529664</BitOffs>
+            <BitOffs>1297846912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -76369,7 +76129,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529680</BitOffs>
+            <BitOffs>1297846928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76381,7 +76141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295544320</BitOffs>
+            <BitOffs>1297865600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -76393,7 +76153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295870208</BitOffs>
+            <BitOffs>1298191488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -76402,21 +76162,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878144</BitOffs>
+            <BitOffs>1298199424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -76425,21 +76175,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878152</BitOffs>
+            <BitOffs>1298199432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -76448,21 +76188,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878160</BitOffs>
+            <BitOffs>1298199440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -76485,7 +76215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878176</BitOffs>
+            <BitOffs>1298199456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -76498,7 +76228,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878208</BitOffs>
+            <BitOffs>1298199488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -76511,7 +76241,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878272</BitOffs>
+            <BitOffs>1298199552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -76524,7 +76254,19 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878288</BitOffs>
+            <BitOffs>1298199568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1298216704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -76533,21 +76275,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899328</BitOffs>
+            <BitOffs>1298224640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -76556,21 +76288,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899336</BitOffs>
+            <BitOffs>1298224648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -76579,21 +76301,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899344</BitOffs>
+            <BitOffs>1298224656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -76616,7 +76328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899360</BitOffs>
+            <BitOffs>1298224672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -76629,7 +76341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899392</BitOffs>
+            <BitOffs>1298224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -76642,7 +76354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899456</BitOffs>
+            <BitOffs>1298224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -76655,7 +76367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899472</BitOffs>
+            <BitOffs>1298224784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -76664,21 +76376,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920512</BitOffs>
+            <BitOffs>1298249856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -76687,21 +76389,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920520</BitOffs>
+            <BitOffs>1298249864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -76710,21 +76402,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920528</BitOffs>
+            <BitOffs>1298249872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -76747,7 +76429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920544</BitOffs>
+            <BitOffs>1298249888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -76760,7 +76442,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920576</BitOffs>
+            <BitOffs>1298249920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -76773,7 +76455,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920640</BitOffs>
+            <BitOffs>1298249984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -76786,7 +76468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920656</BitOffs>
+            <BitOffs>1298250000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -76798,7 +76480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295933760</BitOffs>
+            <BitOffs>1298267136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -76807,21 +76489,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941696</BitOffs>
+            <BitOffs>1298275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -76830,21 +76502,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941704</BitOffs>
+            <BitOffs>1298275080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -76853,21 +76515,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941712</BitOffs>
+            <BitOffs>1298275088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -76890,7 +76542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941728</BitOffs>
+            <BitOffs>1298275104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -76903,7 +76555,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941760</BitOffs>
+            <BitOffs>1298275136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -76916,7 +76568,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941824</BitOffs>
+            <BitOffs>1298275200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -76929,7 +76581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941840</BitOffs>
+            <BitOffs>1298275216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -76941,7 +76593,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295954944</BitOffs>
+            <BitOffs>1298292352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -76950,21 +76602,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295962880</BitOffs>
+            <BitOffs>1298300288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -76973,21 +76615,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295962888</BitOffs>
+            <BitOffs>1298300296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -76996,21 +76628,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295962896</BitOffs>
+            <BitOffs>1298300304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -77033,7 +76655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295962912</BitOffs>
+            <BitOffs>1298300320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -77046,7 +76668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295962944</BitOffs>
+            <BitOffs>1298300352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -77059,7 +76681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295963008</BitOffs>
+            <BitOffs>1298300416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -77072,7 +76694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295963024</BitOffs>
+            <BitOffs>1298300432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -77084,7 +76706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295976128</BitOffs>
+            <BitOffs>1298317568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -77093,21 +76715,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984064</BitOffs>
+            <BitOffs>1298325504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -77116,21 +76728,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984072</BitOffs>
+            <BitOffs>1298325512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -77139,21 +76741,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984080</BitOffs>
+            <BitOffs>1298325520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -77176,7 +76768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984096</BitOffs>
+            <BitOffs>1298325536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -77189,7 +76781,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984128</BitOffs>
+            <BitOffs>1298325568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -77202,7 +76794,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984192</BitOffs>
+            <BitOffs>1298325632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -77215,7 +76807,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984208</BitOffs>
+            <BitOffs>1298325648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -77227,7 +76819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295997312</BitOffs>
+            <BitOffs>1298342784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -77236,21 +76828,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005248</BitOffs>
+            <BitOffs>1298350720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -77259,21 +76841,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005256</BitOffs>
+            <BitOffs>1298350728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -77282,21 +76854,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005264</BitOffs>
+            <BitOffs>1298350736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -77319,7 +76881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005280</BitOffs>
+            <BitOffs>1298350752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -77332,7 +76894,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005312</BitOffs>
+            <BitOffs>1298350784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -77345,7 +76907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005376</BitOffs>
+            <BitOffs>1298350848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -77358,7 +76920,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005392</BitOffs>
+            <BitOffs>1298350864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -77370,7 +76932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296018496</BitOffs>
+            <BitOffs>1298368000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -77379,21 +76941,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026432</BitOffs>
+            <BitOffs>1298375936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -77402,21 +76954,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026440</BitOffs>
+            <BitOffs>1298375944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -77425,21 +76967,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026448</BitOffs>
+            <BitOffs>1298375952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -77462,7 +76994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026464</BitOffs>
+            <BitOffs>1298375968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -77475,7 +77007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026496</BitOffs>
+            <BitOffs>1298376000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -77488,7 +77020,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026560</BitOffs>
+            <BitOffs>1298376064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -77501,7 +77033,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026576</BitOffs>
+            <BitOffs>1298376080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77513,7 +77045,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296041216</BitOffs>
+            <BitOffs>1298394752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -77525,7 +77057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296367104</BitOffs>
+            <BitOffs>1298720640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -77534,21 +77066,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375040</BitOffs>
+            <BitOffs>1298728576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -77557,21 +77079,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375048</BitOffs>
+            <BitOffs>1298728584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -77580,21 +77092,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375056</BitOffs>
+            <BitOffs>1298728592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -77617,7 +77119,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375072</BitOffs>
+            <BitOffs>1298728608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -77630,7 +77132,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375104</BitOffs>
+            <BitOffs>1298728640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -77643,7 +77145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375168</BitOffs>
+            <BitOffs>1298728704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -77656,7 +77158,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375184</BitOffs>
+            <BitOffs>1298728720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77668,7 +77170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296389824</BitOffs>
+            <BitOffs>1298747392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -77680,7 +77182,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296715712</BitOffs>
+            <BitOffs>1299073280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -77689,21 +77191,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723648</BitOffs>
+            <BitOffs>1299081216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -77712,21 +77204,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723656</BitOffs>
+            <BitOffs>1299081224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -77735,21 +77217,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723664</BitOffs>
+            <BitOffs>1299081232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -77772,7 +77244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723680</BitOffs>
+            <BitOffs>1299081248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -77785,7 +77257,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723712</BitOffs>
+            <BitOffs>1299081280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -77798,7 +77270,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723776</BitOffs>
+            <BitOffs>1299081344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -77811,7 +77283,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723792</BitOffs>
+            <BitOffs>1299081360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77823,7 +77295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296738432</BitOffs>
+            <BitOffs>1299100032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -77835,7 +77307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297064320</BitOffs>
+            <BitOffs>1299425920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -77844,21 +77316,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072256</BitOffs>
+            <BitOffs>1299433856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -77867,21 +77329,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072264</BitOffs>
+            <BitOffs>1299433864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -77890,21 +77342,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072272</BitOffs>
+            <BitOffs>1299433872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -77927,7 +77369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072288</BitOffs>
+            <BitOffs>1299433888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -77940,7 +77382,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072320</BitOffs>
+            <BitOffs>1299433920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -77953,7 +77395,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072384</BitOffs>
+            <BitOffs>1299433984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -77966,7 +77408,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072400</BitOffs>
+            <BitOffs>1299434000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77978,7 +77420,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297087040</BitOffs>
+            <BitOffs>1299452672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -77990,7 +77432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297412928</BitOffs>
+            <BitOffs>1299778560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -77999,21 +77441,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420864</BitOffs>
+            <BitOffs>1299786496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -78022,21 +77454,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420872</BitOffs>
+            <BitOffs>1299786504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -78045,21 +77467,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420880</BitOffs>
+            <BitOffs>1299786512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -78082,7 +77494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420896</BitOffs>
+            <BitOffs>1299786528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -78095,7 +77507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420928</BitOffs>
+            <BitOffs>1299786560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -78108,7 +77520,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420992</BitOffs>
+            <BitOffs>1299786624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -78121,7 +77533,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297421008</BitOffs>
+            <BitOffs>1299786640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -78133,7 +77545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297434112</BitOffs>
+            <BitOffs>1299803776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -78142,21 +77554,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442048</BitOffs>
+            <BitOffs>1299811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -78165,21 +77567,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442056</BitOffs>
+            <BitOffs>1299811720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -78188,21 +77580,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442064</BitOffs>
+            <BitOffs>1299811728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -78225,7 +77607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442080</BitOffs>
+            <BitOffs>1299811744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -78238,7 +77620,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442112</BitOffs>
+            <BitOffs>1299811776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -78251,7 +77633,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442176</BitOffs>
+            <BitOffs>1299811840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -78264,7 +77646,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442192</BitOffs>
+            <BitOffs>1299811856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78276,7 +77658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297456832</BitOffs>
+            <BitOffs>1299830528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -78288,7 +77670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297782720</BitOffs>
+            <BitOffs>1300156416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -78297,21 +77679,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790656</BitOffs>
+            <BitOffs>1300164352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -78320,21 +77692,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790664</BitOffs>
+            <BitOffs>1300164360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -78343,21 +77705,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790672</BitOffs>
+            <BitOffs>1300164368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -78380,7 +77732,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790688</BitOffs>
+            <BitOffs>1300164384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -78393,7 +77745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790720</BitOffs>
+            <BitOffs>1300164416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -78406,7 +77758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790784</BitOffs>
+            <BitOffs>1300164480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -78419,7 +77771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790800</BitOffs>
+            <BitOffs>1300164496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78431,7 +77783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297805440</BitOffs>
+            <BitOffs>1300183168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -78443,7 +77795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298131328</BitOffs>
+            <BitOffs>1300509056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -78452,21 +77804,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139264</BitOffs>
+            <BitOffs>1300516992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -78475,21 +77817,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139272</BitOffs>
+            <BitOffs>1300517000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -78498,21 +77830,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139280</BitOffs>
+            <BitOffs>1300517008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -78535,7 +77857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139296</BitOffs>
+            <BitOffs>1300517024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -78548,7 +77870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139328</BitOffs>
+            <BitOffs>1300517056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -78561,7 +77883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139392</BitOffs>
+            <BitOffs>1300517120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -78574,7 +77896,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139408</BitOffs>
+            <BitOffs>1300517136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -78586,7 +77908,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298152512</BitOffs>
+            <BitOffs>1300534272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -78595,21 +77917,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160448</BitOffs>
+            <BitOffs>1300542208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -78618,21 +77930,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160456</BitOffs>
+            <BitOffs>1300542216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -78641,21 +77943,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160464</BitOffs>
+            <BitOffs>1300542224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -78678,7 +77970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160480</BitOffs>
+            <BitOffs>1300542240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -78691,7 +77983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160512</BitOffs>
+            <BitOffs>1300542272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -78704,7 +77996,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160576</BitOffs>
+            <BitOffs>1300542336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -78717,7 +78009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160592</BitOffs>
+            <BitOffs>1300542352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -78729,7 +78021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298173696</BitOffs>
+            <BitOffs>1300559488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -78738,21 +78030,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181632</BitOffs>
+            <BitOffs>1300567424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -78761,21 +78043,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181640</BitOffs>
+            <BitOffs>1300567432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -78784,21 +78056,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181648</BitOffs>
+            <BitOffs>1300567440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -78821,7 +78083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181664</BitOffs>
+            <BitOffs>1300567456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -78834,7 +78096,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181696</BitOffs>
+            <BitOffs>1300567488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -78847,7 +78109,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181760</BitOffs>
+            <BitOffs>1300567552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -78860,7 +78122,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181776</BitOffs>
+            <BitOffs>1300567568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -78872,7 +78134,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298194880</BitOffs>
+            <BitOffs>1300584704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -78881,21 +78143,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202816</BitOffs>
+            <BitOffs>1300592640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -78904,21 +78156,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202824</BitOffs>
+            <BitOffs>1300592648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -78927,21 +78169,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202832</BitOffs>
+            <BitOffs>1300592656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -78964,7 +78196,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202848</BitOffs>
+            <BitOffs>1300592672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -78977,7 +78209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202880</BitOffs>
+            <BitOffs>1300592704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -78990,7 +78222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202944</BitOffs>
+            <BitOffs>1300592768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -79003,7 +78235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202960</BitOffs>
+            <BitOffs>1300592784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -79015,7 +78247,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298216064</BitOffs>
+            <BitOffs>1300609920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -79024,21 +78256,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224000</BitOffs>
+            <BitOffs>1300617856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -79047,21 +78269,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224008</BitOffs>
+            <BitOffs>1300617864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -79070,21 +78282,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224016</BitOffs>
+            <BitOffs>1300617872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -79107,7 +78309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224032</BitOffs>
+            <BitOffs>1300617888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -79120,7 +78322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224064</BitOffs>
+            <BitOffs>1300617920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -79133,7 +78335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224128</BitOffs>
+            <BitOffs>1300617984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -79146,7 +78348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224144</BitOffs>
+            <BitOffs>1300618000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -79158,7 +78360,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298237248</BitOffs>
+            <BitOffs>1300635136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -79167,21 +78369,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245184</BitOffs>
+            <BitOffs>1300643072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -79190,21 +78382,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245192</BitOffs>
+            <BitOffs>1300643080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -79213,21 +78395,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245200</BitOffs>
+            <BitOffs>1300643088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -79250,7 +78422,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245216</BitOffs>
+            <BitOffs>1300643104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -79263,7 +78435,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245248</BitOffs>
+            <BitOffs>1300643136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -79276,7 +78448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245312</BitOffs>
+            <BitOffs>1300643200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -79289,7 +78461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245328</BitOffs>
+            <BitOffs>1300643216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -79301,7 +78473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298258432</BitOffs>
+            <BitOffs>1300660352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -79310,21 +78482,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266368</BitOffs>
+            <BitOffs>1300668288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -79333,21 +78495,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266376</BitOffs>
+            <BitOffs>1300668296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -79356,21 +78508,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266384</BitOffs>
+            <BitOffs>1300668304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -79393,7 +78535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266400</BitOffs>
+            <BitOffs>1300668320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -79406,7 +78548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266432</BitOffs>
+            <BitOffs>1300668352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -79419,7 +78561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266496</BitOffs>
+            <BitOffs>1300668416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -79432,7 +78574,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266512</BitOffs>
+            <BitOffs>1300668432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79444,7 +78586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298281152</BitOffs>
+            <BitOffs>1300687104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -79456,7 +78598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298607040</BitOffs>
+            <BitOffs>1301012992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -79465,21 +78607,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298614976</BitOffs>
+            <BitOffs>1301020928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -79488,21 +78620,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298614984</BitOffs>
+            <BitOffs>1301020936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -79511,21 +78633,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298614992</BitOffs>
+            <BitOffs>1301020944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -79548,7 +78660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298615008</BitOffs>
+            <BitOffs>1301020960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -79561,7 +78673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298615040</BitOffs>
+            <BitOffs>1301020992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -79574,7 +78686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298615104</BitOffs>
+            <BitOffs>1301021056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -79587,7 +78699,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298615120</BitOffs>
+            <BitOffs>1301021072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79599,7 +78711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629760</BitOffs>
+            <BitOffs>1301039744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -79611,7 +78723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298955648</BitOffs>
+            <BitOffs>1301365632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -79620,21 +78732,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963584</BitOffs>
+            <BitOffs>1301373568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -79643,21 +78745,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963592</BitOffs>
+            <BitOffs>1301373576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -79666,21 +78758,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963600</BitOffs>
+            <BitOffs>1301373584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -79703,7 +78785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963616</BitOffs>
+            <BitOffs>1301373600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -79716,7 +78798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963648</BitOffs>
+            <BitOffs>1301373632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -79729,7 +78811,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963712</BitOffs>
+            <BitOffs>1301373696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -79742,7 +78824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963728</BitOffs>
+            <BitOffs>1301373712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79754,7 +78836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298978368</BitOffs>
+            <BitOffs>1301392384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -79766,7 +78848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299304256</BitOffs>
+            <BitOffs>1301718272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -79775,21 +78857,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312192</BitOffs>
+            <BitOffs>1301726208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -79798,21 +78870,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312200</BitOffs>
+            <BitOffs>1301726216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -79821,21 +78883,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312208</BitOffs>
+            <BitOffs>1301726224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -79858,7 +78910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312224</BitOffs>
+            <BitOffs>1301726240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -79871,7 +78923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312256</BitOffs>
+            <BitOffs>1301726272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -79884,7 +78936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312320</BitOffs>
+            <BitOffs>1301726336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -79897,7 +78949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312336</BitOffs>
+            <BitOffs>1301726352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79909,7 +78961,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299326976</BitOffs>
+            <BitOffs>1301745024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -79921,7 +78973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299652864</BitOffs>
+            <BitOffs>1302070912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -79930,21 +78982,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660800</BitOffs>
+            <BitOffs>1302078848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -79953,21 +78995,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660808</BitOffs>
+            <BitOffs>1302078856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -79976,21 +79008,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660816</BitOffs>
+            <BitOffs>1302078864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -80013,7 +79035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660832</BitOffs>
+            <BitOffs>1302078880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -80026,7 +79048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660864</BitOffs>
+            <BitOffs>1302078912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -80039,7 +79061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660928</BitOffs>
+            <BitOffs>1302078976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -80052,7 +79074,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660944</BitOffs>
+            <BitOffs>1302078992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80064,7 +79086,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299675584</BitOffs>
+            <BitOffs>1302097664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -80076,7 +79098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300001472</BitOffs>
+            <BitOffs>1302423552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -80085,21 +79107,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009408</BitOffs>
+            <BitOffs>1302431488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -80108,21 +79120,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009416</BitOffs>
+            <BitOffs>1302431496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -80131,21 +79133,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009424</BitOffs>
+            <BitOffs>1302431504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -80168,7 +79160,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009440</BitOffs>
+            <BitOffs>1302431520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -80181,7 +79173,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009472</BitOffs>
+            <BitOffs>1302431552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -80194,7 +79186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009536</BitOffs>
+            <BitOffs>1302431616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -80207,7 +79199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009552</BitOffs>
+            <BitOffs>1302431632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80219,7 +79211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300024192</BitOffs>
+            <BitOffs>1302450304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -80231,7 +79223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300350080</BitOffs>
+            <BitOffs>1302776192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -80240,21 +79232,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358016</BitOffs>
+            <BitOffs>1302784128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -80263,21 +79245,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358024</BitOffs>
+            <BitOffs>1302784136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -80286,21 +79258,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358032</BitOffs>
+            <BitOffs>1302784144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -80323,7 +79285,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358048</BitOffs>
+            <BitOffs>1302784160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -80336,7 +79298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358080</BitOffs>
+            <BitOffs>1302784192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -80349,7 +79311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358144</BitOffs>
+            <BitOffs>1302784256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -80362,7 +79324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358160</BitOffs>
+            <BitOffs>1302784272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80374,7 +79336,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300372800</BitOffs>
+            <BitOffs>1302802944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -80386,7 +79348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300698688</BitOffs>
+            <BitOffs>1303128832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -80395,21 +79357,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706624</BitOffs>
+            <BitOffs>1303136768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -80418,21 +79370,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706632</BitOffs>
+            <BitOffs>1303136776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -80441,21 +79383,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706640</BitOffs>
+            <BitOffs>1303136784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -80478,7 +79410,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706656</BitOffs>
+            <BitOffs>1303136800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -80491,7 +79423,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706688</BitOffs>
+            <BitOffs>1303136832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -80504,7 +79436,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706752</BitOffs>
+            <BitOffs>1303136896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -80517,7 +79449,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706768</BitOffs>
+            <BitOffs>1303136912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80529,7 +79461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300721408</BitOffs>
+            <BitOffs>1303155584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -80541,7 +79473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301047296</BitOffs>
+            <BitOffs>1303481472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -80550,21 +79482,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055232</BitOffs>
+            <BitOffs>1303489408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -80573,21 +79495,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055240</BitOffs>
+            <BitOffs>1303489416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -80596,21 +79508,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055248</BitOffs>
+            <BitOffs>1303489424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -80633,7 +79535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055264</BitOffs>
+            <BitOffs>1303489440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -80646,7 +79548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055296</BitOffs>
+            <BitOffs>1303489472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -80659,7 +79561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055360</BitOffs>
+            <BitOffs>1303489536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -80672,7 +79574,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055376</BitOffs>
+            <BitOffs>1303489552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80684,7 +79586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301070016</BitOffs>
+            <BitOffs>1303508224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -80696,7 +79598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301395904</BitOffs>
+            <BitOffs>1303834112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -80705,21 +79607,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403840</BitOffs>
+            <BitOffs>1303842048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -80728,21 +79620,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403848</BitOffs>
+            <BitOffs>1303842056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -80751,21 +79633,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403856</BitOffs>
+            <BitOffs>1303842064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -80788,7 +79660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403872</BitOffs>
+            <BitOffs>1303842080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -80801,7 +79673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403904</BitOffs>
+            <BitOffs>1303842112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -80814,7 +79686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403968</BitOffs>
+            <BitOffs>1303842176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -80827,7 +79699,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403984</BitOffs>
+            <BitOffs>1303842192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80839,7 +79711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301418624</BitOffs>
+            <BitOffs>1303860864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -80851,7 +79723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301744512</BitOffs>
+            <BitOffs>1304186752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -80860,21 +79732,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752448</BitOffs>
+            <BitOffs>1304194688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -80883,21 +79745,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752456</BitOffs>
+            <BitOffs>1304194696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -80906,21 +79758,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752464</BitOffs>
+            <BitOffs>1304194704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -80943,7 +79785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752480</BitOffs>
+            <BitOffs>1304194720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -80956,7 +79798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752512</BitOffs>
+            <BitOffs>1304194752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -80969,7 +79811,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752576</BitOffs>
+            <BitOffs>1304194816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -80982,7 +79824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752592</BitOffs>
+            <BitOffs>1304194832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80994,7 +79836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301767232</BitOffs>
+            <BitOffs>1304213504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -81006,7 +79848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302093120</BitOffs>
+            <BitOffs>1304539392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -81015,21 +79857,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101056</BitOffs>
+            <BitOffs>1304547328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -81038,21 +79870,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101064</BitOffs>
+            <BitOffs>1304547336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -81061,21 +79883,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101072</BitOffs>
+            <BitOffs>1304547344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -81098,7 +79910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101088</BitOffs>
+            <BitOffs>1304547360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -81111,7 +79923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101120</BitOffs>
+            <BitOffs>1304547392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -81124,7 +79936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101184</BitOffs>
+            <BitOffs>1304547456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -81137,7 +79949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101200</BitOffs>
+            <BitOffs>1304547472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81149,7 +79961,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302115840</BitOffs>
+            <BitOffs>1304566144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -81161,7 +79973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302441728</BitOffs>
+            <BitOffs>1304892032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -81170,21 +79982,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449664</BitOffs>
+            <BitOffs>1304899968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -81193,21 +79995,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449672</BitOffs>
+            <BitOffs>1304899976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -81216,21 +80008,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449680</BitOffs>
+            <BitOffs>1304899984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -81253,7 +80035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449696</BitOffs>
+            <BitOffs>1304900000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -81266,7 +80048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449728</BitOffs>
+            <BitOffs>1304900032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -81279,7 +80061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449792</BitOffs>
+            <BitOffs>1304900096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -81292,7 +80074,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449808</BitOffs>
+            <BitOffs>1304900112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81304,29 +80086,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302464448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.sio_load</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302789248</BitOffs>
+            <BitOffs>1304918784</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -81337,7 +80104,19 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273036480</BitOffs>
+            <BitOffs>1275470208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1275805184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower01</Name>
@@ -81363,7 +80142,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273369872</BitOffs>
+            <BitOffs>1276136448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower02</Name>
@@ -81388,19 +80167,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273369880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1273371520</BitOffs>
+            <BitOffs>1276136456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower03</Name>
@@ -81425,7 +80192,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273697632</BitOffs>
+            <BitOffs>1276136464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bLEDPower04</Name>
@@ -81450,7 +80217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273697640</BitOffs>
+            <BitOffs>1276136472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nMR1K1_Y_ENC_PMPS</Name>
@@ -81467,7 +80234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1273702784</BitOffs>
+            <BitOffs>1276136480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81479,7 +80246,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1281555520</BitOffs>
+            <BitOffs>1283989248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81491,7 +80258,79 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1281890496</BitOffs>
+            <BitOffs>1284324224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284659200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284986624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285314048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285641472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285968896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286296320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower01</Name>
@@ -81516,7 +80355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223888</BitOffs>
+            <BitOffs>1286624704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower02</Name>
@@ -81541,7 +80380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223896</BitOffs>
+            <BitOffs>1286624712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower03</Name>
@@ -81566,7 +80405,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223904</BitOffs>
+            <BitOffs>1286624720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bFanOn</Name>
@@ -81590,7 +80429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223912</BitOffs>
+            <BitOffs>1286624728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bLEDPower</Name>
@@ -81615,79 +80454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282223920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282225536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282552960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282880384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283207808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283535232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283862656</BitOffs>
+            <BitOffs>1286624736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81699,7 +80466,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284383744</BitOffs>
+            <BitOffs>1286687808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81711,7 +80478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284711168</BitOffs>
+            <BitOffs>1287015232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81723,7 +80490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285038592</BitOffs>
+            <BitOffs>1287342656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81735,7 +80502,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285366016</BitOffs>
+            <BitOffs>1287670080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81747,7 +80514,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285693440</BitOffs>
+            <BitOffs>1287997504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.iIlluminatorINT</Name>
@@ -81759,7 +80526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714816</BitOffs>
+            <BitOffs>1289019136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.bGigePower</Name>
@@ -81779,7 +80546,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714832</BitOffs>
+            <BitOffs>1289019152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbSetIllPercent.iRaw</Name>
@@ -81792,7 +80559,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286715904</BitOffs>
+            <BitOffs>1289020224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81804,7 +80571,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286718528</BitOffs>
+            <BitOffs>1289022848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -81820,7 +80587,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287048288</BitOffs>
+            <BitOffs>1289352608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -81840,7 +80607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293425896</BitOffs>
+            <BitOffs>1295730984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -81860,7 +80627,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293950248</BitOffs>
+            <BitOffs>1296255336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -81872,7 +80639,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294474752</BitOffs>
+            <BitOffs>1296779904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -81881,21 +80648,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294483736</BitOffs>
+            <BitOffs>1296788888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81907,7 +80664,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294497472</BitOffs>
+            <BitOffs>1296806656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -81919,7 +80676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294823360</BitOffs>
+            <BitOffs>1297132544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -81928,21 +80685,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294832344</BitOffs>
+            <BitOffs>1297141528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81954,7 +80701,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294846080</BitOffs>
+            <BitOffs>1297159296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -81966,7 +80713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295171968</BitOffs>
+            <BitOffs>1297485184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -81975,21 +80722,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295180952</BitOffs>
+            <BitOffs>1297494168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82001,7 +80738,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295194688</BitOffs>
+            <BitOffs>1297511936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -82013,7 +80750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295520576</BitOffs>
+            <BitOffs>1297837824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -82022,21 +80759,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295529560</BitOffs>
+            <BitOffs>1297846808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82048,7 +80775,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295543296</BitOffs>
+            <BitOffs>1297864576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -82060,7 +80787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295869184</BitOffs>
+            <BitOffs>1298190464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -82069,21 +80796,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295878168</BitOffs>
+            <BitOffs>1298199448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -82095,7 +80812,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295890368</BitOffs>
+            <BitOffs>1298215680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -82104,21 +80821,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295899352</BitOffs>
+            <BitOffs>1298224664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -82130,7 +80837,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295911552</BitOffs>
+            <BitOffs>1298240896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -82139,21 +80846,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295920536</BitOffs>
+            <BitOffs>1298249880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -82165,7 +80862,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295932736</BitOffs>
+            <BitOffs>1298266112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -82174,21 +80871,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295941720</BitOffs>
+            <BitOffs>1298275096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -82200,7 +80887,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295953920</BitOffs>
+            <BitOffs>1298291328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -82209,21 +80896,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295962904</BitOffs>
+            <BitOffs>1298300312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -82235,7 +80912,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295975104</BitOffs>
+            <BitOffs>1298316544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -82244,21 +80921,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295984088</BitOffs>
+            <BitOffs>1298325528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -82270,7 +80937,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295996288</BitOffs>
+            <BitOffs>1298341760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -82279,21 +80946,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296005272</BitOffs>
+            <BitOffs>1298350744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -82305,7 +80962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296017472</BitOffs>
+            <BitOffs>1298366976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -82314,21 +80971,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296026456</BitOffs>
+            <BitOffs>1298375960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82340,7 +80987,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296040192</BitOffs>
+            <BitOffs>1298393728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -82352,7 +80999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296366080</BitOffs>
+            <BitOffs>1298719616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -82361,21 +81008,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296375064</BitOffs>
+            <BitOffs>1298728600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82387,7 +81024,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296388800</BitOffs>
+            <BitOffs>1298746368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -82399,7 +81036,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296714688</BitOffs>
+            <BitOffs>1299072256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -82408,21 +81045,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296723672</BitOffs>
+            <BitOffs>1299081240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82434,7 +81061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296737408</BitOffs>
+            <BitOffs>1299099008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -82446,7 +81073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297063296</BitOffs>
+            <BitOffs>1299424896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -82455,21 +81082,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297072280</BitOffs>
+            <BitOffs>1299433880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82481,7 +81098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297086016</BitOffs>
+            <BitOffs>1299451648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -82493,7 +81110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297411904</BitOffs>
+            <BitOffs>1299777536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -82502,21 +81119,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297420888</BitOffs>
+            <BitOffs>1299786520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -82528,7 +81135,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297433088</BitOffs>
+            <BitOffs>1299802752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -82537,21 +81144,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297442072</BitOffs>
+            <BitOffs>1299811736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82563,7 +81160,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297455808</BitOffs>
+            <BitOffs>1299829504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -82575,7 +81172,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297781696</BitOffs>
+            <BitOffs>1300155392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -82584,21 +81181,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297790680</BitOffs>
+            <BitOffs>1300164376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82610,7 +81197,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297804416</BitOffs>
+            <BitOffs>1300182144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -82622,7 +81209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298130304</BitOffs>
+            <BitOffs>1300508032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -82631,21 +81218,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298139288</BitOffs>
+            <BitOffs>1300517016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -82657,7 +81234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298151488</BitOffs>
+            <BitOffs>1300533248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -82666,21 +81243,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298160472</BitOffs>
+            <BitOffs>1300542232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -82692,7 +81259,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298172672</BitOffs>
+            <BitOffs>1300558464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -82701,21 +81268,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298181656</BitOffs>
+            <BitOffs>1300567448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -82727,7 +81284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298193856</BitOffs>
+            <BitOffs>1300583680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -82736,21 +81293,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298202840</BitOffs>
+            <BitOffs>1300592664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -82762,7 +81309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298215040</BitOffs>
+            <BitOffs>1300608896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -82771,21 +81318,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224024</BitOffs>
+            <BitOffs>1300617880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -82797,7 +81334,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298236224</BitOffs>
+            <BitOffs>1300634112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -82806,21 +81343,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298245208</BitOffs>
+            <BitOffs>1300643096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -82832,7 +81359,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298257408</BitOffs>
+            <BitOffs>1300659328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -82841,21 +81368,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266392</BitOffs>
+            <BitOffs>1300668312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82867,7 +81384,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298280128</BitOffs>
+            <BitOffs>1300686080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -82879,7 +81396,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298606016</BitOffs>
+            <BitOffs>1301011968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -82888,21 +81405,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298615000</BitOffs>
+            <BitOffs>1301020952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82914,7 +81421,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298628736</BitOffs>
+            <BitOffs>1301038720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -82926,7 +81433,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298954624</BitOffs>
+            <BitOffs>1301364608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -82935,21 +81442,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298963608</BitOffs>
+            <BitOffs>1301373592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82961,7 +81458,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298977344</BitOffs>
+            <BitOffs>1301391360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -82973,7 +81470,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299303232</BitOffs>
+            <BitOffs>1301717248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -82982,21 +81479,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299312216</BitOffs>
+            <BitOffs>1301726232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83008,7 +81495,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299325952</BitOffs>
+            <BitOffs>1301744000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -83020,7 +81507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299651840</BitOffs>
+            <BitOffs>1302069888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -83029,21 +81516,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299660824</BitOffs>
+            <BitOffs>1302078872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83055,7 +81532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299674560</BitOffs>
+            <BitOffs>1302096640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -83067,7 +81544,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300000448</BitOffs>
+            <BitOffs>1302422528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -83076,21 +81553,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300009432</BitOffs>
+            <BitOffs>1302431512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83102,7 +81569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300023168</BitOffs>
+            <BitOffs>1302449280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -83114,7 +81581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300349056</BitOffs>
+            <BitOffs>1302775168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -83123,21 +81590,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300358040</BitOffs>
+            <BitOffs>1302784152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83149,7 +81606,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300371776</BitOffs>
+            <BitOffs>1302801920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -83161,7 +81618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300697664</BitOffs>
+            <BitOffs>1303127808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -83170,21 +81627,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706648</BitOffs>
+            <BitOffs>1303136792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83196,7 +81643,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300720384</BitOffs>
+            <BitOffs>1303154560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -83208,7 +81655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301046272</BitOffs>
+            <BitOffs>1303480448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -83217,21 +81664,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301055256</BitOffs>
+            <BitOffs>1303489432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83243,7 +81680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301068992</BitOffs>
+            <BitOffs>1303507200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -83255,7 +81692,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301394880</BitOffs>
+            <BitOffs>1303833088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -83264,21 +81701,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301403864</BitOffs>
+            <BitOffs>1303842072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83290,7 +81717,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301417600</BitOffs>
+            <BitOffs>1303859840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -83302,7 +81729,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301743488</BitOffs>
+            <BitOffs>1304185728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -83311,21 +81738,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301752472</BitOffs>
+            <BitOffs>1304194712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83337,7 +81754,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301766208</BitOffs>
+            <BitOffs>1304212480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -83349,7 +81766,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302092096</BitOffs>
+            <BitOffs>1304538368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -83358,21 +81775,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302101080</BitOffs>
+            <BitOffs>1304547352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83384,7 +81791,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302114816</BitOffs>
+            <BitOffs>1304565120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -83396,7 +81803,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302440704</BitOffs>
+            <BitOffs>1304891008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -83405,21 +81812,11 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449688</BitOffs>
+            <BitOffs>1304899992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -83431,14 +81828,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302463424</BitOffs>
+            <BitOffs>1304917760</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -89096,13 +87493,10 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>625205728</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <Name>MOTION_GVL.nMaxStateMotorCount</Name>
+            <Comment> Debug, records the highest number of motors used in an ND states block in the PLC. Can be used to limit MotionConstants.MAX_STATE_MOTORS to save on memory usage and PV count.</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -89198,7 +87592,39 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>633593024</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>MOTION_GVL.nMaxStates</Name>
+            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633593312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
+            <Comment>
+    Arbitary cap on multidimensional states to simplify statements for the compiler.
+    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
+    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
+    </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633593328</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>MOTION_GVL.fbPmpsFileReader</Name>
+            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
             <BitSize>935616</BitSize>
             <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
             <Properties>
@@ -89210,6 +87636,7 @@ Emergency Stop for MR1K1</Comment>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
             <BitSize>30144</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
             <Properties>
@@ -89316,7 +87743,21 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634563744</BitOffs>
+            <BitOffs>634563840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634563872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -89330,7 +87771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634563840</BitOffs>
+            <BitOffs>634563904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -89338,20 +87779,6 @@ Emergency Stop for MR1K1</Comment>
             <BaseType>LREAL</BaseType>
             <Default>
               <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634563904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
             </Default>
             <Properties>
               <Property>
@@ -89373,7 +87800,22 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634564000</BitOffs>
+            <BitOffs>634564032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634564064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -89387,7 +87829,68 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634564032</BitOffs>
+            <BitOffs>634564080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634564096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634564160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634565920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -89412,68 +87915,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634564048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stAttenuators</Name>
-            <BitSize>64</BitSize>
-            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.xAttOK</Name>
-                <Value>1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634564064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634564128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cst0RateBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)0RateBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC 0-rate beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634565888</BitOffs>
+            <BitOffs>634567680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -89488,21 +87930,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634567648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_cBoundaries</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>31</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634567664</BitOffs>
+            <BitOffs>634567696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -89521,7 +87949,36 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634567680</BitOffs>
+            <BitOffs>634567712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>31</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634568736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <Comment> Max fast faults for an FFO</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634568752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -89548,7 +88005,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634568704</BitOffs>
+            <BitOffs>634568768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -89703,7 +88160,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634568736</BitOffs>
+            <BitOffs>634568800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -89858,36 +88315,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634569760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
-            <Comment> Max fast faults for an FFO</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>50</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634570784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>1000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634570800</BitOffs>
+            <BitOffs>634569824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -89902,7 +88330,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634570816</BitOffs>
+            <BitOffs>634570848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -89917,7 +88345,35 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634570848</BitOffs>
+            <BitOffs>634570880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634570912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634570928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -89928,7 +88384,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634570880</BitOffs>
+            <BitOffs>634570944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -89964,21 +88420,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634571264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634571552</BitOffs>
+            <BitOffs>634571328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -89992,7 +88434,34 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634571568</BitOffs>
+            <BitOffs>634571616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
+            <Comment> Enable (TRUE) or disable (FALSE) publishing of the xUnit Xml report </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634571632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
+            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634571640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -90003,7 +88472,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634571584</BitOffs>
+            <BitOffs>634571648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -90017,7 +88486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634578688</BitOffs>
+            <BitOffs>634578752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -90031,7 +88500,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634578752</BitOffs>
+            <BitOffs>634578816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -90067,34 +88536,37 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634578816</BitOffs>
+            <BitOffs>634578880</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
-            <Comment> Enable (TRUE) or disable (FALSE) publishing of the xUnit Xml report </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
+            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
             <Default>
-              <Bool>false</Bool>
+              <Value>65535</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634579104</BitOffs>
+            <BitOffs>634579168</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
-            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
+            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Default>
+              <String>C:\tcunit_xunit_testresults.xml</String>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634579112</BitOffs>
+            <BitOffs>634579200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -90112,37 +88584,33 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634579120</BitOffs>
+            <BitOffs>634581248</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
-            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>65535</Value>
-            </Default>
+            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
+            <Comment> Whether or not the current test being called has finished running </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634579136</BitOffs>
+            <BitOffs>634581264</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
-            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Default>
-              <String>C:\tcunit_xunit_testresults.xml</String>
-            </Default>
+            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
+            <Comment> This is a flag that indicates that the current test should be ignored, and
+       thus that all assertions under it should be ignored as well. A test can be ignored either
+       because the user has requested so, or because the test is a duplicate name </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634579168</BitOffs>
+            <BitOffs>634581272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -90158,7 +88626,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634581216</BitOffs>
+            <BitOffs>634581280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
@@ -90169,7 +88637,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634581248</BitOffs>
+            <BitOffs>634581312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -90181,7 +88649,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256409728</BitOffs>
+            <BitOffs>1256409792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -90193,33 +88661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256409792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
-            <Comment> Whether or not the current test being called has finished running </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1256411840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
-            <Comment> This is a flag that indicates that the current test should be ignored, and
-       thus that all assertions under it should be ignored as well. A test can be ignored either
-       because the user has requested so, or because the test is a duplicate name </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1256411848</BitOffs>
+            <BitOffs>1256409856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -90235,7 +88677,21 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256411856</BitOffs>
+            <BitOffs>1256411904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.nCTRL_LOGGER_DATA_ARRAY_SIZE</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1256411920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoRange</Name>
@@ -90250,7 +88706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256411872</BitOffs>
+            <BitOffs>1256411936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -90265,7 +88721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256411904</BitOffs>
+            <BitOffs>1256411968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -90283,7 +88739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256475904</BitOffs>
+            <BitOffs>1256475968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -90295,7 +88751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1256491904</BitOffs>
+            <BitOffs>1256491968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -90331,21 +88787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264813056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.nCTRL_LOGGER_DATA_ARRAY_SIZE</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1264813344</BitOffs>
+            <BitOffs>1264813120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
@@ -90360,7 +88802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264813376</BitOffs>
+            <BitOffs>1264813440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -90375,7 +88817,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264813440</BitOffs>
+            <BitOffs>1264813504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -90390,12 +88832,12 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264813504</BitOffs>
+            <BitOffs>1264813568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -90419,10 +88861,10 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264813568</BitOffs>
+            <BitOffs>1264813632</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics_nrw</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
             <Default>
@@ -90432,11 +88874,11 @@ Emergency Stop for MR1K1</Comment>
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>6</Value>
+                <Value>0</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>1</Value>
+                <Value>0</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -90448,7 +88890,7 @@ Emergency Stop for MR1K1</Comment>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>0.6.1</String>
+                <String>0.0.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -90459,7 +88901,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264816064</BitOffs>
+            <BitOffs>1264816128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ControllerToolbox</Name>
@@ -90499,43 +88941,55 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264816352</BitOffs>
+            <BitOffs>1264816416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.stCtrl_GLOBAL_CycleTimeInterpretation</Name>
             <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1264816640</BitOffs>
+            <BitOffs>1264816704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
             <Comment> Temp testing</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1264936272</BitOffs>
+            <BitOffs>1265711360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1264936288</BitOffs>
+            <BitOffs>1265711376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1264936304</BitOffs>
+            <BitOffs>1265711392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>1265711408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>1265711416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265827136</BitOffs>
+            <BitOffs>1265827200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -90548,26 +89002,46 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265827264</BitOffs>
+            <BitOffs>1265827328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
             <BitSize>5798336</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>1265833152</BitOffs>
+            <BitOffs>1265833216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.fMpiEncoderPosDiff</Name>
             <Comment> SP1K1 Mirror Pitch Mono Vibration Stats</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1271647744</BitOffs>
+            <BitOffs>1272929856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afMpiPosDiffBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1272929920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_Stats.afMpiExtraBuffer</Name>
+            <BitSize>640000</BitSize>
+            <BaseType>LREAL</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>10000</Elements>
+            </ArrayInfo>
+            <BitOffs>1273569920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.fbMpiPosDiffCollect</Name>
             <BitSize>448</BitSize>
             <BaseType Namespace="LCLS_General">FB_DataBuffer</BaseType>
-            <BitOffs>1271711808</BitOffs>
+            <BitOffs>1274209920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_Stats.fbMpiPosDiffStats</Name>
@@ -90581,12 +89055,12 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1271712256</BitOffs>
+            <BitOffs>1274210368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.M1K1</Name>
             <BitSize>23552</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">DUT_HOMS</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -90604,13 +89078,13 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1271785472</BitOffs>
+            <BitOffs>1274219200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbYRMSErrorM1K1</Name>
             <Comment> Encoder Arrays/RMS Watch:</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -90619,24 +89093,24 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1271809024</BitOffs>
+            <BitOffs>1274242752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxYRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272196544</BitOffs>
+            <BitOffs>1274630272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMinYRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272196608</BitOffs>
+            <BitOffs>1274630336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbXRMSErrorM1K1</Name>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -90645,24 +89119,24 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1272196672</BitOffs>
+            <BitOffs>1274630400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxXRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272584192</BitOffs>
+            <BitOffs>1275017920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMinXRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272584256</BitOffs>
+            <BitOffs>1275017984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbPitchRMSErrorM1K1</Name>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -90671,38 +89145,35 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1272584320</BitOffs>
+            <BitOffs>1275018048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxPitchRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272971840</BitOffs>
+            <BitOffs>1275405568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMinPitchRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1272971904</BitOffs>
+            <BitOffs>1275405632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1272971968</BitOffs>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PitchControl</BaseType>
+            <BitOffs>1275405696</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>1273369856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>1273369864</BitOffs>
+            <Name>PRG_MR1K1_BEND.fbMotionStage_m16</Name>
+            <Comment> 3-15-20 Having issues with pitch control on new Axilon systems (M1K2)
+ Should test on this one to see if common to all new systems
+ Using stepper only for now</Comment>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <BitOffs>1275803584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntYupM1K1</Name>
@@ -90719,16 +89190,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273369888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbMotionStage_m16</Name>
-            <Comment> 3-15-20 Having issues with pitch control on new Axilon systems (M1K2)
- Should test on this one to see if common to all new systems
- Using stepper only for now</Comment>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1273369920</BitOffs>
+            <BitOffs>1276131008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntYdwnM1K1</Name>
@@ -90744,7 +89206,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697344</BitOffs>
+            <BitOffs>1276131040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntXupM1K1</Name>
@@ -90760,7 +89222,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697376</BitOffs>
+            <BitOffs>1276131072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntXdwnM1K1</Name>
@@ -90776,7 +89238,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697408</BitOffs>
+            <BitOffs>1276131104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntPitchM1K1</Name>
@@ -90792,7 +89254,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697440</BitOffs>
+            <BitOffs>1276131136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefYupM1K1</Name>
@@ -90809,7 +89271,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697472</BitOffs>
+            <BitOffs>1276131168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefYdwnM1K1</Name>
@@ -90825,7 +89287,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697504</BitOffs>
+            <BitOffs>1276131200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefXupM1K1</Name>
@@ -90841,7 +89303,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697536</BitOffs>
+            <BitOffs>1276131232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefXdwnM1K1</Name>
@@ -90857,7 +89319,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697568</BitOffs>
+            <BitOffs>1276131264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncRefPitchM1K1</Name>
@@ -90873,20 +89335,20 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273697600</BitOffs>
+            <BitOffs>1276131296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.mcReadParameterPitchM1K1</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1273697664</BitOffs>
+            <BitOffs>1276131328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fEncRefPitchM1K1_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1273702656</BitOffs>
+            <BitOffs>1276136320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fEncLeverArm_mm</Name>
@@ -90896,7 +89358,7 @@ Emergency Stop for MR1K1</Comment>
             <Default>
               <Value>410</Value>
             </Default>
-            <BitOffs>1273702720</BitOffs>
+            <BitOffs>1276136384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncRefBendUSM1K1</Name>
@@ -90914,7 +89376,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273702816</BitOffs>
+            <BitOffs>1276136544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_1</Name>
@@ -90927,7 +89389,7 @@ MR1K1 BEND US ENC REF</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1273702848</BitOffs>
+            <BitOffs>1276136576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_1_val</Name>
@@ -90943,7 +89405,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273703360</BitOffs>
+            <BitOffs>1276137088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_2</Name>
@@ -90955,7 +89417,7 @@ MR1K1 BEND US ENC REF</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1273703424</BitOffs>
+            <BitOffs>1276137152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Flow_2_val</Name>
@@ -90971,7 +89433,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273703936</BitOffs>
+            <BitOffs>1276137664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Press_1</Name>
@@ -90983,7 +89445,7 @@ MR1K1 BEND US ENC REF</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1273704000</BitOffs>
+            <BitOffs>1276137728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fM1K1_Press_1_val</Name>
@@ -90999,14 +89461,14 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273704512</BitOffs>
+            <BitOffs>1276138240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
             <Comment> Encoder Arrays/RMS Watch:
 MR1K1 US BENDER ENC RMS</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -91015,25 +89477,25 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1273704576</BitOffs>
+            <BitOffs>1276138304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1274092096</BitOffs>
+            <BitOffs>1276525824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMinBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1274092160</BitOffs>
+            <BitOffs>1276525888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
             <Comment>MR1K1 DS BENDER ENC RMS</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -91042,19 +89504,19 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274092224</BitOffs>
+            <BitOffs>1276525952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendDSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1274479744</BitOffs>
+            <BitOffs>1276913472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMinBendDSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1274479808</BitOffs>
+            <BitOffs>1276913536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncRefBendDSM1K1</Name>
@@ -91071,7 +89533,7 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274479872</BitOffs>
+            <BitOffs>1276913600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncCntBendUSM1K1</Name>
@@ -91089,7 +89551,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274479904</BitOffs>
+            <BitOffs>1276913632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncCntBendDSM1K1</Name>
@@ -91106,7 +89568,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274479936</BitOffs>
+            <BitOffs>1276913664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_1</Name>
@@ -91125,7 +89587,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274480000</BitOffs>
+            <BitOffs>1276913696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_2</Name>
@@ -91142,7 +89604,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274480032</BitOffs>
+            <BitOffs>1276913728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_3</Name>
@@ -91159,7 +89621,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274480064</BitOffs>
+            <BitOffs>1276913760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_1</Name>
@@ -91177,7 +89639,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274480096</BitOffs>
+            <BitOffs>1276913792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_2</Name>
@@ -91194,7 +89656,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274480128</BitOffs>
+            <BitOffs>1276913824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_3</Name>
@@ -91211,32 +89673,32 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1274480160</BitOffs>
+            <BitOffs>1276913856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorMR1K1</Name>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
-            <BitOffs>1274480224</BitOffs>
+            <BitOffs>1276913936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1274480240</BitOffs>
+            <BitOffs>1276913952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1274480248</BitOffs>
+            <BitOffs>1276913960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbLogHandler</Name>
             <Comment> Logging</Comment>
             <BitSize>5798336</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>1274480256</BitOffs>
+            <BitOffs>1276913984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.ffBenderRange</Name>
@@ -91261,12 +89723,12 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>1026</Value>
               </SubItem>
             </Default>
-            <BitOffs>1280278592</BitOffs>
+            <BitOffs>1282712320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2</Name>
             <BitSize>23552</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">DUT_HOMS</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -91284,13 +89746,13 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280304512</BitOffs>
+            <BitOffs>1282738240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
             <Comment> Encoder Arrays/RMS Watch:</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -91299,24 +89761,24 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280328064</BitOffs>
+            <BitOffs>1282761792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1280715584</BitOffs>
+            <BitOffs>1283149312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1280715648</BitOffs>
+            <BitOffs>1283149376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -91325,24 +89787,24 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1280715712</BitOffs>
+            <BitOffs>1283149440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281103232</BitOffs>
+            <BitOffs>1283536960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281103296</BitOffs>
+            <BitOffs>1283537024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -91351,26 +89813,26 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1281103360</BitOffs>
+            <BitOffs>1283537088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281490880</BitOffs>
+            <BitOffs>1283924608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281490944</BitOffs>
+            <BitOffs>1283924672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1281491008</BitOffs>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PitchControl</BaseType>
+            <BitOffs>1283924736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -91378,7 +89840,7 @@ M1K1 BEND US ENC CNT</Comment>
  Using stepper only for now</Comment>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1281888896</BitOffs>
+            <BitOffs>1284322624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fYRoll_urad</Name>
@@ -91395,7 +89857,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216320</BitOffs>
+            <BitOffs>1284650048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYleftM1K2</Name>
@@ -91412,7 +89874,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216384</BitOffs>
+            <BitOffs>1284650112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYrightM1K2</Name>
@@ -91428,7 +89890,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216416</BitOffs>
+            <BitOffs>1284650144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXupM1K2</Name>
@@ -91444,7 +89906,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216448</BitOffs>
+            <BitOffs>1284650176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXdwnM1K2</Name>
@@ -91460,7 +89922,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216480</BitOffs>
+            <BitOffs>1284650208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntPitchM1K2</Name>
@@ -91476,7 +89938,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216512</BitOffs>
+            <BitOffs>1284650240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYleftM1K2</Name>
@@ -91493,7 +89955,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216544</BitOffs>
+            <BitOffs>1284650272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYrightM1K2</Name>
@@ -91509,7 +89971,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216576</BitOffs>
+            <BitOffs>1284650304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXupM1K2</Name>
@@ -91525,7 +89987,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216608</BitOffs>
+            <BitOffs>1284650336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXdwnM1K2</Name>
@@ -91541,7 +90003,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216640</BitOffs>
+            <BitOffs>1284650368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefPitchM1K2</Name>
@@ -91557,20 +90019,20 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282216672</BitOffs>
+            <BitOffs>1284650400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.mcReadParameterPitchM1K2</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1282216704</BitOffs>
+            <BitOffs>1284650432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncRefPitchM1K2_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282221696</BitOffs>
+            <BitOffs>1284655424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncLeverArm_mm</Name>
@@ -91580,7 +90042,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>391</Value>
             </Default>
-            <BitOffs>1282221760</BitOffs>
+            <BitOffs>1284655488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1</Name>
@@ -91593,7 +90055,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1282221824</BitOffs>
+            <BitOffs>1284655552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1_val</Name>
@@ -91609,7 +90071,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282222336</BitOffs>
+            <BitOffs>1284656064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2</Name>
@@ -91621,7 +90083,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1282222400</BitOffs>
+            <BitOffs>1284656128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2_val</Name>
@@ -91637,7 +90099,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282222912</BitOffs>
+            <BitOffs>1284656640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1</Name>
@@ -91649,7 +90111,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1282222976</BitOffs>
+            <BitOffs>1284656704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1_val</Name>
@@ -91665,52 +90127,43 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282223488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SL1K2_EXIT.bInit</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <BitOffs>1282223928</BitOffs>
+            <BitOffs>1284657216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1282223936</BitOffs>
+            <BitOffs>1284657600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1282551360</BitOffs>
+            <BitOffs>1284985024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1282878784</BitOffs>
+            <BitOffs>1285312448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283206208</BitOffs>
+            <BitOffs>1285639872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283533632</BitOffs>
+            <BitOffs>1285967296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283861056</BitOffs>
+            <BitOffs>1286294720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upeurad</Name>
@@ -91725,7 +90178,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284188736</BitOffs>
+            <BitOffs>1286622400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upeurad</Name>
@@ -91740,7 +90193,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284188800</BitOffs>
+            <BitOffs>1286622464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1</Name>
@@ -91763,7 +90216,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E13]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284188864</BitOffs>
+            <BitOffs>1286622528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2</Name>
@@ -91785,7 +90238,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E13]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189120</BitOffs>
+            <BitOffs>1286622784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3</Name>
@@ -91807,7 +90260,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189376</BitOffs>
+            <BitOffs>1286623040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4</Name>
@@ -91829,7 +90282,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189632</BitOffs>
+            <BitOffs>1286623296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5</Name>
@@ -91851,7 +90304,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284189888</BitOffs>
+            <BitOffs>1286623552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6</Name>
@@ -91873,7 +90326,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190144</BitOffs>
+            <BitOffs>1286623808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7</Name>
@@ -91895,7 +90348,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190400</BitOffs>
+            <BitOffs>1286624064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8</Name>
@@ -91917,7 +90370,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1284190656</BitOffs>
+            <BitOffs>1286624320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_read</Name>
@@ -91933,7 +90386,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284190912</BitOffs>
+            <BitOffs>1286624576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_set</Name>
@@ -91948,7 +90401,48 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284190976</BitOffs>
+            <BitOffs>1286624640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SL1K2_EXIT.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <BitOffs>1286624744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)SafeBenderRange
+        field: ZNAM FALSE
+        field: ONAM TRUE
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)LRG_Grating_IN
+        field: ZNAM FALSE
+        field: ONAM TRUE
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_FFO</Name>
@@ -91968,7 +90462,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>4368</Value>
               </SubItem>
             </Default>
-            <BitOffs>1284191040</BitOffs>
+            <BitOffs>1286624768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_e_pmps</Name>
@@ -91977,7 +90471,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>74000.29</Value>
             </Default>
-            <BitOffs>1284216960</BitOffs>
+            <BitOffs>1286650688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1</Name>
@@ -91990,7 +90484,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1284217024</BitOffs>
+            <BitOffs>1286650752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1_val</Name>
@@ -92006,7 +90500,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284217536</BitOffs>
+            <BitOffs>1286651264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2</Name>
@@ -92018,7 +90512,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1284217600</BitOffs>
+            <BitOffs>1286651328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2_val</Name>
@@ -92034,7 +90528,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284218112</BitOffs>
+            <BitOffs>1286651840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1</Name>
@@ -92046,7 +90540,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1284218176</BitOffs>
+            <BitOffs>1286651904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1_val</Name>
@@ -92062,7 +90556,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284218688</BitOffs>
+            <BitOffs>1286652416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -92082,41 +90576,41 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>3664</Value>
               </SubItem>
             </Default>
-            <BitOffs>1284356224</BitOffs>
+            <BitOffs>1286660288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284382144</BitOffs>
+            <BitOffs>1286686208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284709568</BitOffs>
+            <BitOffs>1287013632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285036992</BitOffs>
+            <BitOffs>1287341056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285364416</BitOffs>
+            <BitOffs>1287668480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285691840</BitOffs>
+            <BitOffs>1287995904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbStates</Name>
-            <BitSize>694464</BitSize>
+            <BitSize>694720</BitSize>
             <BaseType>FB_XS_YAG_States</BaseType>
             <Properties>
               <Property>
@@ -92127,7 +90621,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286019264</BitOffs>
+            <BitOffs>1288323328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP</Name>
@@ -92148,7 +90642,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_1]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286713728</BitOffs>
+            <BitOffs>1289018048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM</Name>
@@ -92169,7 +90663,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_2]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286713984</BitOffs>
+            <BitOffs>1289018304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG</Name>
@@ -92190,7 +90684,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_4]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714240</BitOffs>
+            <BitOffs>1289018560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync</Name>
@@ -92211,7 +90705,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_3]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714496</BitOffs>
+            <BitOffs>1289018816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige</Name>
@@ -92230,7 +90724,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bGigePower := TIIB[EL2004_SL1K2]^Channel 3^Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286714752</BitOffs>
+            <BitOffs>1289019072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter</Name>
@@ -92260,7 +90754,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3052_SL1K2_FWM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1286716096</BitOffs>
+            <BitOffs>1289020416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fSmallDelta</Name>
@@ -92270,7 +90764,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.01</Value>
             </Default>
-            <BitOffs>1286716608</BitOffs>
+            <BitOffs>1289020928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fBigDelta</Name>
@@ -92279,7 +90773,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>10</Value>
             </Default>
-            <BitOffs>1286716672</BitOffs>
+            <BitOffs>1289020992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fMaxVelocity</Name>
@@ -92288,7 +90782,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.5</Value>
             </Default>
-            <BitOffs>1286716736</BitOffs>
+            <BitOffs>1289021056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fHighAccel</Name>
@@ -92297,7 +90791,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.8</Value>
             </Default>
-            <BitOffs>1286716800</BitOffs>
+            <BitOffs>1289021120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fLowAccel</Name>
@@ -92306,25 +90800,25 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1286716864</BitOffs>
+            <BitOffs>1289021184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286716928</BitOffs>
+            <BitOffs>1289021248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO</Name>
             <BitSize>145024</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>1287045568</BitOffs>
+            <BitOffs>1289349888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>1287190592</BitOffs>
+            <BitOffs>1289494912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ff2_ff1_link_optics</Name>
@@ -92348,7 +90842,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>65535</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287218944</BitOffs>
+            <BitOffs>1289523264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX01</Name>
@@ -92373,7 +90867,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62729</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287244864</BitOffs>
+            <BitOffs>1289549184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX02</Name>
@@ -92397,7 +90891,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62736</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287270784</BitOffs>
+            <BitOffs>1289575104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX05</Name>
@@ -92421,7 +90915,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62737</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287296704</BitOffs>
+            <BitOffs>1289601024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.delta</Name>
@@ -92430,39 +90924,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1287322624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)SafeBenderRange
-        field: ZNAM FALSE
-        field: ONAM TRUE
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287322656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LRG_Grating_IN
-        field: ZNAM FALSE
-        field: ONAM TRUE
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287322664</BitOffs>
+            <BitOffs>1289626944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOS_IN</Name>
@@ -92478,7 +90940,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287322672</BitOffs>
+            <BitOffs>1289626976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOB_on_Lower_Stopper</Name>
@@ -92494,7 +90956,39 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287322680</BitOffs>
+            <BitOffs>1289626984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)MR1K1_Inserted
+        field: ZNAM FALSE
+        field: ONAM TRUE
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1289626992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)BeamPermitted
+        field: ZNAM FALSE
+        field: ONAM TRUE
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1289627000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeam</Name>
@@ -92519,39 +91013,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287322688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)MR1K1_Inserted
-        field: ZNAM FALSE
-        field: ONAM TRUE
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287348608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)BeamPermitted
-        field: ZNAM FALSE
-        field: ONAM TRUE
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287348616</BitOffs>
+            <BitOffs>1289627008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.nMachineMode</Name>
@@ -92569,7 +91031,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287348624</BitOffs>
+            <BitOffs>1289652928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefXM2K2</Name>
@@ -92587,110 +91049,110 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1287348640</BitOffs>
+            <BitOffs>1289652960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287348672</BitOffs>
+            <BitOffs>1289652992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287348736</BitOffs>
+            <BitOffs>1289653056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287348800</BitOffs>
+            <BitOffs>1289653120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287348864</BitOffs>
+            <BitOffs>1289653184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.HZos</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287348928</BitOffs>
+            <BitOffs>1289653248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287348992</BitOffs>
+            <BitOffs>1289653312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349056</BitOffs>
+            <BitOffs>1289653376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349120</BitOffs>
+            <BitOffs>1289653440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349184</BitOffs>
+            <BitOffs>1289653504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349248</BitOffs>
+            <BitOffs>1289653568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349312</BitOffs>
+            <BitOffs>1289653632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hb0m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349376</BitOffs>
+            <BitOffs>1289653696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm3</Name>
             <Comment>fixed calc</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349440</BitOffs>
+            <BitOffs>1289653760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hpiv</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349504</BitOffs>
+            <BitOffs>1289653824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349568</BitOffs>
+            <BitOffs>1289653888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349632</BitOffs>
+            <BitOffs>1289653952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349696</BitOffs>
+            <BitOffs>1289654016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Delta</Name>
@@ -92706,13 +91168,13 @@ MR2K2 X ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287349760</BitOffs>
+            <BitOffs>1289654080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Ans</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287349824</BitOffs>
+            <BitOffs>1289654144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeamExitSlits</Name>
@@ -92736,7 +91198,7 @@ MR2K2 X ENC REF</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287349888</BitOffs>
+            <BitOffs>1289654208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hi2</Name>
@@ -92746,7 +91208,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>1.4</Value>
             </Default>
-            <BitOffs>1287375808</BitOffs>
+            <BitOffs>1289680128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zi2</Name>
@@ -92756,7 +91218,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>731.613</Value>
             </Default>
-            <BitOffs>1287375872</BitOffs>
+            <BitOffs>1289680192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta0</Name>
@@ -92765,7 +91227,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>1287375936</BitOffs>
+            <BitOffs>1289680256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zm1</Name>
@@ -92775,7 +91237,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>733.772</Value>
             </Default>
-            <BitOffs>1287376000</BitOffs>
+            <BitOffs>1289680320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zmon</Name>
@@ -92785,7 +91247,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>739.622</Value>
             </Default>
-            <BitOffs>1287376064</BitOffs>
+            <BitOffs>1289680384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zpiv</Name>
@@ -92795,7 +91257,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>739.762</Value>
             </Default>
-            <BitOffs>1287376128</BitOffs>
+            <BitOffs>1289680448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zzos</Name>
@@ -92805,7 +91267,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>741.422</Value>
             </Default>
-            <BitOffs>1287376192</BitOffs>
+            <BitOffs>1289680512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1Offset</Name>
@@ -92814,7 +91276,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>18081.1</Value>
             </Default>
-            <BitOffs>1287376256</BitOffs>
+            <BitOffs>1289680576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2Offset</Name>
@@ -92823,7 +91285,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>-90603</Value>
             </Default>
-            <BitOffs>1287376320</BitOffs>
+            <BitOffs>1289680640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3Offset</Name>
@@ -92833,83 +91295,83 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>-63300</Value>
             </Default>
-            <BitOffs>1287376384</BitOffs>
+            <BitOffs>1289680704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
             <Comment> Encoder Arrays/RMS Watch:
 MR2K2 X ENC RMS</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>	pv: MR2K2:FLAT:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1287376448</BitOffs>
+            <BitOffs>1289681408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287763968</BitOffs>
+            <BitOffs>1290068928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1287764032</BitOffs>
+            <BitOffs>1290068992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
             <Comment>MR2K2 Y ENC RMS</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1287764096</BitOffs>
+            <BitOffs>1290069056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288151616</BitOffs>
+            <BitOffs>1290456576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288151680</BitOffs>
+            <BitOffs>1290456640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
             <Comment>MR2K2 rX ENC RMS</Comment>
             <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1288151744</BitOffs>
+            <BitOffs>1290456704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288539264</BitOffs>
+            <BitOffs>1290844224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288539328</BitOffs>
+            <BitOffs>1290844288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefYM2K2</Name>
@@ -92926,7 +91388,7 @@ MR2K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288539392</BitOffs>
+            <BitOffs>1290844352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefrXM2K2</Name>
@@ -92943,7 +91405,7 @@ MR2K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288539424</BitOffs>
+            <BitOffs>1290844384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntXM2K2</Name>
@@ -92961,7 +91423,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288539456</BitOffs>
+            <BitOffs>1290844416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntYM2K2</Name>
@@ -92978,7 +91440,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288539488</BitOffs>
+            <BitOffs>1290844448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntrXM2K2</Name>
@@ -92995,218 +91457,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1288539520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1</Name>
-            <Comment> MR2K2 Flow Press Sensors</Comment>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288539584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2K2:FLAT:FWM:1
-        field: EGU lpm
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288540096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288540160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Flow_2_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2K2:FLAT:FWM:2
-        field: EGU lpm
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288540672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Press_1</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288540736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fMR2K2_Press_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2K2:FLAT:PRSM:1
-        field: EGU bar
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288541248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR3K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288541312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1288928832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1288928896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
-            <Comment>MR3K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288928960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1289316480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1289316544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
-            <Comment>MR3K2 rY ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1289316608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1289704128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1289704192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
-            <Comment>MR3K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1289704256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1290091776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1290091840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
-            <Comment>MR3K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290091904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1290479424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1290479488</BitOffs>
+            <BitOffs>1290844480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefXM3K2</Name>
@@ -93224,7 +91475,154 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479552</BitOffs>
+            <BitOffs>1290844512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
+            <BitSize>1792</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
+   							  .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
+		                      .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
+	</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2K2:FLAT
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290844544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR3K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290846336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1291233856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1291233920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
+            <Comment>MR3K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1291233984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1291621504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1291621568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
+            <Comment>MR3K2 rY ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1291621632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1292009152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1292009216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
+            <Comment>MR3K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292009280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1292396800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1292396864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
+            <Comment>MR3K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292396928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1292784448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1292784512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefYM3K2</Name>
@@ -93241,7 +91639,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479584</BitOffs>
+            <BitOffs>1292784576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefrYM3K2</Name>
@@ -93258,7 +91656,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479616</BitOffs>
+            <BitOffs>1292784608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefUSM3K2</Name>
@@ -93275,7 +91673,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479648</BitOffs>
+            <BitOffs>1292784640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefDSM3K2</Name>
@@ -93292,7 +91690,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479680</BitOffs>
+            <BitOffs>1292784672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntXM3K2</Name>
@@ -93310,7 +91708,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479712</BitOffs>
+            <BitOffs>1292784704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntYM3K2</Name>
@@ -93327,7 +91725,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479744</BitOffs>
+            <BitOffs>1292784736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntrYM3K2</Name>
@@ -93344,7 +91742,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479776</BitOffs>
+            <BitOffs>1292784768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntUSM3K2</Name>
@@ -93361,7 +91759,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479808</BitOffs>
+            <BitOffs>1292784800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntDSM3K2</Name>
@@ -93378,7 +91776,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479840</BitOffs>
+            <BitOffs>1292784832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_1</Name>
@@ -93397,7 +91795,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479872</BitOffs>
+            <BitOffs>1292784864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_2</Name>
@@ -93414,7 +91812,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479904</BitOffs>
+            <BitOffs>1292784896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
@@ -93431,7 +91829,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479936</BitOffs>
+            <BitOffs>1292784928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
@@ -93449,7 +91847,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290479968</BitOffs>
+            <BitOffs>1292784960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
@@ -93466,7 +91864,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290480000</BitOffs>
+            <BitOffs>1292784992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -93483,190 +91881,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290480032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1</Name>
-            <Comment> MR3K2 Flow Sensors</Comment>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290480128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Flow_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR3K2:KBH:FWM:1
-        field: EGU lpm
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290480640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290480704</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fMR3K2_Press_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR3K2:KBH:PRSM:1
-        field: EGU bar
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290481216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR4K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290481280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1290868800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1290868864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
-            <Comment>MR4K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290868928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1291256448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1291256512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
-            <Comment>MR4K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1291256576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1291644096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1291644160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
-            <Comment>MR4K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1291644224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1292031744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1292031808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
-            <Comment>MR4K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292031872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1292419392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1292419456</BitOffs>
+            <BitOffs>1292785024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -93684,7 +91899,154 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419520</BitOffs>
+            <BitOffs>1292785120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
+            <Comment> MR3K2 Flow Sensors</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
+		                      .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+	</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292785152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR4K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292786368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1293173888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1293173952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
+            <Comment>MR4K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1293174016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1293561536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1293561600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
+            <Comment>MR4K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1293561664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1293949184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1293949248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
+            <Comment>MR4K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1293949312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1294336832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1294336896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
+            <Comment>MR4K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294336960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1294724480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1294724544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -93701,7 +92063,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419552</BitOffs>
+            <BitOffs>1294724608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -93718,7 +92080,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419584</BitOffs>
+            <BitOffs>1294724640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -93735,7 +92097,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419616</BitOffs>
+            <BitOffs>1294724672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -93752,7 +92114,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419648</BitOffs>
+            <BitOffs>1294724704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -93770,7 +92132,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419680</BitOffs>
+            <BitOffs>1294724736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -93787,7 +92149,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419712</BitOffs>
+            <BitOffs>1294724768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -93804,7 +92166,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419744</BitOffs>
+            <BitOffs>1294724800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -93821,7 +92183,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419776</BitOffs>
+            <BitOffs>1294724832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -93838,7 +92200,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419808</BitOffs>
+            <BitOffs>1294724864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -93857,7 +92219,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419840</BitOffs>
+            <BitOffs>1294724896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -93874,7 +92236,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419872</BitOffs>
+            <BitOffs>1294724928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -93891,7 +92253,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419904</BitOffs>
+            <BitOffs>1294724960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -93909,7 +92271,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419936</BitOffs>
+            <BitOffs>1294724992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -93926,7 +92288,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292419968</BitOffs>
+            <BitOffs>1294725024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -93943,7 +92305,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292420000</BitOffs>
+            <BitOffs>1294725056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -93966,7 +92328,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292420032</BitOffs>
+            <BitOffs>1294725120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -93989,71 +92351,35 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292420288</BitOffs>
+            <BitOffs>1294725376</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1</Name>
-            <Comment> MR4K2 Flow Sensors</Comment>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
+            <Comment> MR4K2 Flow Sensors	</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
+		                      .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+	</Value>
               </Property>
-            </Properties>
-            <BitOffs>1292420608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Flow_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: MR4K2:KBV:FWM:1
-        field: EGU lpm
-        io: i
+        pv: MR4K2:KBV
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292421120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1</Name>
-            <BitSize>512</BitSize>
-            <BaseType Namespace="LCLS_General">FB_AnalogInput</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292421184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMR4K2_Press_1_val</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR4K2:KBV:PRSM:1
-        field: EGU bar
-        io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292421696</BitOffs>
+            <BitOffs>1294725696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
             <Comment> Pitch Mechanism:\
  Currently unused</Comment>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -94081,7 +92407,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292426816</BitOffs>
+            <BitOffs>1294731968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -94096,7 +92422,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429312</BitOffs>
+            <BitOffs>1294734464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -94110,7 +92436,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429376</BitOffs>
+            <BitOffs>1294734528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -94125,7 +92451,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429440</BitOffs>
+            <BitOffs>1294734592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -94140,7 +92466,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429504</BitOffs>
+            <BitOffs>1294734656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -94155,7 +92481,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429568</BitOffs>
+            <BitOffs>1294734720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -94170,7 +92496,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429632</BitOffs>
+            <BitOffs>1294734784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -94186,7 +92512,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429760</BitOffs>
+            <BitOffs>1294734912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -94200,7 +92526,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429824</BitOffs>
+            <BitOffs>1294734976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -94214,7 +92540,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429888</BitOffs>
+            <BitOffs>1294735040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -94228,7 +92554,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292429952</BitOffs>
+            <BitOffs>1294735104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -94243,7 +92569,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432512</BitOffs>
+            <BitOffs>1294737664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -94258,7 +92584,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432576</BitOffs>
+            <BitOffs>1294737728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -94273,7 +92599,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432640</BitOffs>
+            <BitOffs>1294737792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -94289,7 +92615,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432704</BitOffs>
+            <BitOffs>1294737856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -94303,7 +92629,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432768</BitOffs>
+            <BitOffs>1294737920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -94317,7 +92643,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432832</BitOffs>
+            <BitOffs>1294737984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -94332,7 +92658,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432896</BitOffs>
+            <BitOffs>1294738048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -94347,7 +92673,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292432960</BitOffs>
+            <BitOffs>1294738112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -94363,7 +92689,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433152</BitOffs>
+            <BitOffs>1294738240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -94377,7 +92703,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433216</BitOffs>
+            <BitOffs>1294738304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -94391,7 +92717,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433280</BitOffs>
+            <BitOffs>1294738368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -94406,7 +92732,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433344</BitOffs>
+            <BitOffs>1294738432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -94421,7 +92747,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433408</BitOffs>
+            <BitOffs>1294738496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -94436,7 +92762,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433472</BitOffs>
+            <BitOffs>1294738560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -94451,7 +92777,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433536</BitOffs>
+            <BitOffs>1294738624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -94466,7 +92792,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433600</BitOffs>
+            <BitOffs>1294738688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -94481,7 +92807,22 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433664</BitOffs>
+            <BitOffs>1294738752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
+            <Comment> lever arm for Yright/Yleft axes in um</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>717000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1294738912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -94497,7 +92838,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433792</BitOffs>
+            <BitOffs>1294738944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -94511,7 +92852,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433856</BitOffs>
+            <BitOffs>1294739008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -94525,7 +92866,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433920</BitOffs>
+            <BitOffs>1294739072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -94539,33 +92880,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292433984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
-            <Comment> lever arm for Yright/Yleft axes in um</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>717000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1292434048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.rPhotonEnergy</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1292434080</BitOffs>
+            <BitOffs>1294739136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -94583,7 +92898,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292434112</BitOffs>
+            <BitOffs>1294739200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -94601,7 +92916,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1292929856</BitOffs>
+            <BitOffs>1295234944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -94630,7 +92945,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293425600</BitOffs>
+            <BitOffs>1295730688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -94659,13 +92974,24 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293949952</BitOffs>
+            <BitOffs>1296255040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_PMPS.rPhotonEnergy</Name>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1296779392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
             <Comment> M1K2 Yleft</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94673,7 +92999,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -94696,7 +93022,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294474688</BitOffs>
+            <BitOffs>1296779840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -94707,13 +93033,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294495872</BitOffs>
+            <BitOffs>1296805056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
             <Comment> M1K2 Yright</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94721,7 +93047,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -94744,7 +93070,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294823296</BitOffs>
+            <BitOffs>1297132480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -94755,13 +93081,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294844480</BitOffs>
+            <BitOffs>1297157696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
             <Comment> M1K2 Xup</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94769,7 +93095,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -94792,7 +93118,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295171904</BitOffs>
+            <BitOffs>1297485120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -94803,13 +93129,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295193088</BitOffs>
+            <BitOffs>1297510336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
             <Comment> M1K2 Xdwn</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94817,7 +93143,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -94840,7 +93166,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295520512</BitOffs>
+            <BitOffs>1297837760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -94851,13 +93177,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295541696</BitOffs>
+            <BitOffs>1297862976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
             <Comment> M1K2 Pitch Stepper</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94865,7 +93191,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -94888,17 +93214,55 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295869120</BitOffs>
+            <BitOffs>1298190400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6</Name>
+            <Comment> M_PI, urad</Comment>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_PI
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1298215616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
             <Comment> M_H, um</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94926,17 +93290,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295932672</BitOffs>
+            <BitOffs>1298266048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
             <Comment> G_H, um</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -94964,17 +93328,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295953856</BitOffs>
+            <BitOffs>1298291264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
             <Comment> SD_V, um</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95001,17 +93365,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295975040</BitOffs>
+            <BitOffs>1298316480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
             <Comment> SD_R, urad</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95033,13 +93397,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295996224</BitOffs>
+            <BitOffs>1298341696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
             <Comment> M1K1 Yup</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95047,7 +93411,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95071,7 +93435,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296017408</BitOffs>
+            <BitOffs>1298366912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -95082,13 +93446,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296038592</BitOffs>
+            <BitOffs>1298392128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
             <Comment> M1K1 Ydwn</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95096,7 +93460,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95119,7 +93483,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296366016</BitOffs>
+            <BitOffs>1298719552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -95130,13 +93494,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296387200</BitOffs>
+            <BitOffs>1298744768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
             <Comment> M1K1 Xup</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95144,7 +93508,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95167,7 +93531,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296714624</BitOffs>
+            <BitOffs>1299072192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -95178,13 +93542,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296735808</BitOffs>
+            <BitOffs>1299097408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
             <Comment> M1K1 Xdwn</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95192,7 +93556,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95215,7 +93579,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297063232</BitOffs>
+            <BitOffs>1299424832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -95226,13 +93590,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297084416</BitOffs>
+            <BitOffs>1299450048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
             <Comment> M1K1 Pitch Stepper</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.fVelocity</Name>
@@ -95240,7 +93604,7 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95264,17 +93628,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297411840</BitOffs>
+            <BitOffs>1299777472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
             <Comment>MR1K1 US BEND</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95297,7 +93661,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297433024</BitOffs>
+            <BitOffs>1299802688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -95308,17 +93672,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297454208</BitOffs>
+            <BitOffs>1299827904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
             <Comment>MR1K1 DS BEND</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95342,7 +93706,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297781632</BitOffs>
+            <BitOffs>1300155328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -95353,13 +93717,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297802816</BitOffs>
+            <BitOffs>1300180544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
             <Comment> Air Pitch</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.sName</Name>
@@ -95387,13 +93751,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298130240</BitOffs>
+            <BitOffs>1300507968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
             <Comment> Air Vertical</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.sName</Name>
@@ -95421,13 +93785,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298151424</BitOffs>
+            <BitOffs>1300533184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
             <Comment> Air Roll</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.sName</Name>
@@ -95455,13 +93819,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298172608</BitOffs>
+            <BitOffs>1300558400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
             <Comment> GAP</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.sName</Name>
@@ -95489,13 +93853,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298193792</BitOffs>
+            <BitOffs>1300583616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
             <Comment> YAG</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.sName</Name>
@@ -95523,13 +93887,13 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298214976</BitOffs>
+            <BitOffs>1300608832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
             <Comment> ST1K1-ZOS-MMS</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.sName</Name>
@@ -95552,17 +93916,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298236160</BitOffs>
+            <BitOffs>1300634048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
             <Comment>X mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95584,7 +93948,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298257344</BitOffs>
+            <BitOffs>1300659264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -95595,17 +93959,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298278528</BitOffs>
+            <BitOffs>1300684480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
             <Comment>Y mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95627,7 +93991,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298605952</BitOffs>
+            <BitOffs>1301011904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -95638,17 +94002,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298627136</BitOffs>
+            <BitOffs>1301037120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
             <Comment>Pitch mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95670,7 +94034,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298954560</BitOffs>
+            <BitOffs>1301364544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -95681,17 +94045,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298975744</BitOffs>
+            <BitOffs>1301389760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
             <Comment>X mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95713,7 +94077,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299303168</BitOffs>
+            <BitOffs>1301717184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -95724,17 +94088,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299324352</BitOffs>
+            <BitOffs>1301742400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
             <Comment>Y mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95756,7 +94120,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299651776</BitOffs>
+            <BitOffs>1302069824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -95767,17 +94131,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299672960</BitOffs>
+            <BitOffs>1302095040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
             <Comment>Pitch mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95799,7 +94163,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300000384</BitOffs>
+            <BitOffs>1302422464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -95810,17 +94174,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300021568</BitOffs>
+            <BitOffs>1302447680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
             <Comment>MR3K2 US BEND</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95842,7 +94206,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300348992</BitOffs>
+            <BitOffs>1302775104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -95853,17 +94217,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300370176</BitOffs>
+            <BitOffs>1302800320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
             <Comment>MR3K2 DS BEND</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95885,7 +94249,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300697600</BitOffs>
+            <BitOffs>1303127744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -95896,17 +94260,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300718784</BitOffs>
+            <BitOffs>1303152960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
             <Comment>X mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95928,7 +94292,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301046208</BitOffs>
+            <BitOffs>1303480384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -95939,17 +94303,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301067392</BitOffs>
+            <BitOffs>1303505600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
             <Comment>Y mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -95971,7 +94335,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301394816</BitOffs>
+            <BitOffs>1303833024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -95982,17 +94346,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301416000</BitOffs>
+            <BitOffs>1303858240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
             <Comment>Pitch mot</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.ALWAYS</EnumText>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -96014,7 +94378,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301743424</BitOffs>
+            <BitOffs>1304185664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -96025,17 +94389,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301764608</BitOffs>
+            <BitOffs>1304210880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
             <Comment>MR4K2 US BEND</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -96057,7 +94421,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302092032</BitOffs>
+            <BitOffs>1304538304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -96068,17 +94432,17 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302113216</BitOffs>
+            <BitOffs>1304563520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
             <Comment>MR4K2 DS BEND</Comment>
-            <BitSize>21184</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">DUT_MotionStage</BaseType>
+            <BitSize>25216</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <EnumText>ENUM_StageEnableMode.DURING_MOTION</EnumText>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.bPowerSelf</Name>
@@ -96100,7 +94464,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302440640</BitOffs>
+            <BitOffs>1304890944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -96111,7 +94475,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302461824</BitOffs>
+            <BitOffs>1304916160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -96122,7 +94486,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789264</BitOffs>
+            <BitOffs>1305243584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -96137,7 +94501,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789280</BitOffs>
+            <BitOffs>1305243600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -96152,7 +94516,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789288</BitOffs>
+            <BitOffs>1305243608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -96182,7 +94546,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789296</BitOffs>
+            <BitOffs>1305243616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -96212,7 +94576,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789360</BitOffs>
+            <BitOffs>1305243680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -96227,7 +94591,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789424</BitOffs>
+            <BitOffs>1305243744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -96242,7 +94606,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789440</BitOffs>
+            <BitOffs>1305243760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -96257,7 +94621,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789456</BitOffs>
+            <BitOffs>1305243776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -96271,7 +94635,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789464</BitOffs>
+            <BitOffs>1305243784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -96286,7 +94650,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789472</BitOffs>
+            <BitOffs>1305243808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -96301,7 +94665,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789504</BitOffs>
+            <BitOffs>1305243840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -96422,7 +94786,56 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302789536</BitOffs>
+            <BitOffs>1305243872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305253344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305253376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
+            <BitSize>896</BitSize>
+            <BaseType>_Implicit_Task_Info</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.dwVersion</Name>
+                <Value>2</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcContextName</Name>
+                <Value>PlcTask</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305257024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -96494,7 +94907,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302807584</BitOffs>
+            <BitOffs>1305274944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -96566,7 +94979,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302807712</BitOffs>
+            <BitOffs>1305275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -96638,7 +95051,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302807840</BitOffs>
+            <BitOffs>1305275200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -96710,7 +95123,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302807968</BitOffs>
+            <BitOffs>1305275328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -96782,7 +95195,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302808096</BitOffs>
+            <BitOffs>1305275456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -96854,7 +95267,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302808224</BitOffs>
+            <BitOffs>1305275584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -96880,83 +95293,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302841248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302857696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302857728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
-            <BitSize>896</BitSize>
-            <BaseType>_Implicit_Task_Info</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.dwVersion</Name>
-                <Value>2</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcContextName</Name>
-                <Value>PlcTask</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302861376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_Stats.afMpiPosDiffBuffer</Name>
-            <BitSize>640000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>10000</Elements>
-            </ArrayInfo>
-            <BitOffs>1312312128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_Stats.afMpiExtraBuffer</Name>
-            <BitSize>640000</BitSize>
-            <BaseType>LREAL</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>10000</Elements>
-            </ArrayInfo>
-            <BitOffs>1313594368</BitOffs>
+            <BitOffs>1305308608</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -96974,7 +95318,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633593312</BitOffs>
+            <BitOffs>634563712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AccumulatedFF</Name>
@@ -96993,7 +95337,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634563712</BitOffs>
+            <BitOffs>634563744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.BP_jsonDoc</Name>
@@ -97036,7 +95380,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-01-30T13:39:53</Value>
+          <Value>2024-02-05T16:47:57</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
@@ -97044,7 +95388,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>162791424</Value>
+          <Value>162811904</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{59E3669E-D1DA-ED54-7F83-ABBB45EA4F77}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{09BF2CD2-8525-B6F1-2E3E-E7CCEA6380AC}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -60027,12 +60027,15 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Name>pytmc</Name>
             <Value>
         pv: FWM:1
-        autosave_pass0: HIGH HIHI LOW LOLO
         field: EGU lpm
         field: HIGH 2.3
         field: HIHI 3.0
         field: LOW 1.7
         field: LOLO 1.5
+		field: LSV MINOR
+		field: LLSV MAJOR
+		field: HSV MINOR
+		field: HHSV MAJOR
         io: i
     </Value>
           </Property>
@@ -60051,10 +60054,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Property>
             <Name>pytmc</Name>
             <Value>
-        autosave_pass0: LOW
         pv: PRSM:1
         field: EGU bar
         field: LOW 0.1
+		field: LSV MAJOR
         io: i
     </Value>
           </Property>
@@ -60097,12 +60100,15 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Name>pytmc</Name>
             <Value>
         pv: FWM:2
-        autosave_pass0: HIGH HIHI LOW LOLO
         field: EGU lpm
         field: HIGH 2.3
         field: HIHI 3.0
         field: LOW 1.7
         field: LOLO 1.5
+		field: LSV MINOR
+		field: LLSV MAJOR
+		field: HSV MINOR
+		field: HHSV MAJOR
         io: i
     </Value>
           </Property>
@@ -95383,7 +95389,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-05T17:55:20</Value>
+          <Value>2024-02-07T16:41:13</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{09BF2CD2-8525-B6F1-2E3E-E7CCEA6380AC}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{E3C294DB-8219-B920-2780-EBADF1F16FAF}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -5134,13 +5134,7 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_System">T_MaxString</Name>
-      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
-      <BitSize>2048</BitSize>
-      <BaseType>STRING(255)</BaseType>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
       <BitSize>384</BitSize>
       <SubItem>
         <Name>tCtrlCycleTime</Name>
@@ -5214,7 +5208,7 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Name>
+      <Name Namespace="lcls_twincat_optics">ST_PiezoAxis</Name>
       <BitSize>2240</BitSize>
       <SubItem>
         <Name>sIdn</Name>
@@ -5343,7 +5337,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>stPIParams</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
         <BitSize>384</BitSize>
         <BitOffs>1792</BitOffs>
         <Default>
@@ -5397,6 +5391,66 @@ External Setpoint Generation:
           <Value>-10</Value>
         </Default>
       </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">HOMS_PitchMechanism</Name>
+      <BitSize>2496</BitSize>
+      <SubItem>
+        <Name>Piezo</Name>
+        <Type Namespace="lcls_twincat_optics">ST_PiezoAxis</Type>
+        <Comment>Piezo</Comment>
+        <BitSize>2240</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ReqPosLimHi</Name>
+        <Type>REAL</Type>
+        <Comment> Soft limits, egu urad </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ReqPosLimLo</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diEncPosLimHi</Name>
+        <Type>LINT</Type>
+        <Comment> Hard limits, egu INC 
+ These are discovered during installation, and represent encoder ticks, unbiased 
+ We changed to these when our pitch mechanism limit switches were insufficient for
+    good control. They had too much hysteresis/ lack of precision. At this point the limit
+    switches are ignored, and instead their function is carried out by these. </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diEncPosLimLo</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diEncCnt</Name>
+        <Type>LINT</Type>
+        <Comment>Raw encoder count</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_MaxString</Name>
+      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
+      <BitSize>2048</BitSize>
+      <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ClearComBuffer</Name>
@@ -6797,7 +6851,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Name>
+      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Name>
       <BitSize>35200</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -7091,7 +7145,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</Name>
+      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</Name>
       <BitSize>112640</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -7194,7 +7248,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>iq_stPiezoAxis</Name>
-        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
         <BitSize>64</BitSize>
         <BitOffs>67008</BitOffs>
         <Properties>
@@ -7254,7 +7308,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>fbPITransaction</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Type>
+        <Type Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Type>
         <BitSize>35200</BitSize>
         <BitOffs>68160</BitOffs>
       </SubItem>
@@ -7297,60 +7351,6 @@ External Setpoint Generation:
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</Name>
-      <BitSize>2496</BitSize>
-      <SubItem>
-        <Name>Piezo</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Type>
-        <Comment>Piezo</Comment>
-        <BitSize>2240</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ReqPosLimHi</Name>
-        <Type>REAL</Type>
-        <Comment> Soft limits, egu urad </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2240</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ReqPosLimLo</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diEncPosLimHi</Name>
-        <Type>LINT</Type>
-        <Comment> Hard limits, egu INC 
- These are discovered during installation, and represent encoder ticks, unbiased 
- We changed to these when our pitch mechanism limit switches were insufficient for
-    good control. They had too much hysteresis/ lack of precision. At this point the limit
-    switches are ignored, and instead their function is carried out by these. </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2304</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diEncPosLimLo</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>2368</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diEncCnt</Name>
-        <Type>LINT</Type>
-        <Comment>Raw encoder count</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
     </DataType>
     <DataType>
       <Name GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}" Namespace="PLC" TcBaseType="true">PlcTaskSystemInfo</Name>
@@ -10194,31 +10194,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163192152</GetCodeOffs>
+        <GetCodeOffs>163192136</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163192224</GetCodeOffs>
+        <GetCodeOffs>163192208</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192240</GetCodeOffs>
+        <GetCodeOffs>163192224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192200</GetCodeOffs>
+        <GetCodeOffs>163192184</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192232</GetCodeOffs>
+        <GetCodeOffs>163192216</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11470,15 +11470,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192024</GetCodeOffs>
-        <SetCodeOffs>163192072</SetCodeOffs>
+        <GetCodeOffs>163192008</GetCodeOffs>
+        <SetCodeOffs>163192056</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192104</GetCodeOffs>
-        <SetCodeOffs>163192128</SetCodeOffs>
+        <GetCodeOffs>163192088</GetCodeOffs>
+        <SetCodeOffs>163192112</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11719,31 +11719,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>163192336</GetCodeOffs>
+        <GetCodeOffs>163192320</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163192296</GetCodeOffs>
+        <GetCodeOffs>163192280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192472</GetCodeOffs>
+        <GetCodeOffs>163192456</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192480</GetCodeOffs>
+        <GetCodeOffs>163192464</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192392</GetCodeOffs>
+        <GetCodeOffs>163192376</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11755,7 +11755,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192488</GetCodeOffs>
+        <GetCodeOffs>163192472</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12348,7 +12348,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163192544</GetCodeOffs>
+        <GetCodeOffs>163192528</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -36580,7 +36580,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Name>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Name>
       <BitSize>128</BitSize>
       <SubItem>
         <Name>bInterpretCycleTimeAsTicks</Name>
@@ -36760,7 +36760,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163204176</GetCodeOffs>
+        <GetCodeOffs>163204160</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -38688,31 +38688,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163203576</GetCodeOffs>
+        <GetCodeOffs>163203560</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163203664</GetCodeOffs>
+        <GetCodeOffs>163203648</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163203592</GetCodeOffs>
+        <GetCodeOffs>163203576</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163203640</GetCodeOffs>
+        <GetCodeOffs>163203624</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163203680</GetCodeOffs>
+        <GetCodeOffs>163203664</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -40847,276 +40847,34 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
-      <BitSize>0</BitSize>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Name>
-      <Comment> Renishaw BiSS-C absolute encoder used with an EL5042</Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>Count</Name>
-        <Type>ULINT</Type>
-        <Comment> Connect to encoder "Position" input</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Status</Name>
-        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
-        <Comment> Status struct placeholder</Comment>
-        <BitSize>0</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Ref</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder zero position (useful for aligned position with gantries)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Name>
-      <BitSize>512</BitSize>
-      <SubItem>
-        <Name>PEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Primary axis encoder (usually the upstream one)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Secondary axis encoder (couples to the primary)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GantDiffTol</Name>
-        <Type>LINT</Type>
-        <Comment> Gantry differenace tolerance in encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PLimFwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Primary axis forward direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PLimBwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Primary axis reverse direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SLimFwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Secondary axis forward direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SLimBwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Secondary axis reverse direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GantryDiff</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_BufferMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>MC_Aborting</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_Buffered</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingLow</Text>
-        <Enum>18</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingPrevious</Text>
-        <Enum>19</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingNext</Text>
-        <Enum>20</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingHigh</Text>
-        <Enum>21</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Name>
+      <Name Namespace="Tc2_MC2">_E_TcMC_STATES</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR</Text>
-        <Enum>1</Enum>
-        <Comment> Lineare Kopplung (Geradengleichung) </Comment>
+        <Text>STATE_INITIALIZATION</Text>
+        <Enum>100</Enum>
       </EnumInfo>
       <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONVELOCITY</Text>
-        <Enum>2</Enum>
-        <Comment> diagonal synchron. Aufkoppeln schnellstens auf Geschwindigkeit </Comment>
+        <Text>STATE_ORDER</Text>
+        <Enum>101</Enum>
       </EnumInfo>
       <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONPOSITION</Text>
-        <Enum>3</Enum>
-        <Comment> diagonal synchron. Aufkoppeln auf Position und Geschwindigkeit </Comment>
+        <Text>STATE_RUNNING</Text>
+        <Enum>102</Enum>
       </EnumInfo>
       <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_QUADRATIC</Text>
-        <Enum>4</Enum>
-        <Comment> diagonal synchron. Aufkoppeln (quadratisches Geschw.-Profil) </Comment>
+        <Text>STATE_WAITING</Text>
+        <Enum>103</Enum>
       </EnumInfo>
       <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONVELO</Text>
-        <Enum>5</Enum>
-        <Comment> synchron. Aufkoppeln instantan auf Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONPOS</Text>
-        <Enum>6</Enum>
-        <Comment> synchron. Aufkoppeln auf Positionen und Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCJERKSETTER_ONVELO</Text>
-        <Enum>7</Enum>
-        <Comment> synchron. Aufkoppeln auf Geschwindigkeit (zeitbasiert mittels Ruck-Steller) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_TABULAR</Text>
-        <Enum>10</Enum>
-        <Comment> Tabellen-Kopplung ("simple/standard tabular slave") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_MULTITABULAR</Text>
-        <Enum>11</Enum>
-        <Comment> Tabellen-Kopplung ("multiscalable multi-tabular slave") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGMODULO_LINEAR</Text>
-        <Enum>12</Enum>
-        <Comment> Modulo Kopplung auf Position und/oder Geschwindigkeit mit anschliessender Linear Kopplung ("Schuette") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_MOTIONFUNCTIONTABULAR</Text>
-        <Enum>13</Enum>
-        <Comment> Tabellen-Kopplung "motion functions" </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_UNIVERSALTABULAR</Text>
-        <Enum>14</Enum>
-        <Comment> Tabellen-Kopplung, universal tabular type substitues TABULAR, MULTITABULAR and MOTIONFUNCTION - 08.07.05 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR_CYCLICCHANGES_RAMP</Text>
-        <Enum>15</Enum>
-        <Comment> Lineare Kopplung (Geradengleichung) mit zyklischer Koppelfaktoraenderung </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_BILINEAR</Text>
-        <Enum>16</Enum>
-        <Comment> 27.04.01: Zweifach Lineare Kopplung (Geradengleichung)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR_MULTIMASTER</Text>
-        <Enum>17</Enum>
-        <Comment> 29.05.08: Lineare Multi-Master-Kopplung ('MC_GearInMultiMaster') </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_CONST_SURFACEVELO_RAMP</Text>
-        <Enum>18</Enum>
-        <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
+        <Text>STATE_MOTIONCOMMANDSLOCKED</Text>
+        <Enum>104</Enum>
       </EnumInfo>
       <Properties>
         <Property>
           <Name>conditionalshow</Name>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
-      <BitSize>16</BitSize>
-      <SubItem>
-        <Name>SlaveType</Name>
-        <Type Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_ST_FunctionBlockResults</Name>
@@ -41167,2305 +40925,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Properties>
         <Property>
           <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_E_TcMC_STATES</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>STATE_INITIALIZATION</Text>
-        <Enum>100</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>STATE_ORDER</Text>
-        <Enum>101</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>STATE_RUNNING</Text>
-        <Enum>102</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>STATE_WAITING</Text>
-        <Enum>103</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>STATE_MOTIONCOMMANDSLOCKED</Text>
-        <Enum>104</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Name>
-      <BitSize>384</BitSize>
-      <SubItem>
-        <Name>nSlaveType</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nMasterAxisId</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nMasterSubIdx</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nSlaveSubIdx</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam2</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam3</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam4</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearInDynOptions</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>CCVmode</Name>
-        <Type>BOOL</Type>
-        <Comment> constant circumference velocity mode </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearInDyn</Name>
-      <BitSize>4416</BitSize>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GearRatio</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Acceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Deceleration</Name>
-        <Type>LREAL</Type>
-        <Comment> not used </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Jerk</Name>
-        <Type>LREAL</Type>
-        <Comment> not used </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>BufferMode</Name>
-        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearInDynOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>InGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>536</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>544</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Active</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>552</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CommandAborted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>568</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>720</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>iSubState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1344</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsRead</Name>
-        <Type Namespace="Tc2_System">ADSREAD</Type>
-        <BitSize>1408</BitSize>
-        <BitOffs>2112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sCouple</Name>
-        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>3520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>v_max</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>3904</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pa_limit</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>3968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>WasInGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>4032</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iAcceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>4096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>4160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearIn</Name>
-      <BitSize>7360</BitSize>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Execute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>RatioNumerator</Name>
-        <Type>LREAL</Type>
-        <Comment> changed from INT (PLCopen) to LREAL </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>RatioDenominator</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Acceleration</Name>
-        <Type>LREAL</Type>
-        <Comment>	MasterValueSource :	MC_SOURCE; 
- not available </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Deceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Jerk</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>BufferMode</Name>
-        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearInOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>592</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>InGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>608</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>616</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Active</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CommandAborted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>632</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>640</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>672</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>816</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1344</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sCouple</Name>
-        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>2176</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOptGearInDyn</Name>
-        <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
-        <BitSize>4416</BitSize>
-        <BitOffs>2560</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOnTrigger</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6976</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>7104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ActGearInDyn</Name>
-      </Action>
-      <Action>
-        <Name>WriteGearRatio</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearOutOptions</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>reserved</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearOut</Name>
-      <BitSize>2112</BitSize>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Execute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearOutOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Done</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>336</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1344</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOnTrigger</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_SetEnables</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Name>
-      <BitSize>10752</BitSize>
-      <SubItem>
-        <Name>nGantryTol</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>MasterEnc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SlaveEnc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCouple</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecouple</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>gantry_diff_limit</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>couple</Name>
-        <Type Namespace="Tc2_MC2">MC_GearIn</Type>
-        <BitSize>7360</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>decouple</Name>
-        <Type Namespace="Tc2_MC2">MC_GearOut</Type>
-        <BitSize>2112</BitSize>
-        <BitOffs>8448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInitComplete</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>10560</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbSetEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>10624</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Name>
-      <BitSize>23296</BitSize>
-      <SubItem>
-        <Name>nYupEncRef</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder Reference Values</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nYdwnEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nXupEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nXdwnEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTolY</Name>
-        <Type>LINT</Type>
-        <Comment> Encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>50000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTolX</Name>
-        <Type>LINT</Type>
-        <Comment> Encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>50000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledY</Name>
-        <Type>BOOL</Type>
-        <Comment> Gantry coupling status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryY</Name>
-        <Type>LINT</Type>
-        <Comment> Current gantry difference</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryX</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor Structs</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPitch</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleY</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <Comment> Manual coupling Gantried Axes</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleX</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleY</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleX</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable1</Name>
-        <Type>BOOL</Type>
-        <Comment> STO Button</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable2</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYupEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Encoders</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>1280</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYdwnEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXupEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1536</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXdwnEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1664</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbAutoCoupleY</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
-        <Comment> Autocoupling Gantried Axes</Comment>
-        <BitSize>10752</BitSize>
-        <BitOffs>1792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAutoCoupleX</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
-        <BitSize>10752</BitSize>
-        <BitOffs>12544</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">DUT_HOMS</Name>
-      <BitSize>23552</BitSize>
-      <SubItem>
-        <Name>fbRunHOMS</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Type>
-        <Comment> System initializiation</Comment>
-        <BitSize>23296</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleY</Name>
-        <Type>BOOL</Type>
-        <Comment> Couple/Decouple motors</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>23296</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: COUPLE_Y
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleY</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DECOUPLE_Y
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: COUPLE_X
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DECOUPLE_X
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledY</Name>
-        <Type>BOOL</Type>
-        <Comment> Coupling status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>23328</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ALREADY_COUPLED_Y
-        io: i
-        field: ZSV MAJOR
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ALREADY_COUPLED_X
-        io: i
-        field: ZSV MAJOR
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryY</Name>
-        <Type>LINT</Type>
-        <Comment> encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>23360</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryX</Name>
-        <Type>LINT</Type>
-        <Comment> encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>23424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrGantryY_um</Name>
-        <Type>REAL</Type>
-        <Comment> Y Gantry difference in um</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>23488</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GANTRY_Y
-        field: EGU um
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrGantryX_um</Name>
-        <Type>REAL</Type>
-        <Comment> X Gantry difference in um</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>23520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GANTRY_X
-        field: EGU um
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
-      <BitSize>128704</BitSize>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we'll accumulate a value on this cycle.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fInput</Name>
-        <Type>LREAL</Type>
-        <Comment> The value to accumulate.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrOutput</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bNewArray</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrPartial</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>64256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataBuffer</Name>
-        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
-        <BitSize>448</BitSize>
-        <BitOffs>128256</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</Name>
-      <BitSize>387520</BitSize>
-      <SubItem>
-        <Name>fMaxRMSError</Name>
-        <Type>LREAL</Type>
-        <Comment> RMS Error</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMinRMSError</Name>
-        <Type>LREAL</Type>
-        <Comment> start at something huge, FB will update with any smaller measured value</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScalingNum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScalingDenom</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncOffset</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScale</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataEncPos</Name>
-        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
-        <Comment> ActPos Data Acquisition FB</Comment>
-        <BitSize>128704</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataSetPos</Name>
-        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
-        <Comment> SetPos Data Acquisition FB</Comment>
-        <BitSize>128704</BitSize>
-        <BitOffs>129216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDataStorage</Name>
-        <Type>BOOL</Type>
-        <Comment> Take data of both ActPos and SetPos</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>257920</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bNewEncArray</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>257928</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStats</Name>
-        <Type Namespace="LCLS_General">FB_BasicStats</Type>
-        <Comment> Calculate mean/standard deviation of ActPos</Comment>
-        <BitSize>1152</BitSize>
-        <BitOffs>257984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncMean</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MEAN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fEncStDev</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STDEV
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrRMSError</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259264</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RMS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>259328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSum</Name>
-        <Type>LREAL</Type>
-        <Comment> Just for calculating rms</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>259392</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fDiff</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259456</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>aEncActPos</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>259520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ACTPOSARRAY
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>aEncSetPos</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>323520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SETPOSARRAY
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_Index</Name>
-      <Comment> Index FB
-A. Wallace 2016-9-3
-
-Why doesn't beckhoff have this as a builtin type?
-
-Use this thing to have a simple indexer with rollover.
-
-</Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>LowerLimit</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer will rollver over to this value (and initialize to this value)</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>naming</Name>
-            <Value>off</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ValInc</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer increments by this value</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>UpperLimit</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer will rollover at this value to lower limit</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nVal</Name>
-        <Type>INT</Type>
-        <Comment>Internal incrementer value, initialized to LowerLimit</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>112</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>off</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>Dec</Name>
-      </Action>
-      <Action>
-        <Name>Inc</Name>
-      </Action>
-      <Method>
-        <Name>DecVal</Name>
-        <Comment>Decrement the counter and return new value</Comment>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IncVal</Name>
-        <Comment>Increment the counter and return new value</Comment>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">ST_FbDiagnostics</Name>
-      <Comment>Stuff to log messages within function blocks</Comment>
-      <BitSize>49664</BitSize>
-      <SubItem>
-        <Name>asResults</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>20</Elements>
-        </ArrayInfo>
-        <Comment>Diagnostic messages, use to record state changes or other important events.</Comment>
-        <BitSize>40960</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>resultIdx</Name>
-        <Type Namespace="LCLS_General">FB_Index</Type>
-        <Comment>Incrementer, included here to facilitate using asResults</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>40960</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.LowerLimit</Name>
-            <Value>1</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.UpperLimit</Name>
-            <Value>20</Value>
-          </SubItem>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>omit</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fString</Name>
-        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-        <Comment>Use to create good log messages, similar to C++ fstring</Comment>
-        <BitSize>8576</BitSize>
-        <BitOffs>41088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>omit</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">E_MotionRequest</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>WAIT</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>INTERRUPT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ABORT</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionRequest</Name>
-      <BitSize>1920</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start move on rising edge, stop move on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Reset errors on rising edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
-        <Comment> Define behavior for when the motor is already moving</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Goal position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVel</Name>
-        <Type>LREAL</Type>
-        <Comment> Move velocity</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAcc</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional acceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDec</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional deceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if in error state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> What the error code means</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and our most recent move was successful</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftExec</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nState</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bMyMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCausedError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>INIT</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1760</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_EXEC</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1776</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>PICK_REQUEST</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1792</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_OTHER_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1808</BitOffs>
-        <Default>
-          <Value>3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>STOP_OTHER_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1824</BitOffs>
-        <Default>
-          <Value>4</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>START_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1840</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_MY_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Default>
-          <Value>6</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>STOP_MY_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1872</BitOffs>
-        <Default>
-          <Value>7</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>DONE_MOVING</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1888</BitOffs>
-        <Default>
-          <Value>8</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ERROR</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1904</BitOffs>
-        <Default>
-          <Value>9</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -43592,6 +41051,35 @@ Use this thing to have a simple indexer with rollover.
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_BufferMode</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>MC_Aborting</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_Buffered</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingLow</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingPrevious</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingNext</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingHigh</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_PowerOptions</Name>
@@ -49464,6 +46952,525 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearInDynOptions</Name>
+      <BitSize>8</BitSize>
+      <SubItem>
+        <Name>CCVmode</Name>
+        <Type>BOOL</Type>
+        <Comment> constant circumference velocity mode </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Name>
+      <BitSize>384</BitSize>
+      <SubItem>
+        <Name>nSlaveType</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nMasterAxisId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nMasterSubIdx</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nSlaveSubIdx</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam2</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam3</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam4</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearInDyn</Name>
+      <BitSize>4416</BitSize>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Enable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GearRatio</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Acceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> not used </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Jerk</Name>
+        <Type>LREAL</Type>
+        <Comment> not used </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BufferMode</Name>
+        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearInDynOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Active</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>552</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CommandAborted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>720</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>iSubState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRead</Name>
+        <Type Namespace="Tc2_System">ADSREAD</Type>
+        <BitSize>1408</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCouple</Name>
+        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>3520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>v_max</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pa_limit</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WasInGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iAcceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>4096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>4160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearOutOptions</Name>
+      <BitSize>8</BitSize>
+      <SubItem>
+        <Name>reserved</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearOut</Name>
+      <BitSize>2112</BitSize>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Execute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearOutOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Done</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>336</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOnTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_DriveVirtual</Name>
       <BitSize>181056</BitSize>
       <SubItem>
@@ -50456,6 +48463,28 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_SetEnables</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_EncoderValue</Name>
       <BitSize>128</BitSize>
       <SubItem>
@@ -50856,2389 +48885,6 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>128</BitSize>
         <BitOffs>327296</BitOffs>
       </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_MotionRequest</Name>
-      <BitSize>16</BitSize>
-      <BaseType Namespace="lcls_twincat_motion">E_MotionRequest</BaseType>
-      <Properties>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use E_MotionRequest</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">E_PiezoControl</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>EPC_Idle</Text>
-        <Enum>0</Enum>
-        <Comment>Piezo Control Machine</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_Init</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MoveRequested</Text>
-        <Enum>50</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MovingPositive</Text>
-        <Enum>100</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MovingNegative</Text>
-        <Enum>200</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MoveCompleted</Text>
-        <Enum>350</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_Error</Text>
-        <Enum>500</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eCTRL_MODE_IDLE</Text>
-        <Enum>0</Enum>
-        <Comment> mode idle					</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_PASSIVE</Text>
-        <Enum>1</Enum>
-        <Comment> mode passive				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_ACTIVE</Text>
-        <Enum>2</Enum>
-        <Comment> mode active					</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_RESET</Text>
-        <Enum>3</Enum>
-        <Comment> mode reset					</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_MANUAL</Text>
-        <Enum>4</Enum>
-        <Comment> mode manual				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_TUNE</Text>
-        <Enum>5</Enum>
-        <Comment> mode tuning				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_SELFTEST</Text>
-        <Enum>6</Enum>
-        <Comment> mode selftest				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_SYNC_MOVEMENT</Text>
-        <Enum>7</Enum>
-        <Comment> mode synchronize			</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_FREEZE</Text>
-        <Enum>8</Enum>
-        <Comment> mode freeze				</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eCTRL_STATE_IDLE</Text>
-        <Enum>0</Enum>
-        <Comment> state idle		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_PASSIVE</Text>
-        <Enum>1</Enum>
-        <Comment> state passive	</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_ACTIVE</Text>
-        <Enum>2</Enum>
-        <Comment> state active		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_RESET</Text>
-        <Enum>3</Enum>
-        <Comment> state reset		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_MANUAL</Text>
-        <Enum>4</Enum>
-        <Comment> state manual	</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_TUNING</Text>
-        <Enum>5</Enum>
-        <Comment> state tuning		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_TUNED</Text>
-        <Enum>6</Enum>
-        <Comment> state tuning ready - tuned		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_SELFTEST</Text>
-        <Enum>7</Enum>
-        <Comment> state selftest		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_ERROR</Text>
-        <Enum>8</Enum>
-        <Comment> state error		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_SYNC_MOVEMENT</Text>
-        <Enum>9</Enum>
-        <Comment> state synchronizing movement		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_FREEZE</Text>
-        <Enum>10</Enum>
-        <Comment> state freeze 	</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_NOERROR</Text>
-        <Enum>0</Enum>
-        <Comment> no error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDTASKCYCLETIME</Text>
-        <Enum>1</Enum>
-        <Comment> invalid task cycle time </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDCTRLCYCLETIME</Text>
-        <Enum>2</Enum>
-        <Comment> invalid ctrl cycle time </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM</Text>
-        <Enum>3</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tv</Text>
-        <Enum>4</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Td</Text>
-        <Enum>5</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tn</Text>
-        <Enum>6</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Ti</Text>
-        <Enum>7</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fHystereisisRange</Text>
-        <Enum>8</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fPosOutOn_Off</Text>
-        <Enum>9</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fNegOutOn_Off</Text>
-        <Enum>10</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_TableDescription</Text>
-        <Enum>11</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_TableData</Text>
-        <Enum>12</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableADR</Text>
-        <Enum>13</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T0</Text>
-        <Enum>14</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T1</Text>
-        <Enum>15</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T2</Text>
-        <Enum>16</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T3</Text>
-        <Enum>17</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Theta</Text>
-        <Enum>18</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nOrder</Text>
-        <Enum>19</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tt</Text>
-        <Enum>20</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tu</Text>
-        <Enum>21</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tg</Text>
-        <Enum>22</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_infinite_slope</Text>
-        <Enum>23</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxIsLessThanfMin</Text>
-        <Enum>24</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOutMaxLimitIsLessThanfOutMinLimit</Text>
-        <Enum>25</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindow</Text>
-        <Enum>26</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fInnerWindow</Text>
-        <Enum>27</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindowIsLessThanfInnerWindow</Text>
-        <Enum>28</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandInput</Text>
-        <Enum>29</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandOutput</Text>
-        <Enum>30</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_PWM_Cycletime</Text>
-        <Enum>31</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_no_Parameterset</Text>
-        <Enum>32</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOn</Text>
-        <Enum>33</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOff</Text>
-        <Enum>34</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fGain</Text>
-        <Enum>35</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOffset</Text>
-        <Enum>36</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_MODE_NOT_SUPPORTED</Text>
-        <Enum>37</Enum>
-        <Comment> invalid mode: mode not supported </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_heating</Text>
-        <Enum>38</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Td_heating</Text>
-        <Enum>39</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_heating</Text>
-        <Enum>40</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_cooling</Text>
-        <Enum>41</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Td_cooling</Text>
-        <Enum>42</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_cooling</Text>
-        <Enum>43</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_RANGE_NOT_SUPPORTED</Text>
-        <Enum>44</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nParameterChangeCycleTicks</Text>
-        <Enum>45</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_ParameterEstimationFailed</Text>
-        <Enum>46</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_NoiseLevelToHigh</Text>
-        <Enum>47</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_0</Text>
-        <Enum>48</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_1</Text>
-        <Enum>49</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_2</Text>
-        <Enum>50</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_3</Text>
-        <Enum>51</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_4</Text>
-        <Enum>52</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_5</Text>
-        <Enum>53</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_6</Text>
-        <Enum>54</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_7</Text>
-        <Enum>55</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_8</Text>
-        <Enum>56</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_9</Text>
-        <Enum>57</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArrayADR</Text>
-        <Enum>58</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tOnTime</Text>
-        <Enum>59</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tOffTime</Text>
-        <Enum>60</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nMaxMovingPulses</Text>
-        <Enum>61</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nAdditionalPulsesAtLimits</Text>
-        <Enum>62</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fCtrlOutMax_Min</Text>
-        <Enum>63</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeltaMax</Text>
-        <Enum>64</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tMovingTime</Text>
-        <Enum>65</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tDeadTime</Text>
-        <Enum>66</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tAdditionalMoveTimeAtLimits</Text>
-        <Enum>67</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fThreshold</Text>
-        <Enum>68</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_MEMCPY</Text>
-        <Enum>69</Enum>
-        <Comment> MEMCPY failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_MEMSET</Text>
-        <Enum>70</Enum>
-        <Comment> MEMSET failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfColumns</Text>
-        <Enum>71</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileClose</Text>
-        <Enum>72</Enum>
-        <Comment> File Close  failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileOpen</Text>
-        <Enum>73</Enum>
-        <Comment> File Open failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileWrite</Text>
-        <Enum>74</Enum>
-        <Comment> File Write failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloNeg</Text>
-        <Enum>75</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloPos</Text>
-        <Enum>76</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandInput</Text>
-        <Enum>77</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandOutput</Text>
-        <Enum>78</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_CycleDuration</Text>
-        <Enum>79</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tStart</Text>
-        <Enum>80</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_StepHeigthTuningToLow</Text>
-        <Enum>81</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsLessThanZero</Text>
-        <Enum>82</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxLimitIsGreaterThan100</Text>
-        <Enum>83</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fStepSize</Text>
-        <Enum>84</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOkRangeIsLessOrEqualZero</Text>
-        <Enum>85</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fForceRangeIsLessOrEqualfOkRange</Text>
-        <Enum>86</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPWMPeriod</Text>
-        <Enum>87</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tMinimumPulseTime</Text>
-        <Enum>88</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileDelete</Text>
-        <Enum>89</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfPwmOutputs</Text>
-        <Enum>90</Enum>
-        <Comment> File Delete failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_SIZEOF</Text>
-        <Enum>91</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_SIZEOF</Text>
-        <Enum>92</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_SIZEOF</Text>
-        <Enum>93</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_SIZEOF</Text>
-        <Enum>94</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_SIZEOF</Text>
-        <Enum>95</Enum>
-        <Comment> SiZEOF failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction</Text>
-        <Enum>96</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_SIZEOF</Text>
-        <Enum>97</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_SIZEOF</Text>
-        <Enum>98</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_a_n_IsZero</Text>
-        <Enum>99</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArraySIZEOF</Text>
-        <Enum>100</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGRANGE_MIN_MAX</Text>
-        <Enum>101</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGTIME</Text>
-        <Enum>102</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DEADTIME</Text>
-        <Enum>103</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsGreaterThanfMaxLimit</Text>
-        <Enum>104</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableSIZEOF</Text>
-        <Enum>105</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_OutputVectorDescription</Text>
-        <Enum>106</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_TaskCycleTimeIsLessThanOneMillisecond</Text>
-        <Enum>107</Enum>
-        <Comment>  </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nMinMovingPulses</Text>
-        <Enum>108</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fAcceleration</Text>
-        <Enum>109</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeceleration</Text>
-        <Enum>110</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_StartAndTargetPos</Text>
-        <Enum>111</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fVelocity</Text>
-        <Enum>112</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetPos</Text>
-        <Enum>113</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fStartPos</Text>
-        <Enum>114</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMovingLength</Text>
-        <Enum>115</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_NT_GetTime</Text>
-        <Enum>116</Enum>
-        <Comment> internal error NT_GetTime </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_No3PhaseSolutionPossible</Text>
-        <Enum>117</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fStartVelo</Text>
-        <Enum>118</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetVelo</Text>
-        <Enum>119</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALID_NEW_PARAMETER_TYPE</Text>
-        <Enum>120</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fBaseTime</Text>
-        <Enum>121</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction_SIZEOF</Text>
-        <Enum>122</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nFilterOrder</Text>
-        <Enum>124</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_SIZEOF</Text>
-        <Enum>125</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_SIZEOF</Text>
-        <Enum>126</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_SIZEOF</Text>
-        <Enum>127</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_SIZEOF</Text>
-        <Enum>128</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_LogBufferOverflow</Text>
-        <Enum>129</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_ADR</Text>
-        <Enum>130</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_ADR</Text>
-        <Enum>131</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_ADR</Text>
-        <Enum>132</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_ADR</Text>
-        <Enum>133</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_ADR</Text>
-        <Enum>134</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_ADR</Text>
-        <Enum>135</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_ADR</Text>
-        <Enum>136</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_ADR</Text>
-        <Enum>137</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_ADR</Text>
-        <Enum>138</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_ADR</Text>
-        <Enum>139</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction1Data_ADR</Text>
-        <Enum>140</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction2Data_ADR</Text>
-        <Enum>141</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileSeek</Text>
-        <Enum>142</Enum>
-        <Comment> internal error FB_FileSeek </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_AmbientTempMaxIsLessThanAmbientTempMin</Text>
-        <Enum>143</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_ForerunTempMaxIsLessThanForerunTempMin</Text>
-        <Enum>144</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDLOGCYCLETIME</Text>
-        <Enum>145</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDVERSION_TcControllerToolbox</Text>
-        <Enum>146</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Bandwidth</Text>
-        <Enum>147</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_NotchFrequency</Text>
-        <Enum>148</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DampingCoefficient</Text>
-        <Enum>149</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fKpIsLessThanZero</Text>
-        <Enum>150</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nSamplesToFilter</Text>
-        <Enum>151</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_PI</Name>
-      <BitSize>2240</BitSize>
-      <SubItem>
-        <Name>fSetpointValue</Name>
-        <Type>LREAL</Type>
-        <Comment> setpoint value of controlled variable </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fActualValue</Name>
-        <Type>LREAL</Type>
-        <Comment> actual value of the controlled variable </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fManSyncValue</Name>
-        <Type>LREAL</Type>
-        <Comment> manual value to synchronize controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSync</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge sets controller output manual sync value </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <Comment> operating mode </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHold</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE will hold the controller output at current value </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fOut</Name>
-        <Type>LREAL</Type>
-        <Comment> controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bARWactive</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE indicates that the controller output is restricted </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
-        <Comment> current state of the function block </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
-        <Comment> error code </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if error occurs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stParams</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_PI_PARAMS</Type>
-        <Comment> parameter structure </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalParams</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalCycleTimeInterpretation</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCallAfterAStateChange</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1032</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fD_I</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTaskCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fHalfCtrlCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTn</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bIPartEnabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSyncValueInternal</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLimitValue</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fE</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1600</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fE_1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1664</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY_I</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY_I_1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1792</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY_P</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1920</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nCtrlCycleTicks</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nActCtrlCycleTick</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2016</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>2048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMaxLimitReached</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2064</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMinLimitReached</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2072</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bSyncRequest</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbR_TRIG</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>2112</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>M_Error</Name>
-      </Action>
-      <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
-        <Name>M_Manual</Name>
-      </Action>
-      <Action>
-        <Name>M_Active</Name>
-      </Action>
-      <Action>
-        <Name>M_StateChange</Name>
-      </Action>
-      <Action>
-        <Name>M_Passive</Name>
-      </Action>
-      <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</Name>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>tTaskCycleTime</Name>
-        <Type>TIME</Type>
-        <Comment> task cycle time			[TIME]		</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tCtrlCycleTime</Name>
-        <Type>TIME</Type>
-        <Comment> controller cycle time 	[TIME]		</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloPos</Name>
-        <Type>LREAL</Type>
-        <Comment> velocity ramp by time, range &gt; 0.0 	</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloNeg</Name>
-        <Type>LREAL</Type>
-        <Comment> velocity ramp by time, range &gt; 0.0	</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Name>
-      <BitSize>192</BitSize>
-      <BaseType Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</BaseType>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Name>
-      <BitSize>1280</BitSize>
-      <SubItem>
-        <Name>fStartValue</Name>
-        <Type>LREAL</Type>
-        <Comment> starting value of the ramp </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fTargetValue</Name>
-        <Type>LREAL</Type>
-        <Comment> target value of the ramp </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fManValue</Name>
-        <Type>LREAL</Type>
-        <Comment> manual value to synchronize controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHold</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE will hold the controller output at current value </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <Comment> operating mode </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fOut</Name>
-        <Type>LREAL</Type>
-        <Comment> controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloOut</Name>
-        <Type>LREAL</Type>
-        <Comment> current velocity of the ramp generator </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValueReached</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE indicates that target value is reached </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
-        <Comment> current state of the function block </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
-        <Comment> error code </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if error occurs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stParams</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
-        <Comment> parameter structure </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fTaskCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutLocal</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bGetStartValue</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>768</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalParams</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
-        <BitSize>192</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalCycleTimeInterpretation</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCtrlCycleTicks</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nActCtrlCycleTick</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1232</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>M_Error</Name>
-      </Action>
-      <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
-        <Name>M_Manual</Name>
-      </Action>
-      <Action>
-        <Name>M_Active</Name>
-      </Action>
-      <Action>
-        <Name>M_StateChange</Name>
-      </Action>
-      <Action>
-        <Name>M_Passive</Name>
-      </Action>
-      <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Name>
-      <BitSize>768</BitSize>
-      <SubItem>
-        <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <Comment> operating mode </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tTaskCycleTime</Name>
-        <Type>TIME</Type>
-        <Comment> resolution  1ms</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bCycleTimeValid</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if cycle time is valid </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
-        <Comment> current state of the function block </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
-        <Comment> error code </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if error occurs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>184</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nCpuCntLoDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCpuCntHiDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLastcpuCntLoDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLastcpuCntHiDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCycleTimeDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCycleTimeDWold</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCallReady</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGETCPUCOUNTER</Name>
-        <Type Namespace="Tc2_System">GETCPUCOUNTER</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
-        <Name>M_StateChange</Name>
-      </Action>
-      <Action>
-        <Name>M_Active</Name>
-      </Action>
-      <Action>
-        <Name>M_Passive</Name>
-      </Action>
-      <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_PiezoControl</Name>
-      <BitSize>6720</BitSize>
-      <SubItem>
-        <Name>iq_Piezo</Name>
-        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">ST_PiezoAxis</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xExecute</Name>
-        <Type>BOOL</Type>
-        <Comment>Rising edge being piezo motion</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable_Positive</Name>
-        <Type>BOOL</Type>
-        <Comment>Reverse of Positive Limit Switch</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable_Negative</Name>
-        <Type>BOOL</Type>
-        <Comment>Reverse of Negative Limit Switch</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xBusy</Name>
-        <Type>BOOL</Type>
-        <Comment>Busy remains true while piezo position is being adjusted</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xDone</Name>
-        <Type>BOOL</Type>
-        <Comment>Reached target position</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xError</Name>
-        <Type>BOOL</Type>
-        <Comment>General error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xLimited</Name>
-        <Type>BOOL</Type>
-        <Comment>Piezo move was limited</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>E_State</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">E_PiezoControl</Type>
-        <Comment>ENUM for Piezo Control State</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtStartMove</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <Comment>Rising Trigger for Execution</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <Comment>Rising Trigger for Error reset</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rSetpoint</Name>
-        <Type>REAL</Type>
-        <Comment>Internal Storage of Setpoint</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rReqVoltage</Name>
-        <Type>REAL</Type>
-        <Comment>requested voltage</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rLLSV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rHLSV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>608</BitOffs>
-        <Default>
-          <Value>120</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbPI</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_PI</Type>
-        <BitSize>2240</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbRamp</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Type>
-        <BitSize>1280</BitSize>
-        <BitOffs>2880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInitialized</Name>
-        <Type>BOOL</Type>
-        <Comment> FB initialized flag</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>4160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCycleTime</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Type>
-        <Comment>Get cycle time for control FBs</Comment>
-        <BitSize>768</BitSize>
-        <BitOffs>4224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tTaskCycleTime</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>4992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCycleTimeValid</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>5024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtVoltMode</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>5056</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOut</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>5184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPiezoBias</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>5248</BitOffs>
-        <Default>
-          <Value>60</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fScale</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>5312</BitOffs>
-        <Default>
-          <Value>-60</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tonPiezoDone</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>5376</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#2S</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tonPiezoLimited</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>5632</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#500MS</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>xVoltageLimited</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>5888</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftEnPos</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>5952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftEnNeg</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtEnPos</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtEnNeg</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6336</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutLimitHolder</Name>
-        <Type>LREAL</Type>
-        <Comment>holds the limit value until restored</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>6464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutHiLimHolder</Name>
-        <Type>LREAL</Type>
-        <Comment>holds the limit value until restored</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>6528</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutLoLimHolder</Name>
-        <Type>LREAL</Type>
-        <Comment>holds the limit value until restored</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>6592</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFirstPass</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>6656</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>ACT_CheckLimits</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Controller</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">E_PitchControl</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>PCM_Init</Text>
-        <Enum>0</Enum>
-        <Comment>Pitch Control Machine</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Standby</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_MoveRequested</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Coarse50Piezo</Text>
-        <Enum>20</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_CoarseMove</Text>
-        <Enum>21</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_CoarseMoveCleanup</Text>
-        <Enum>22</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_FineMove</Text>
-        <Enum>30</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Halt</Text>
-        <Enum>50</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Done</Text>
-        <Enum>8000</Enum>
-        <Comment>why is 8000 done? Where did this come from??</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Error</Text>
-        <Enum>9000</Enum>
-        <Comment>Anything above 9000 is considered an error</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_StepperError</Text>
-        <Enum>9100</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_PiezoError</Text>
-        <Enum>9200</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_OtherError</Text>
-        <Enum>9300</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_STOHit</Text>
-        <Enum>9400</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_PitchControl</Name>
-      <BitSize>397888</BitSize>
-      <SubItem>
-        <Name>Pitch</Name>
-        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">HOMS_PitchMechanism</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Stepper</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>lrCurrentSetpoint</Name>
-        <Type>LREAL</Type>
-        <Comment> Setpoint: Epics writes to ST_MotionStage which gets fed into this</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_bDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>264</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_bBusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDiag</Name>
-        <Type Namespace="LCLS_General">ST_FbDiagnostics</Type>
-        <Comment> Logging</Comment>
-        <BitSize>49664</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbFormatString</Name>
-        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>49984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>POUName</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <Comment> Name of the POU for logging/error reporting</Comment>
-        <BitSize>2048</BitSize>
-        <BitOffs>58560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>no_init</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>lrActPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Actual Position of piezo mechanism</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrPrevStepperPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Previous successfully achieved stepper position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftLimitSwitch</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>60736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrOriginalPosRequest</Name>
-        <Type>LREAL</Type>
-        <Comment> Used for logging</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60864</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrLastSetpoint</Name>
-        <Type>LREAL</Type>
-        <Comment> Previous successfully achieved setpoint</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60928</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
-        <BitSize>1920</BitSize>
-        <BitOffs>60992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>327424</BitSize>
-        <BitOffs>62912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLimitHit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>390336</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonStepperHold</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Timer to hold stepper position while the system relaxes</Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>390400</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#100MS</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rSettledRange</Name>
-        <Type>REAL</Type>
-        <Comment> Units = urad</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>390656</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bResetStepper</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>390688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteStepper</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>390696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
-        <Comment> Wait for move to complete before taking another request</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>390704</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tonPiezoSettled</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Piezo</Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>390720</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#2S</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbPiezoControl</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">FB_PiezoControl</Type>
-        <BitSize>6720</BitSize>
-        <BitOffs>390976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtPiezoMoveDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>397696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PC_State</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">E_PitchControl</Type>
-        <Comment> State Machine</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>397824</BitOffs>
-        <Default>
-          <EnumText>E_PitchControl.PCM_Init</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bCoarse50PiezoMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>397840</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>ACT_ResetSetpoint</Name>
-      </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -54553,6 +50199,42 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
+      <BitSize>0</BitSize>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Name>
+      <Comment> Renishaw BiSS-C absolute encoder used with an EL5042</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>Count</Name>
+        <Type>ULINT</Type>
+        <Comment> Connect to encoder "Position" input</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Status</Name>
+        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
+        <Comment> Status struct placeholder</Comment>
+        <BitSize>0</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Ref</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder zero position (useful for aligned position with gantries)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General">FB_TempSensor</Name>
       <BitSize>256</BitSize>
       <SubItem>
@@ -54911,6 +50593,348 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">E_MotionRequest</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>WAIT</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>INTERRUPT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ABORT</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionRequest</Name>
+      <BitSize>1920</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start move on rising edge, stop move on falling edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset errors on rising edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when the motor is already moving</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Goal position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVel</Name>
+        <Type>LREAL</Type>
+        <Comment> Move velocity</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAcc</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional acceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDec</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional deceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> True if in error state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> What the error code means</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are moving the motor</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are not moving the motor and our most recent move was successful</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bMyMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1744</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCausedError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>INIT</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1760</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_EXEC</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1776</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>PICK_REQUEST</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_OTHER_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>STOP_OTHER_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1824</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>START_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1840</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_MY_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Default>
+          <Value>6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>STOP_MY_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1872</BitOffs>
+        <Default>
+          <Value>7</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>DONE_MOVING</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1888</BitOffs>
+        <Default>
+          <Value>8</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ERROR</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1904</BitOffs>
+        <Default>
+          <Value>9</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
@@ -57800,6 +53824,110 @@ ELSE:
       </EnumInfo>
     </DataType>
     <DataType>
+      <Name Namespace="LCLS_General">FB_Index</Name>
+      <Comment> Index FB
+A. Wallace 2016-9-3
+
+Why doesn't beckhoff have this as a builtin type?
+
+Use this thing to have a simple indexer with rollover.
+
+</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>LowerLimit</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer will rollver over to this value (and initialize to this value)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>naming</Name>
+            <Value>off</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ValInc</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer increments by this value</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>UpperLimit</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer will rollover at this value to lower limit</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nVal</Name>
+        <Type>INT</Type>
+        <Comment>Internal incrementer value, initialized to LowerLimit</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>112</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>off</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>Dec</Name>
+      </Action>
+      <Action>
+        <Name>Inc</Name>
+      </Action>
+      <Method>
+        <Name>DecVal</Name>
+        <Comment>Decrement the counter and return new value</Comment>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IncVal</Name>
+        <Comment>Increment the counter and return new value</Comment>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="PMPS">BeamParameterTransitionManager</Name>
       <Comment>
 Implements the procedure for safely transitioning between device states.
@@ -60002,124 +56130,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</Name>
-      <BitSize>1216</BitSize>
-      <SubItem>
-        <Name>fFlow_1_val</Name>
-        <Type>LREAL</Type>
-        <Comment> Mirrors with 1 Cooling Flow Meter and 1 Pressure Meter</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: FWM:1
-        field: EGU lpm
-        field: HIGH 2.3
-        field: HIHI 3.0
-        field: LOW 1.7
-        field: LOLO 1.5
-		field: LSV MINOR
-		field: LLSV MAJOR
-		field: HSV MINOR
-		field: HHSV MAJOR
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPress_1_val</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PRSM:1
-        field: EGU bar
-        field: LOW 0.1
-		field: LSV MAJOR
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFlow_1</Name>
-        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbPress_1</Name>
-        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</Name>
-      <BitSize>1792</BitSize>
-      <ExtendsType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</ExtendsType>
-      <SubItem>
-        <Name>fFlow_2_val</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: FWM:2
-        field: EGU lpm
-        field: HIGH 2.3
-        field: HIHI 3.0
-        field: LOW 1.7
-        field: LOLO 1.5
-		field: LSV MINOR
-		field: LLSV MAJOR
-		field: HSV MINOR
-		field: HHSV MAJOR
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFlow_2</Name>
-        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -72172,6 +68182,3996 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Property>
       </Properties>
     </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</Name>
+      <BitSize>1216</BitSize>
+      <SubItem>
+        <Name>fFlow_1_val</Name>
+        <Type>LREAL</Type>
+        <Comment> Mirrors with 1 Cooling Flow Meter and 1 Pressure Meter</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM:1
+        field: EGU lpm
+        field: HIGH 2.3
+        field: HIHI 3.0
+        field: LOW 1.7
+        field: LOLO 1.5
+        field: LSV MINOR
+        field: LLSV MAJOR
+        field: HSV MINOR
+        field: HHSV MAJOR
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPress_1_val</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PRSM:1
+        field: EGU bar
+        field: LOW 0.1
+        field: LSV MAJOR
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlow_1</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPress_1</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</Name>
+      <BitSize>1792</BitSize>
+      <ExtendsType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</ExtendsType>
+      <SubItem>
+        <Name>fFlow_2_val</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM:2
+        field: EGU lpm
+        field: HIGH 2.3
+        field: HIHI 3.0
+        field: LOW 1.7
+        field: LOLO 1.5
+        field: LSV MINOR
+        field: LLSV MAJOR
+        field: HSV MINOR
+        field: HHSV MAJOR
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlow_2</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Name>
+      <BitSize>512</BitSize>
+      <SubItem>
+        <Name>PEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Primary axis encoder (usually the upstream one)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Secondary axis encoder (couples to the primary)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GantDiffTol</Name>
+        <Type>LINT</Type>
+        <Comment> Gantry differenace tolerance in encoder counts</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PLimFwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Primary axis forward direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PLimBwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Primary axis reverse direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SLimFwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Secondary axis forward direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SLimBwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Secondary axis reverse direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GantryDiff</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR</Text>
+        <Enum>1</Enum>
+        <Comment> Lineare Kopplung (Geradengleichung) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONVELOCITY</Text>
+        <Enum>2</Enum>
+        <Comment> diagonal synchron. Aufkoppeln schnellstens auf Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONPOSITION</Text>
+        <Enum>3</Enum>
+        <Comment> diagonal synchron. Aufkoppeln auf Position und Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_QUADRATIC</Text>
+        <Enum>4</Enum>
+        <Comment> diagonal synchron. Aufkoppeln (quadratisches Geschw.-Profil) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONVELO</Text>
+        <Enum>5</Enum>
+        <Comment> synchron. Aufkoppeln instantan auf Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONPOS</Text>
+        <Enum>6</Enum>
+        <Comment> synchron. Aufkoppeln auf Positionen und Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCJERKSETTER_ONVELO</Text>
+        <Enum>7</Enum>
+        <Comment> synchron. Aufkoppeln auf Geschwindigkeit (zeitbasiert mittels Ruck-Steller) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_TABULAR</Text>
+        <Enum>10</Enum>
+        <Comment> Tabellen-Kopplung ("simple/standard tabular slave") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_MULTITABULAR</Text>
+        <Enum>11</Enum>
+        <Comment> Tabellen-Kopplung ("multiscalable multi-tabular slave") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGMODULO_LINEAR</Text>
+        <Enum>12</Enum>
+        <Comment> Modulo Kopplung auf Position und/oder Geschwindigkeit mit anschliessender Linear Kopplung ("Schuette") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_MOTIONFUNCTIONTABULAR</Text>
+        <Enum>13</Enum>
+        <Comment> Tabellen-Kopplung "motion functions" </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_UNIVERSALTABULAR</Text>
+        <Enum>14</Enum>
+        <Comment> Tabellen-Kopplung, universal tabular type substitues TABULAR, MULTITABULAR and MOTIONFUNCTION - 08.07.05 </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR_CYCLICCHANGES_RAMP</Text>
+        <Enum>15</Enum>
+        <Comment> Lineare Kopplung (Geradengleichung) mit zyklischer Koppelfaktoraenderung </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_BILINEAR</Text>
+        <Enum>16</Enum>
+        <Comment> 27.04.01: Zweifach Lineare Kopplung (Geradengleichung)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR_MULTIMASTER</Text>
+        <Enum>17</Enum>
+        <Comment> 29.05.08: Lineare Multi-Master-Kopplung ('MC_GearInMultiMaster') </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_CONST_SURFACEVELO_RAMP</Text>
+        <Enum>18</Enum>
+        <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
+      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>SlaveType</Name>
+        <Type Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearIn</Name>
+      <BitSize>7360</BitSize>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Execute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RatioNumerator</Name>
+        <Type>LREAL</Type>
+        <Comment> changed from INT (PLCopen) to LREAL </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RatioDenominator</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Acceleration</Name>
+        <Type>LREAL</Type>
+        <Comment>	MasterValueSource :	MC_SOURCE; 
+ not available </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Jerk</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BufferMode</Name>
+        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearInOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>616</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Active</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CommandAborted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>632</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>816</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCouple</Name>
+        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>2176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOptGearInDyn</Name>
+        <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
+        <BitSize>4416</BitSize>
+        <BitOffs>2560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOnTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>7104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ActGearInDyn</Name>
+      </Action>
+      <Action>
+        <Name>WriteGearRatio</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Name>
+      <BitSize>10752</BitSize>
+      <SubItem>
+        <Name>nGantryTol</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MasterEnc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SlaveEnc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCouple</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecouple</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>gantry_diff_limit</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>couple</Name>
+        <Type Namespace="Tc2_MC2">MC_GearIn</Type>
+        <BitSize>7360</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>decouple</Name>
+        <Type Namespace="Tc2_MC2">MC_GearOut</Type>
+        <BitSize>2112</BitSize>
+        <BitOffs>8448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInitComplete</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>10560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbSetEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>10624</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_RunHOMS</Name>
+      <BitSize>23296</BitSize>
+      <SubItem>
+        <Name>nYupEncRef</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder Reference Values</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nYdwnEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nXupEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nXdwnEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTolY</Name>
+        <Type>LINT</Type>
+        <Comment> Encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>50000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTolX</Name>
+        <Type>LINT</Type>
+        <Comment> Encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>50000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledY</Name>
+        <Type>BOOL</Type>
+        <Comment> Gantry coupling status</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryY</Name>
+        <Type>LINT</Type>
+        <Comment> Current gantry difference</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryX</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYup</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor Structs</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYdwn</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXup</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXdwn</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPitch</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleY</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <Comment> Manual coupling Gantried Axes</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleX</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleY</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleX</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable1</Name>
+        <Type>BOOL</Type>
+        <Comment> STO Button</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable2</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYupEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Encoders</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>1280</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYdwnEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXupEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXdwnEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1664</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAutoCoupleY</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
+        <Comment> Autocoupling Gantried Axes</Comment>
+        <BitSize>10752</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAutoCoupleX</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
+        <BitSize>10752</BitSize>
+        <BitOffs>12544</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">DUT_HOMS</Name>
+      <BitSize>23552</BitSize>
+      <SubItem>
+        <Name>fbRunHOMS</Name>
+        <Type Namespace="lcls_twincat_optics">FB_RunHOMS</Type>
+        <Comment> System initializiation</Comment>
+        <BitSize>23296</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleY</Name>
+        <Type>BOOL</Type>
+        <Comment> Couple/Decouple motors</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>23296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: COUPLE_Y
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DECOUPLE_Y
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: COUPLE_X
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DECOUPLE_X
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledY</Name>
+        <Type>BOOL</Type>
+        <Comment> Coupling status</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>23328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ALREADY_COUPLED_Y
+        io: i
+        field: ZSV MAJOR
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ALREADY_COUPLED_X
+        io: i
+        field: ZSV MAJOR
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryY</Name>
+        <Type>LINT</Type>
+        <Comment> encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>23360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryX</Name>
+        <Type>LINT</Type>
+        <Comment> encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>23424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrGantryY_um</Name>
+        <Type>REAL</Type>
+        <Comment> Y Gantry difference in um</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>23488</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GANTRY_Y
+        field: EGU um
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrGantryX_um</Name>
+        <Type>REAL</Type>
+        <Comment> X Gantry difference in um</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>23520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GANTRY_X
+        field: EGU um
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
+      <BitSize>128704</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we'll accumulate a value on this cycle.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fInput</Name>
+        <Type>LREAL</Type>
+        <Comment> The value to accumulate.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrOutput</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bNewArray</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrPartial</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>64256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataBuffer</Name>
+        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>128256</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
+      <BitSize>387520</BitSize>
+      <SubItem>
+        <Name>fMaxRMSError</Name>
+        <Type>LREAL</Type>
+        <Comment> RMS Error</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMinRMSError</Name>
+        <Type>LREAL</Type>
+        <Comment> start at something huge, FB will update with any smaller measured value</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScalingNum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScalingDenom</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncOffset</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScale</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataEncPos</Name>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
+        <Comment> ActPos Data Acquisition FB</Comment>
+        <BitSize>128704</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataSetPos</Name>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
+        <Comment> SetPos Data Acquisition FB</Comment>
+        <BitSize>128704</BitSize>
+        <BitOffs>129216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDataStorage</Name>
+        <Type>BOOL</Type>
+        <Comment> Take data of both ActPos and SetPos</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>257920</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bNewEncArray</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>257928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStats</Name>
+        <Type Namespace="LCLS_General">FB_BasicStats</Type>
+        <Comment> Calculate mean/standard deviation of ActPos</Comment>
+        <BitSize>1152</BitSize>
+        <BitOffs>257984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncMean</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MEAN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEncStDev</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STDEV
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrRMSError</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259264</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RMS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>259328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSum</Name>
+        <Type>LREAL</Type>
+        <Comment> Just for calculating rms</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>259392</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fDiff</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259456</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>aEncActPos</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>259520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ACTPOSARRAY
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>aEncSetPos</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>323520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: SETPOSARRAY
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">ST_FbDiagnostics</Name>
+      <Comment>Stuff to log messages within function blocks</Comment>
+      <BitSize>49664</BitSize>
+      <SubItem>
+        <Name>asResults</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>20</Elements>
+        </ArrayInfo>
+        <Comment>Diagnostic messages, use to record state changes or other important events.</Comment>
+        <BitSize>40960</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>resultIdx</Name>
+        <Type Namespace="LCLS_General">FB_Index</Type>
+        <Comment>Incrementer, included here to facilitate using asResults</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>40960</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.LowerLimit</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.UpperLimit</Name>
+            <Value>20</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>omit</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fString</Name>
+        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+        <Comment>Use to create good log messages, similar to C++ fstring</Comment>
+        <BitSize>8576</BitSize>
+        <BitOffs>41088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>omit</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ENUM_MotionRequest</Name>
+      <BitSize>16</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">E_MotionRequest</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use E_MotionRequest</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">E_PiezoControl</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>EPC_Idle</Text>
+        <Enum>0</Enum>
+        <Comment>Piezo Control Machine</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_Init</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MoveRequested</Text>
+        <Enum>50</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MovingPositive</Text>
+        <Enum>100</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MovingNegative</Text>
+        <Enum>200</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MoveCompleted</Text>
+        <Enum>350</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_Error</Text>
+        <Enum>500</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eCTRL_MODE_IDLE</Text>
+        <Enum>0</Enum>
+        <Comment> mode idle					</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_PASSIVE</Text>
+        <Enum>1</Enum>
+        <Comment> mode passive				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_ACTIVE</Text>
+        <Enum>2</Enum>
+        <Comment> mode active					</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_RESET</Text>
+        <Enum>3</Enum>
+        <Comment> mode reset					</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_MANUAL</Text>
+        <Enum>4</Enum>
+        <Comment> mode manual				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_TUNE</Text>
+        <Enum>5</Enum>
+        <Comment> mode tuning				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_SELFTEST</Text>
+        <Enum>6</Enum>
+        <Comment> mode selftest				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_SYNC_MOVEMENT</Text>
+        <Enum>7</Enum>
+        <Comment> mode synchronize			</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_FREEZE</Text>
+        <Enum>8</Enum>
+        <Comment> mode freeze				</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eCTRL_STATE_IDLE</Text>
+        <Enum>0</Enum>
+        <Comment> state idle		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_PASSIVE</Text>
+        <Enum>1</Enum>
+        <Comment> state passive	</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_ACTIVE</Text>
+        <Enum>2</Enum>
+        <Comment> state active		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_RESET</Text>
+        <Enum>3</Enum>
+        <Comment> state reset		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_MANUAL</Text>
+        <Enum>4</Enum>
+        <Comment> state manual	</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_TUNING</Text>
+        <Enum>5</Enum>
+        <Comment> state tuning		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_TUNED</Text>
+        <Enum>6</Enum>
+        <Comment> state tuning ready - tuned		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_SELFTEST</Text>
+        <Enum>7</Enum>
+        <Comment> state selftest		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_ERROR</Text>
+        <Enum>8</Enum>
+        <Comment> state error		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_SYNC_MOVEMENT</Text>
+        <Enum>9</Enum>
+        <Comment> state synchronizing movement		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_FREEZE</Text>
+        <Enum>10</Enum>
+        <Comment> state freeze 	</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_NOERROR</Text>
+        <Enum>0</Enum>
+        <Comment> no error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDTASKCYCLETIME</Text>
+        <Enum>1</Enum>
+        <Comment> invalid task cycle time </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDCTRLCYCLETIME</Text>
+        <Enum>2</Enum>
+        <Comment> invalid ctrl cycle time </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM</Text>
+        <Enum>3</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tv</Text>
+        <Enum>4</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Td</Text>
+        <Enum>5</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tn</Text>
+        <Enum>6</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Ti</Text>
+        <Enum>7</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fHystereisisRange</Text>
+        <Enum>8</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fPosOutOn_Off</Text>
+        <Enum>9</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fNegOutOn_Off</Text>
+        <Enum>10</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_TableDescription</Text>
+        <Enum>11</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_TableData</Text>
+        <Enum>12</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableADR</Text>
+        <Enum>13</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T0</Text>
+        <Enum>14</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T1</Text>
+        <Enum>15</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T2</Text>
+        <Enum>16</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T3</Text>
+        <Enum>17</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Theta</Text>
+        <Enum>18</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nOrder</Text>
+        <Enum>19</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tt</Text>
+        <Enum>20</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tu</Text>
+        <Enum>21</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tg</Text>
+        <Enum>22</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_infinite_slope</Text>
+        <Enum>23</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxIsLessThanfMin</Text>
+        <Enum>24</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOutMaxLimitIsLessThanfOutMinLimit</Text>
+        <Enum>25</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindow</Text>
+        <Enum>26</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fInnerWindow</Text>
+        <Enum>27</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindowIsLessThanfInnerWindow</Text>
+        <Enum>28</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandInput</Text>
+        <Enum>29</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandOutput</Text>
+        <Enum>30</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_PWM_Cycletime</Text>
+        <Enum>31</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_no_Parameterset</Text>
+        <Enum>32</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOn</Text>
+        <Enum>33</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOff</Text>
+        <Enum>34</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fGain</Text>
+        <Enum>35</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOffset</Text>
+        <Enum>36</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_MODE_NOT_SUPPORTED</Text>
+        <Enum>37</Enum>
+        <Comment> invalid mode: mode not supported </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_heating</Text>
+        <Enum>38</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Td_heating</Text>
+        <Enum>39</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_heating</Text>
+        <Enum>40</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_cooling</Text>
+        <Enum>41</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Td_cooling</Text>
+        <Enum>42</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_cooling</Text>
+        <Enum>43</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_RANGE_NOT_SUPPORTED</Text>
+        <Enum>44</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nParameterChangeCycleTicks</Text>
+        <Enum>45</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_ParameterEstimationFailed</Text>
+        <Enum>46</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_NoiseLevelToHigh</Text>
+        <Enum>47</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_0</Text>
+        <Enum>48</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_1</Text>
+        <Enum>49</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_2</Text>
+        <Enum>50</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_3</Text>
+        <Enum>51</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_4</Text>
+        <Enum>52</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_5</Text>
+        <Enum>53</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_6</Text>
+        <Enum>54</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_7</Text>
+        <Enum>55</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_8</Text>
+        <Enum>56</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_9</Text>
+        <Enum>57</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArrayADR</Text>
+        <Enum>58</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tOnTime</Text>
+        <Enum>59</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tOffTime</Text>
+        <Enum>60</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nMaxMovingPulses</Text>
+        <Enum>61</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nAdditionalPulsesAtLimits</Text>
+        <Enum>62</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fCtrlOutMax_Min</Text>
+        <Enum>63</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeltaMax</Text>
+        <Enum>64</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tMovingTime</Text>
+        <Enum>65</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tDeadTime</Text>
+        <Enum>66</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tAdditionalMoveTimeAtLimits</Text>
+        <Enum>67</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fThreshold</Text>
+        <Enum>68</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_MEMCPY</Text>
+        <Enum>69</Enum>
+        <Comment> MEMCPY failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_MEMSET</Text>
+        <Enum>70</Enum>
+        <Comment> MEMSET failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfColumns</Text>
+        <Enum>71</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileClose</Text>
+        <Enum>72</Enum>
+        <Comment> File Close  failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileOpen</Text>
+        <Enum>73</Enum>
+        <Comment> File Open failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileWrite</Text>
+        <Enum>74</Enum>
+        <Comment> File Write failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloNeg</Text>
+        <Enum>75</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloPos</Text>
+        <Enum>76</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandInput</Text>
+        <Enum>77</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandOutput</Text>
+        <Enum>78</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_CycleDuration</Text>
+        <Enum>79</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tStart</Text>
+        <Enum>80</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_StepHeigthTuningToLow</Text>
+        <Enum>81</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsLessThanZero</Text>
+        <Enum>82</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxLimitIsGreaterThan100</Text>
+        <Enum>83</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fStepSize</Text>
+        <Enum>84</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOkRangeIsLessOrEqualZero</Text>
+        <Enum>85</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fForceRangeIsLessOrEqualfOkRange</Text>
+        <Enum>86</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPWMPeriod</Text>
+        <Enum>87</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tMinimumPulseTime</Text>
+        <Enum>88</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileDelete</Text>
+        <Enum>89</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfPwmOutputs</Text>
+        <Enum>90</Enum>
+        <Comment> File Delete failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_SIZEOF</Text>
+        <Enum>91</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_SIZEOF</Text>
+        <Enum>92</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_SIZEOF</Text>
+        <Enum>93</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_SIZEOF</Text>
+        <Enum>94</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_SIZEOF</Text>
+        <Enum>95</Enum>
+        <Comment> SiZEOF failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction</Text>
+        <Enum>96</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_SIZEOF</Text>
+        <Enum>97</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_SIZEOF</Text>
+        <Enum>98</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_a_n_IsZero</Text>
+        <Enum>99</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArraySIZEOF</Text>
+        <Enum>100</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGRANGE_MIN_MAX</Text>
+        <Enum>101</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGTIME</Text>
+        <Enum>102</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DEADTIME</Text>
+        <Enum>103</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsGreaterThanfMaxLimit</Text>
+        <Enum>104</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableSIZEOF</Text>
+        <Enum>105</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_OutputVectorDescription</Text>
+        <Enum>106</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_TaskCycleTimeIsLessThanOneMillisecond</Text>
+        <Enum>107</Enum>
+        <Comment>  </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nMinMovingPulses</Text>
+        <Enum>108</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fAcceleration</Text>
+        <Enum>109</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeceleration</Text>
+        <Enum>110</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_StartAndTargetPos</Text>
+        <Enum>111</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fVelocity</Text>
+        <Enum>112</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetPos</Text>
+        <Enum>113</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fStartPos</Text>
+        <Enum>114</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMovingLength</Text>
+        <Enum>115</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_NT_GetTime</Text>
+        <Enum>116</Enum>
+        <Comment> internal error NT_GetTime </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_No3PhaseSolutionPossible</Text>
+        <Enum>117</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fStartVelo</Text>
+        <Enum>118</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetVelo</Text>
+        <Enum>119</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALID_NEW_PARAMETER_TYPE</Text>
+        <Enum>120</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fBaseTime</Text>
+        <Enum>121</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction_SIZEOF</Text>
+        <Enum>122</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nFilterOrder</Text>
+        <Enum>124</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_SIZEOF</Text>
+        <Enum>125</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_SIZEOF</Text>
+        <Enum>126</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_SIZEOF</Text>
+        <Enum>127</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_SIZEOF</Text>
+        <Enum>128</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_LogBufferOverflow</Text>
+        <Enum>129</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_ADR</Text>
+        <Enum>130</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_ADR</Text>
+        <Enum>131</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_ADR</Text>
+        <Enum>132</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_ADR</Text>
+        <Enum>133</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_ADR</Text>
+        <Enum>134</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_ADR</Text>
+        <Enum>135</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_ADR</Text>
+        <Enum>136</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_ADR</Text>
+        <Enum>137</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_ADR</Text>
+        <Enum>138</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_ADR</Text>
+        <Enum>139</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction1Data_ADR</Text>
+        <Enum>140</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction2Data_ADR</Text>
+        <Enum>141</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileSeek</Text>
+        <Enum>142</Enum>
+        <Comment> internal error FB_FileSeek </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_AmbientTempMaxIsLessThanAmbientTempMin</Text>
+        <Enum>143</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_ForerunTempMaxIsLessThanForerunTempMin</Text>
+        <Enum>144</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDLOGCYCLETIME</Text>
+        <Enum>145</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDVERSION_TcControllerToolbox</Text>
+        <Enum>146</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Bandwidth</Text>
+        <Enum>147</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_NotchFrequency</Text>
+        <Enum>148</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DampingCoefficient</Text>
+        <Enum>149</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fKpIsLessThanZero</Text>
+        <Enum>150</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nSamplesToFilter</Text>
+        <Enum>151</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Name>
+      <BitSize>2240</BitSize>
+      <SubItem>
+        <Name>fSetpointValue</Name>
+        <Type>LREAL</Type>
+        <Comment> setpoint value of controlled variable </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fActualValue</Name>
+        <Type>LREAL</Type>
+        <Comment> actual value of the controlled variable </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fManSyncValue</Name>
+        <Type>LREAL</Type>
+        <Comment> manual value to synchronize controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSync</Name>
+        <Type>BOOL</Type>
+        <Comment> rising edge sets controller output manual sync value </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eMode</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Comment> operating mode </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHold</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE will hold the controller output at current value </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fOut</Name>
+        <Type>LREAL</Type>
+        <Comment> controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bARWactive</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE indicates that the controller output is restricted </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Comment> current state of the function block </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eErrorId</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Comment> error code </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if error occurs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_PI_PARAMS</Type>
+        <Comment> parameter structure </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalCycleTimeInterpretation</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCallAfterAStateChange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1032</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fD_I</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTaskCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fHalfCtrlCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTn</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bIPartEnabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSyncValueInternal</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLimitValue</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fE</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1600</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fE_1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY_I</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY_I_1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY_P</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1920</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlCycleTicks</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nActCtrlCycleTick</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eMode_old</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMaxLimitReached</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMinLimitReached</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bSyncRequest</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbR_TRIG</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>M_Error</Name>
+      </Action>
+      <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
+        <Name>M_Manual</Name>
+      </Action>
+      <Action>
+        <Name>M_Active</Name>
+      </Action>
+      <Action>
+        <Name>M_StateChange</Name>
+      </Action>
+      <Action>
+        <Name>M_Passive</Name>
+      </Action>
+      <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</Name>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>tTaskCycleTime</Name>
+        <Type>TIME</Type>
+        <Comment> task cycle time			[TIME]		</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tCtrlCycleTime</Name>
+        <Type>TIME</Type>
+        <Comment> controller cycle time 	[TIME]		</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloPos</Name>
+        <Type>LREAL</Type>
+        <Comment> velocity ramp by time, range &gt; 0.0 	</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloNeg</Name>
+        <Type>LREAL</Type>
+        <Comment> velocity ramp by time, range &gt; 0.0	</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Name>
+      <BitSize>192</BitSize>
+      <BaseType Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Name>
+      <BitSize>1280</BitSize>
+      <SubItem>
+        <Name>fStartValue</Name>
+        <Type>LREAL</Type>
+        <Comment> starting value of the ramp </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTargetValue</Name>
+        <Type>LREAL</Type>
+        <Comment> target value of the ramp </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fManValue</Name>
+        <Type>LREAL</Type>
+        <Comment> manual value to synchronize controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHold</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE will hold the controller output at current value </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eMode</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Comment> operating mode </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fOut</Name>
+        <Type>LREAL</Type>
+        <Comment> controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloOut</Name>
+        <Type>LREAL</Type>
+        <Comment> current velocity of the ramp generator </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValueReached</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE indicates that target value is reached </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Comment> current state of the function block </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eErrorId</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Comment> error code </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if error occurs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
+        <Comment> parameter structure </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTaskCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutLocal</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bGetStartValue</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalCycleTimeInterpretation</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlCycleTicks</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nActCtrlCycleTick</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eMode_old</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1232</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>M_Error</Name>
+      </Action>
+      <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
+        <Name>M_Manual</Name>
+      </Action>
+      <Action>
+        <Name>M_Active</Name>
+      </Action>
+      <Action>
+        <Name>M_StateChange</Name>
+      </Action>
+      <Action>
+        <Name>M_Passive</Name>
+      </Action>
+      <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>eMode</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Comment> operating mode </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTaskCycleTime</Name>
+        <Type>TIME</Type>
+        <Comment> resolution  1ms</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bCycleTimeValid</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if cycle time is valid </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Comment> current state of the function block </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eErrorId</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Comment> error code </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if error occurs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>184</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nCpuCntLoDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCpuCntHiDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLastcpuCntLoDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLastcpuCntHiDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCycleTimeDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCycleTimeDWold</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCallReady</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGETCPUCOUNTER</Name>
+        <Type Namespace="Tc2_System">GETCPUCOUNTER</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eMode_old</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
+        <Name>M_StateChange</Name>
+      </Action>
+      <Action>
+        <Name>M_Active</Name>
+      </Action>
+      <Action>
+        <Name>M_Passive</Name>
+      </Action>
+      <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_PiezoControl</Name>
+      <BitSize>6720</BitSize>
+      <SubItem>
+        <Name>iq_Piezo</Name>
+        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xExecute</Name>
+        <Type>BOOL</Type>
+        <Comment>Rising edge being piezo motion</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Enable_Positive</Name>
+        <Type>BOOL</Type>
+        <Comment>Reverse of Positive Limit Switch</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Enable_Negative</Name>
+        <Type>BOOL</Type>
+        <Comment>Reverse of Negative Limit Switch</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xBusy</Name>
+        <Type>BOOL</Type>
+        <Comment>Busy remains true while piezo position is being adjusted</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xDone</Name>
+        <Type>BOOL</Type>
+        <Comment>Reached target position</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xError</Name>
+        <Type>BOOL</Type>
+        <Comment>General error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xLimited</Name>
+        <Type>BOOL</Type>
+        <Comment>Piezo move was limited</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>E_State</Name>
+        <Type Namespace="lcls_twincat_optics">E_PiezoControl</Type>
+        <Comment>ENUM for Piezo Control State</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtStartMove</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment>Rising Trigger for Execution</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment>Rising Trigger for Error reset</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rSetpoint</Name>
+        <Type>REAL</Type>
+        <Comment>Internal Storage of Setpoint</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rReqVoltage</Name>
+        <Type>REAL</Type>
+        <Comment>requested voltage</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rLLSV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rHLSV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+        <Default>
+          <Value>120</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbPI</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbRamp</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Type>
+        <BitSize>1280</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInitialized</Name>
+        <Type>BOOL</Type>
+        <Comment> FB initialized flag</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCycleTime</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Type>
+        <Comment>Get cycle time for control FBs</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>4224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tTaskCycleTime</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>4992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCycleTimeValid</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtVoltMode</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>5056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOut</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>5184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPiezoBias</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>5248</BitOffs>
+        <Default>
+          <Value>60</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fScale</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5312</BitOffs>
+        <Default>
+          <Value>-60</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tonPiezoDone</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>5376</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T#2S</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tonPiezoLimited</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>5632</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T#500MS</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>xVoltageLimited</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5888</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftEnPos</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>5952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftEnNeg</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtEnPos</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtEnNeg</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutLimitHolder</Name>
+        <Type>LREAL</Type>
+        <Comment>holds the limit value until restored</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>6464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutHiLimHolder</Name>
+        <Type>LREAL</Type>
+        <Comment>holds the limit value until restored</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>6528</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutLoLimHolder</Name>
+        <Type>LREAL</Type>
+        <Comment>holds the limit value until restored</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>6592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFirstPass</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6656</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ACT_CheckLimits</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Controller</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">E_PitchControl</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>PCM_Init</Text>
+        <Enum>0</Enum>
+        <Comment>Pitch Control Machine</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Standby</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_MoveRequested</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Coarse50Piezo</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_CoarseMove</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_CoarseMoveCleanup</Text>
+        <Enum>22</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_FineMove</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Halt</Text>
+        <Enum>50</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Done</Text>
+        <Enum>8000</Enum>
+        <Comment>why is 8000 done? Where did this come from??</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Error</Text>
+        <Enum>9000</Enum>
+        <Comment>Anything above 9000 is considered an error</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_StepperError</Text>
+        <Enum>9100</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_PiezoError</Text>
+        <Enum>9200</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_OtherError</Text>
+        <Enum>9300</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_STOHit</Text>
+        <Enum>9400</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_PitchControl</Name>
+      <BitSize>397888</BitSize>
+      <SubItem>
+        <Name>Pitch</Name>
+        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">HOMS_PitchMechanism</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Stepper</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>lrCurrentSetpoint</Name>
+        <Type>LREAL</Type>
+        <Comment> Setpoint: Epics writes to ST_MotionStage which gets fed into this</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_bDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDiag</Name>
+        <Type Namespace="LCLS_General">ST_FbDiagnostics</Type>
+        <Comment> Logging</Comment>
+        <BitSize>49664</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbFormatString</Name>
+        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+        <BitSize>8576</BitSize>
+        <BitOffs>49984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>POUName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Name of the POU for logging/error reporting</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>58560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>no_init</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>lrActPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Actual Position of piezo mechanism</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrPrevStepperPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Previous successfully achieved stepper position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftLimitSwitch</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>60736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrOriginalPosRequest</Name>
+        <Type>LREAL</Type>
+        <Comment> Used for logging</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60864</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrLastSetpoint</Name>
+        <Type>LREAL</Type>
+        <Comment> Previous successfully achieved setpoint</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
+        <BitSize>1920</BitSize>
+        <BitOffs>60992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>327424</BitSize>
+        <BitOffs>62912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLimitHit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>390336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonStepperHold</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Timer to hold stepper position while the system relaxes</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>390400</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T#100MS</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rSettledRange</Name>
+        <Type>REAL</Type>
+        <Comment> Units = urad</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>390656</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bResetStepper</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>390688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteStepper</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>390696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
+        <Comment> Wait for move to complete before taking another request</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>390704</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tonPiezoSettled</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Piezo</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>390720</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T#2S</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbPiezoControl</Name>
+        <Type Namespace="lcls_twincat_optics">FB_PiezoControl</Type>
+        <BitSize>6720</BitSize>
+        <BitOffs>390976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtPiezoMoveDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>397696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PC_State</Name>
+        <Type Namespace="lcls_twincat_optics">E_PitchControl</Type>
+        <Comment> State Machine</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>397824</BitOffs>
+        <Default>
+          <EnumText>E_PitchControl.PCM_Init</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bCoarse50PiezoMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>397840</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>ACT_ResetSetpoint</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{5356792D-144F-4F3E-8B04-D35060997D7C}" TcSmClass="TComPlcObjDef" TargetPlatform="TwinCAT RT (x64)">
@@ -72250,7 +72250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72266,14 +72266,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779424</BitOffs>
+            <BitOffs>1296779296</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72287,14 +72287,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779616</BitOffs>
+            <BitOffs>1296779488</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72311,7 +72311,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294726912</BitOffs>
+            <BitOffs>1294726784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -72322,7 +72322,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294729424</BitOffs>
+            <BitOffs>1294729296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -72336,7 +72336,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305245920</BitOffs>
+            <BitOffs>1305245792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -72350,7 +72350,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305245952</BitOffs>
+            <BitOffs>1305245824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -72364,7 +72364,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253120</BitOffs>
+            <BitOffs>1305252992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -72385,14 +72385,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253440</BitOffs>
+            <BitOffs>1305253312</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72403,14 +72403,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298241920</BitOffs>
+            <BitOffs>1298241792</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72512,7 +72512,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298240832</BitOffs>
+            <BitOffs>1298240704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -72526,7 +72526,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253152</BitOffs>
+            <BitOffs>1305253024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -72540,7 +72540,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253184</BitOffs>
+            <BitOffs>1305253056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -72561,27 +72561,69 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305254336</BitOffs>
+            <BitOffs>1305254208</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
-            <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
-            <Comment>PI Serial</Comment>
-            <BitSize>112640</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265714560</BitOffs>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305253088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305253120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
+            <BitSize>896</BitSize>
+            <BaseType>_Implicit_Task_Info</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.dwVersion</Name>
+                <Value>2</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcContextName</Name>
+                <Value>PiezoDriver</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305255104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
             <Comment> Pitch Mechanism:
  Currently Unused</Comment>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -72609,63 +72651,21 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294735168</BitOffs>
+            <BitOffs>1312780544</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305253216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305253248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
-            <BitSize>896</BitSize>
-            <BaseType>_Implicit_Task_Info</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.dwVersion</Name>
-                <Value>2</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcContextName</Name>
-                <Value>PiezoDriver</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305255232</BitOffs>
+            <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
+            <Comment>PI Serial</Comment>
+            <BitSize>112640</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
+            <BitOffs>1312800832</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72720,7 +72720,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -73141,7 +73141,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305248000</BitOffs>
+            <BitOffs>1305247872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -73155,7 +73155,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253280</BitOffs>
+            <BitOffs>1305253152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -73169,7 +73169,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253312</BitOffs>
+            <BitOffs>1305253184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -73190,165 +73190,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305256128</BitOffs>
+            <BitOffs>1305256000</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
-          <Symbol>
-            <Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1264816064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
-            <Comment> STO Button</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274220416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274220424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
-            <Comment> Encoders</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274220480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274220608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274220736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274220864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274221632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274221760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274232384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274232512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1275471232</BitOffs>
-          </Symbol>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -73571,144 +73420,6 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1276913976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
-            <Comment> STO Button</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282739456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282739464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
-            <Comment> Encoders</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282739520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282739648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282739776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282739904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282740672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282740800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282751424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282751552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283990272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74826,45 +74537,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1289652952</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290844800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290845312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290845888</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
             <Comment> RTD error bit</Comment>
             <BitSize>8</BitSize>
@@ -74971,32 +74643,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1292785112</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292785408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292785920</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
             <Comment> RTD error bit</Comment>
             <BitSize>8</BitSize>
@@ -75007,7 +74653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725088</BitOffs>
+            <BitOffs>1294725024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -75019,7 +74665,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725096</BitOffs>
+            <BitOffs>1294725032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -75031,7 +74677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725104</BitOffs>
+            <BitOffs>1294725040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -75043,7 +74689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725112</BitOffs>
+            <BitOffs>1294725048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -75067,7 +74713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725320</BitOffs>
+            <BitOffs>1294725256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -75079,7 +74725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725328</BitOffs>
+            <BitOffs>1294725264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -75091,7 +74737,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725336</BitOffs>
+            <BitOffs>1294725272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -75103,7 +74749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725344</BitOffs>
+            <BitOffs>1294725280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -75127,7 +74773,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725576</BitOffs>
+            <BitOffs>1294725512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -75139,7 +74785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725584</BitOffs>
+            <BitOffs>1294725520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -75151,7 +74797,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725592</BitOffs>
+            <BitOffs>1294725528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -75163,7 +74809,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725600</BitOffs>
+            <BitOffs>1294725536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -75175,7 +74821,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725632</BitOffs>
+            <BitOffs>1294725568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -75187,7 +74833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725640</BitOffs>
+            <BitOffs>1294725576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -75204,7 +74850,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725648</BitOffs>
+            <BitOffs>1294725584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -75220,7 +74866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725656</BitOffs>
+            <BitOffs>1294725592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -75240,7 +74886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294725664</BitOffs>
+            <BitOffs>1294725600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -75259,33 +74905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294725680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1294725952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1294726464</BitOffs>
+            <BitOffs>1294725616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -75304,7 +74924,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731936</BitOffs>
+            <BitOffs>1294731808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -75324,20 +74944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1294734400</BitOffs>
+            <BitOffs>1294731824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -75356,7 +74963,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734848</BitOffs>
+            <BitOffs>1294734720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -75375,7 +74982,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734864</BitOffs>
+            <BitOffs>1294734736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -75395,7 +75002,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734880</BitOffs>
+            <BitOffs>1294734752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -75414,20 +75021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1294737600</BitOffs>
+            <BitOffs>1294734768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -75446,7 +75040,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738176</BitOffs>
+            <BitOffs>1294738048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -75466,7 +75060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738192</BitOffs>
+            <BitOffs>1294738064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -75485,7 +75079,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738208</BitOffs>
+            <BitOffs>1294738080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -75504,7 +75098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738224</BitOffs>
+            <BitOffs>1294738096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -75524,7 +75118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738816</BitOffs>
+            <BitOffs>1294738688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -75543,7 +75137,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738832</BitOffs>
+            <BitOffs>1294738704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -75562,7 +75156,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738848</BitOffs>
+            <BitOffs>1294738720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -75582,7 +75176,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738864</BitOffs>
+            <BitOffs>1294738736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -75601,7 +75195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738880</BitOffs>
+            <BitOffs>1294738752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -75620,7 +75214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738896</BitOffs>
+            <BitOffs>1294738768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -75635,7 +75229,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779808</BitOffs>
+            <BitOffs>1296779680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -75650,7 +75244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779824</BitOffs>
+            <BitOffs>1296779696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -75662,7 +75256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296780928</BitOffs>
+            <BitOffs>1296780800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -75675,7 +75269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788864</BitOffs>
+            <BitOffs>1296788736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -75688,7 +75282,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788872</BitOffs>
+            <BitOffs>1296788744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -75701,7 +75295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788880</BitOffs>
+            <BitOffs>1296788752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -75724,7 +75318,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788896</BitOffs>
+            <BitOffs>1296788768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -75737,7 +75331,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788928</BitOffs>
+            <BitOffs>1296788800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -75750,7 +75344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788992</BitOffs>
+            <BitOffs>1296788864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -75763,7 +75357,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296789008</BitOffs>
+            <BitOffs>1296788880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75775,7 +75369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296807680</BitOffs>
+            <BitOffs>1296807552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -75787,7 +75381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297133568</BitOffs>
+            <BitOffs>1297133440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -75800,7 +75394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141504</BitOffs>
+            <BitOffs>1297141376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -75813,7 +75407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141512</BitOffs>
+            <BitOffs>1297141384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -75826,7 +75420,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141520</BitOffs>
+            <BitOffs>1297141392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -75849,7 +75443,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141536</BitOffs>
+            <BitOffs>1297141408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -75862,7 +75456,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141568</BitOffs>
+            <BitOffs>1297141440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -75875,7 +75469,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141632</BitOffs>
+            <BitOffs>1297141504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -75888,7 +75482,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141648</BitOffs>
+            <BitOffs>1297141520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75900,7 +75494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297160320</BitOffs>
+            <BitOffs>1297160192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -75912,7 +75506,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297486208</BitOffs>
+            <BitOffs>1297486080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -75925,7 +75519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494144</BitOffs>
+            <BitOffs>1297494016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -75938,7 +75532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494152</BitOffs>
+            <BitOffs>1297494024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -75951,7 +75545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494160</BitOffs>
+            <BitOffs>1297494032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -75974,7 +75568,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494176</BitOffs>
+            <BitOffs>1297494048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -75987,7 +75581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494208</BitOffs>
+            <BitOffs>1297494080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -76000,7 +75594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494272</BitOffs>
+            <BitOffs>1297494144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -76013,7 +75607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494288</BitOffs>
+            <BitOffs>1297494160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76025,7 +75619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297512960</BitOffs>
+            <BitOffs>1297512832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -76037,7 +75631,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297838848</BitOffs>
+            <BitOffs>1297838720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -76050,7 +75644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846784</BitOffs>
+            <BitOffs>1297846656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -76063,7 +75657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846792</BitOffs>
+            <BitOffs>1297846664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -76076,7 +75670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846800</BitOffs>
+            <BitOffs>1297846672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -76099,7 +75693,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846816</BitOffs>
+            <BitOffs>1297846688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -76112,7 +75706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846848</BitOffs>
+            <BitOffs>1297846720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -76125,7 +75719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846912</BitOffs>
+            <BitOffs>1297846784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -76138,7 +75732,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846928</BitOffs>
+            <BitOffs>1297846800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76150,7 +75744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297865600</BitOffs>
+            <BitOffs>1297865472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -76162,7 +75756,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298191488</BitOffs>
+            <BitOffs>1298191360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -76175,7 +75769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199424</BitOffs>
+            <BitOffs>1298199296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -76188,7 +75782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199432</BitOffs>
+            <BitOffs>1298199304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -76201,7 +75795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199440</BitOffs>
+            <BitOffs>1298199312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -76224,7 +75818,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199456</BitOffs>
+            <BitOffs>1298199328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -76237,7 +75831,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199488</BitOffs>
+            <BitOffs>1298199360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -76250,7 +75844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199552</BitOffs>
+            <BitOffs>1298199424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -76263,7 +75857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199568</BitOffs>
+            <BitOffs>1298199440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -76275,7 +75869,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298216704</BitOffs>
+            <BitOffs>1298216576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -76288,7 +75882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224640</BitOffs>
+            <BitOffs>1298224512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -76301,7 +75895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224648</BitOffs>
+            <BitOffs>1298224520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -76314,7 +75908,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224656</BitOffs>
+            <BitOffs>1298224528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -76337,7 +75931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224672</BitOffs>
+            <BitOffs>1298224544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -76350,7 +75944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224704</BitOffs>
+            <BitOffs>1298224576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -76363,7 +75957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224768</BitOffs>
+            <BitOffs>1298224640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -76376,7 +75970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224784</BitOffs>
+            <BitOffs>1298224656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -76389,7 +75983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249856</BitOffs>
+            <BitOffs>1298249728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -76402,7 +75996,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249864</BitOffs>
+            <BitOffs>1298249736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -76415,7 +76009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249872</BitOffs>
+            <BitOffs>1298249744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -76438,7 +76032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249888</BitOffs>
+            <BitOffs>1298249760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -76451,7 +76045,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249920</BitOffs>
+            <BitOffs>1298249792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -76464,7 +76058,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249984</BitOffs>
+            <BitOffs>1298249856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -76477,7 +76071,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298250000</BitOffs>
+            <BitOffs>1298249872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -76489,7 +76083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298267136</BitOffs>
+            <BitOffs>1298267008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -76502,7 +76096,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275072</BitOffs>
+            <BitOffs>1298274944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -76515,7 +76109,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275080</BitOffs>
+            <BitOffs>1298274952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -76528,7 +76122,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275088</BitOffs>
+            <BitOffs>1298274960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -76551,7 +76145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275104</BitOffs>
+            <BitOffs>1298274976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -76564,7 +76158,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275136</BitOffs>
+            <BitOffs>1298275008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -76577,7 +76171,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275200</BitOffs>
+            <BitOffs>1298275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -76590,7 +76184,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275216</BitOffs>
+            <BitOffs>1298275088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -76602,7 +76196,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298292352</BitOffs>
+            <BitOffs>1298292224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -76615,7 +76209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300288</BitOffs>
+            <BitOffs>1298300160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -76628,7 +76222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300296</BitOffs>
+            <BitOffs>1298300168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -76641,7 +76235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300304</BitOffs>
+            <BitOffs>1298300176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -76664,7 +76258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300320</BitOffs>
+            <BitOffs>1298300192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -76677,7 +76271,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300352</BitOffs>
+            <BitOffs>1298300224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -76690,7 +76284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300416</BitOffs>
+            <BitOffs>1298300288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -76703,7 +76297,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300432</BitOffs>
+            <BitOffs>1298300304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -76715,7 +76309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298317568</BitOffs>
+            <BitOffs>1298317440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -76728,7 +76322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325504</BitOffs>
+            <BitOffs>1298325376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -76741,7 +76335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325512</BitOffs>
+            <BitOffs>1298325384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -76754,7 +76348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325520</BitOffs>
+            <BitOffs>1298325392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -76777,7 +76371,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325536</BitOffs>
+            <BitOffs>1298325408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -76790,7 +76384,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325568</BitOffs>
+            <BitOffs>1298325440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -76803,7 +76397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325632</BitOffs>
+            <BitOffs>1298325504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -76816,7 +76410,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325648</BitOffs>
+            <BitOffs>1298325520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -76828,7 +76422,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298342784</BitOffs>
+            <BitOffs>1298342656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -76841,7 +76435,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350720</BitOffs>
+            <BitOffs>1298350592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -76854,7 +76448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350728</BitOffs>
+            <BitOffs>1298350600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -76867,7 +76461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350736</BitOffs>
+            <BitOffs>1298350608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -76890,7 +76484,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350752</BitOffs>
+            <BitOffs>1298350624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -76903,7 +76497,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350784</BitOffs>
+            <BitOffs>1298350656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -76916,7 +76510,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350848</BitOffs>
+            <BitOffs>1298350720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -76929,7 +76523,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350864</BitOffs>
+            <BitOffs>1298350736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -76941,7 +76535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298368000</BitOffs>
+            <BitOffs>1298367872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -76954,7 +76548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375936</BitOffs>
+            <BitOffs>1298375808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -76967,7 +76561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375944</BitOffs>
+            <BitOffs>1298375816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -76980,7 +76574,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375952</BitOffs>
+            <BitOffs>1298375824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -77003,7 +76597,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375968</BitOffs>
+            <BitOffs>1298375840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -77016,7 +76610,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298376000</BitOffs>
+            <BitOffs>1298375872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -77029,7 +76623,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298376064</BitOffs>
+            <BitOffs>1298375936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -77042,7 +76636,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298376080</BitOffs>
+            <BitOffs>1298375952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77054,7 +76648,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298394752</BitOffs>
+            <BitOffs>1298394624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -77066,7 +76660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298720640</BitOffs>
+            <BitOffs>1298720512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -77079,7 +76673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728576</BitOffs>
+            <BitOffs>1298728448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -77092,7 +76686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728584</BitOffs>
+            <BitOffs>1298728456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -77105,7 +76699,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728592</BitOffs>
+            <BitOffs>1298728464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -77128,7 +76722,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728608</BitOffs>
+            <BitOffs>1298728480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -77141,7 +76735,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728640</BitOffs>
+            <BitOffs>1298728512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -77154,7 +76748,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728704</BitOffs>
+            <BitOffs>1298728576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -77167,7 +76761,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728720</BitOffs>
+            <BitOffs>1298728592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77179,7 +76773,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298747392</BitOffs>
+            <BitOffs>1298747264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -77191,7 +76785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299073280</BitOffs>
+            <BitOffs>1299073152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -77204,7 +76798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081216</BitOffs>
+            <BitOffs>1299081088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -77217,7 +76811,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081224</BitOffs>
+            <BitOffs>1299081096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -77230,7 +76824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081232</BitOffs>
+            <BitOffs>1299081104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -77253,7 +76847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081248</BitOffs>
+            <BitOffs>1299081120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -77266,7 +76860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081280</BitOffs>
+            <BitOffs>1299081152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -77279,7 +76873,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081344</BitOffs>
+            <BitOffs>1299081216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -77292,7 +76886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081360</BitOffs>
+            <BitOffs>1299081232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77304,7 +76898,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299100032</BitOffs>
+            <BitOffs>1299099904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -77316,7 +76910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299425920</BitOffs>
+            <BitOffs>1299425792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -77329,7 +76923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433856</BitOffs>
+            <BitOffs>1299433728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -77342,7 +76936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433864</BitOffs>
+            <BitOffs>1299433736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -77355,7 +76949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433872</BitOffs>
+            <BitOffs>1299433744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -77378,7 +76972,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433888</BitOffs>
+            <BitOffs>1299433760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -77391,7 +76985,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433920</BitOffs>
+            <BitOffs>1299433792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -77404,7 +76998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433984</BitOffs>
+            <BitOffs>1299433856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -77417,7 +77011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299434000</BitOffs>
+            <BitOffs>1299433872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77429,7 +77023,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299452672</BitOffs>
+            <BitOffs>1299452544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -77441,7 +77035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299778560</BitOffs>
+            <BitOffs>1299778432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -77454,7 +77048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786496</BitOffs>
+            <BitOffs>1299786368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -77467,7 +77061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786504</BitOffs>
+            <BitOffs>1299786376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -77480,7 +77074,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786512</BitOffs>
+            <BitOffs>1299786384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -77503,7 +77097,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786528</BitOffs>
+            <BitOffs>1299786400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -77516,7 +77110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786560</BitOffs>
+            <BitOffs>1299786432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -77529,7 +77123,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786624</BitOffs>
+            <BitOffs>1299786496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -77542,7 +77136,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786640</BitOffs>
+            <BitOffs>1299786512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -77554,7 +77148,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299803776</BitOffs>
+            <BitOffs>1299803648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -77567,7 +77161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811712</BitOffs>
+            <BitOffs>1299811584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -77580,7 +77174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811720</BitOffs>
+            <BitOffs>1299811592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -77593,7 +77187,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811728</BitOffs>
+            <BitOffs>1299811600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -77616,7 +77210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811744</BitOffs>
+            <BitOffs>1299811616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -77629,7 +77223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811776</BitOffs>
+            <BitOffs>1299811648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -77642,7 +77236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811840</BitOffs>
+            <BitOffs>1299811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -77655,7 +77249,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811856</BitOffs>
+            <BitOffs>1299811728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77667,7 +77261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299830528</BitOffs>
+            <BitOffs>1299830400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -77679,7 +77273,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300156416</BitOffs>
+            <BitOffs>1300156288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -77692,7 +77286,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164352</BitOffs>
+            <BitOffs>1300164224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -77705,7 +77299,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164360</BitOffs>
+            <BitOffs>1300164232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -77718,7 +77312,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164368</BitOffs>
+            <BitOffs>1300164240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -77741,7 +77335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164384</BitOffs>
+            <BitOffs>1300164256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -77754,7 +77348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164416</BitOffs>
+            <BitOffs>1300164288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -77767,7 +77361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164480</BitOffs>
+            <BitOffs>1300164352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -77780,7 +77374,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164496</BitOffs>
+            <BitOffs>1300164368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77792,7 +77386,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300183168</BitOffs>
+            <BitOffs>1300183040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -77804,7 +77398,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300509056</BitOffs>
+            <BitOffs>1300508928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -77817,7 +77411,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516992</BitOffs>
+            <BitOffs>1300516864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -77830,7 +77424,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517000</BitOffs>
+            <BitOffs>1300516872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -77843,7 +77437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517008</BitOffs>
+            <BitOffs>1300516880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -77866,7 +77460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517024</BitOffs>
+            <BitOffs>1300516896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -77879,7 +77473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517056</BitOffs>
+            <BitOffs>1300516928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -77892,7 +77486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517120</BitOffs>
+            <BitOffs>1300516992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -77905,7 +77499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517136</BitOffs>
+            <BitOffs>1300517008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -77917,7 +77511,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300534272</BitOffs>
+            <BitOffs>1300534144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -77930,7 +77524,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542208</BitOffs>
+            <BitOffs>1300542080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -77943,7 +77537,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542216</BitOffs>
+            <BitOffs>1300542088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -77956,7 +77550,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542224</BitOffs>
+            <BitOffs>1300542096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -77979,7 +77573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542240</BitOffs>
+            <BitOffs>1300542112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -77992,7 +77586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542272</BitOffs>
+            <BitOffs>1300542144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -78005,7 +77599,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542336</BitOffs>
+            <BitOffs>1300542208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -78018,7 +77612,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542352</BitOffs>
+            <BitOffs>1300542224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -78030,7 +77624,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300559488</BitOffs>
+            <BitOffs>1300559360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -78043,7 +77637,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567424</BitOffs>
+            <BitOffs>1300567296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -78056,7 +77650,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567432</BitOffs>
+            <BitOffs>1300567304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -78069,7 +77663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567440</BitOffs>
+            <BitOffs>1300567312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -78092,7 +77686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567456</BitOffs>
+            <BitOffs>1300567328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -78105,7 +77699,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567488</BitOffs>
+            <BitOffs>1300567360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -78118,7 +77712,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567552</BitOffs>
+            <BitOffs>1300567424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -78131,7 +77725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567568</BitOffs>
+            <BitOffs>1300567440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -78143,7 +77737,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300584704</BitOffs>
+            <BitOffs>1300584576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -78156,7 +77750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592640</BitOffs>
+            <BitOffs>1300592512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -78169,7 +77763,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592648</BitOffs>
+            <BitOffs>1300592520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -78182,7 +77776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592656</BitOffs>
+            <BitOffs>1300592528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -78205,7 +77799,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592672</BitOffs>
+            <BitOffs>1300592544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -78218,7 +77812,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592704</BitOffs>
+            <BitOffs>1300592576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -78231,7 +77825,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592768</BitOffs>
+            <BitOffs>1300592640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -78244,7 +77838,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592784</BitOffs>
+            <BitOffs>1300592656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -78256,7 +77850,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300609920</BitOffs>
+            <BitOffs>1300609792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -78269,7 +77863,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617856</BitOffs>
+            <BitOffs>1300617728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -78282,7 +77876,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617864</BitOffs>
+            <BitOffs>1300617736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -78295,7 +77889,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617872</BitOffs>
+            <BitOffs>1300617744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -78318,7 +77912,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617888</BitOffs>
+            <BitOffs>1300617760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -78331,7 +77925,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617920</BitOffs>
+            <BitOffs>1300617792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -78344,7 +77938,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617984</BitOffs>
+            <BitOffs>1300617856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -78357,7 +77951,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300618000</BitOffs>
+            <BitOffs>1300617872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -78369,7 +77963,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300635136</BitOffs>
+            <BitOffs>1300635008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -78382,7 +77976,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643072</BitOffs>
+            <BitOffs>1300642944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -78395,7 +77989,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643080</BitOffs>
+            <BitOffs>1300642952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -78408,7 +78002,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643088</BitOffs>
+            <BitOffs>1300642960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -78431,7 +78025,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643104</BitOffs>
+            <BitOffs>1300642976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -78444,7 +78038,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643136</BitOffs>
+            <BitOffs>1300643008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -78457,7 +78051,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643200</BitOffs>
+            <BitOffs>1300643072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -78470,7 +78064,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643216</BitOffs>
+            <BitOffs>1300643088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -78482,7 +78076,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300660352</BitOffs>
+            <BitOffs>1300660224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -78495,7 +78089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668288</BitOffs>
+            <BitOffs>1300668160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -78508,7 +78102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668296</BitOffs>
+            <BitOffs>1300668168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -78521,7 +78115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668304</BitOffs>
+            <BitOffs>1300668176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -78544,7 +78138,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668320</BitOffs>
+            <BitOffs>1300668192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -78557,7 +78151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668352</BitOffs>
+            <BitOffs>1300668224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -78570,7 +78164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668416</BitOffs>
+            <BitOffs>1300668288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -78583,7 +78177,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668432</BitOffs>
+            <BitOffs>1300668304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78595,7 +78189,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300687104</BitOffs>
+            <BitOffs>1300686976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -78607,7 +78201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301012992</BitOffs>
+            <BitOffs>1301012864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -78620,7 +78214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020928</BitOffs>
+            <BitOffs>1301020800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -78633,7 +78227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020936</BitOffs>
+            <BitOffs>1301020808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -78646,7 +78240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020944</BitOffs>
+            <BitOffs>1301020816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -78669,7 +78263,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020960</BitOffs>
+            <BitOffs>1301020832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -78682,7 +78276,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020992</BitOffs>
+            <BitOffs>1301020864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -78695,7 +78289,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301021056</BitOffs>
+            <BitOffs>1301020928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -78708,7 +78302,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301021072</BitOffs>
+            <BitOffs>1301020944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78720,7 +78314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301039744</BitOffs>
+            <BitOffs>1301039616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -78732,7 +78326,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301365632</BitOffs>
+            <BitOffs>1301365504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -78745,7 +78339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373568</BitOffs>
+            <BitOffs>1301373440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -78758,7 +78352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373576</BitOffs>
+            <BitOffs>1301373448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -78771,7 +78365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373584</BitOffs>
+            <BitOffs>1301373456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -78794,7 +78388,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373600</BitOffs>
+            <BitOffs>1301373472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -78807,7 +78401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373632</BitOffs>
+            <BitOffs>1301373504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -78820,7 +78414,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373696</BitOffs>
+            <BitOffs>1301373568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -78833,7 +78427,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373712</BitOffs>
+            <BitOffs>1301373584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78845,7 +78439,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301392384</BitOffs>
+            <BitOffs>1301392256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -78857,7 +78451,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301718272</BitOffs>
+            <BitOffs>1301718144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -78870,7 +78464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726208</BitOffs>
+            <BitOffs>1301726080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -78883,7 +78477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726216</BitOffs>
+            <BitOffs>1301726088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -78896,7 +78490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726224</BitOffs>
+            <BitOffs>1301726096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -78919,7 +78513,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726240</BitOffs>
+            <BitOffs>1301726112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -78932,7 +78526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726272</BitOffs>
+            <BitOffs>1301726144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -78945,7 +78539,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726336</BitOffs>
+            <BitOffs>1301726208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -78958,7 +78552,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726352</BitOffs>
+            <BitOffs>1301726224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78970,7 +78564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745024</BitOffs>
+            <BitOffs>1301744896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -78982,7 +78576,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302070912</BitOffs>
+            <BitOffs>1302070784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -78995,7 +78589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078848</BitOffs>
+            <BitOffs>1302078720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -79008,7 +78602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078856</BitOffs>
+            <BitOffs>1302078728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -79021,7 +78615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078864</BitOffs>
+            <BitOffs>1302078736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -79044,7 +78638,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078880</BitOffs>
+            <BitOffs>1302078752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -79057,7 +78651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078912</BitOffs>
+            <BitOffs>1302078784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -79070,7 +78664,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078976</BitOffs>
+            <BitOffs>1302078848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -79083,7 +78677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078992</BitOffs>
+            <BitOffs>1302078864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79095,7 +78689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302097664</BitOffs>
+            <BitOffs>1302097536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -79107,7 +78701,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302423552</BitOffs>
+            <BitOffs>1302423424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -79120,7 +78714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431488</BitOffs>
+            <BitOffs>1302431360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -79133,7 +78727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431496</BitOffs>
+            <BitOffs>1302431368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -79146,7 +78740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431504</BitOffs>
+            <BitOffs>1302431376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -79169,7 +78763,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431520</BitOffs>
+            <BitOffs>1302431392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -79182,7 +78776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431552</BitOffs>
+            <BitOffs>1302431424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -79195,7 +78789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431616</BitOffs>
+            <BitOffs>1302431488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -79208,7 +78802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431632</BitOffs>
+            <BitOffs>1302431504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79220,7 +78814,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302450304</BitOffs>
+            <BitOffs>1302450176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -79232,7 +78826,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302776192</BitOffs>
+            <BitOffs>1302776064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -79245,7 +78839,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784128</BitOffs>
+            <BitOffs>1302784000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -79258,7 +78852,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784136</BitOffs>
+            <BitOffs>1302784008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -79271,7 +78865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784144</BitOffs>
+            <BitOffs>1302784016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -79294,7 +78888,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784160</BitOffs>
+            <BitOffs>1302784032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -79307,7 +78901,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784192</BitOffs>
+            <BitOffs>1302784064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -79320,7 +78914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784256</BitOffs>
+            <BitOffs>1302784128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -79333,7 +78927,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784272</BitOffs>
+            <BitOffs>1302784144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79345,7 +78939,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302802944</BitOffs>
+            <BitOffs>1302802816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -79357,7 +78951,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303128832</BitOffs>
+            <BitOffs>1303128704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -79370,7 +78964,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136768</BitOffs>
+            <BitOffs>1303136640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -79383,7 +78977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136776</BitOffs>
+            <BitOffs>1303136648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -79396,7 +78990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136784</BitOffs>
+            <BitOffs>1303136656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -79419,7 +79013,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136800</BitOffs>
+            <BitOffs>1303136672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -79432,7 +79026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136832</BitOffs>
+            <BitOffs>1303136704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -79445,7 +79039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136896</BitOffs>
+            <BitOffs>1303136768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -79458,7 +79052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136912</BitOffs>
+            <BitOffs>1303136784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79470,7 +79064,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303155584</BitOffs>
+            <BitOffs>1303155456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -79482,7 +79076,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303481472</BitOffs>
+            <BitOffs>1303481344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -79495,7 +79089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489408</BitOffs>
+            <BitOffs>1303489280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -79508,7 +79102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489416</BitOffs>
+            <BitOffs>1303489288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -79521,7 +79115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489424</BitOffs>
+            <BitOffs>1303489296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -79544,7 +79138,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489440</BitOffs>
+            <BitOffs>1303489312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -79557,7 +79151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489472</BitOffs>
+            <BitOffs>1303489344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -79570,7 +79164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489536</BitOffs>
+            <BitOffs>1303489408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -79583,7 +79177,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489552</BitOffs>
+            <BitOffs>1303489424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79595,7 +79189,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303508224</BitOffs>
+            <BitOffs>1303508096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -79607,7 +79201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303834112</BitOffs>
+            <BitOffs>1303833984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -79620,7 +79214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842048</BitOffs>
+            <BitOffs>1303841920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -79633,7 +79227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842056</BitOffs>
+            <BitOffs>1303841928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -79646,7 +79240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842064</BitOffs>
+            <BitOffs>1303841936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -79669,7 +79263,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842080</BitOffs>
+            <BitOffs>1303841952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -79682,7 +79276,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842112</BitOffs>
+            <BitOffs>1303841984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -79695,7 +79289,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842176</BitOffs>
+            <BitOffs>1303842048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -79708,7 +79302,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842192</BitOffs>
+            <BitOffs>1303842064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79720,7 +79314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303860864</BitOffs>
+            <BitOffs>1303860736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -79732,7 +79326,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304186752</BitOffs>
+            <BitOffs>1304186624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -79745,7 +79339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194688</BitOffs>
+            <BitOffs>1304194560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -79758,7 +79352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194696</BitOffs>
+            <BitOffs>1304194568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -79771,7 +79365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194704</BitOffs>
+            <BitOffs>1304194576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -79794,7 +79388,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194720</BitOffs>
+            <BitOffs>1304194592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -79807,7 +79401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194752</BitOffs>
+            <BitOffs>1304194624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -79820,7 +79414,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194816</BitOffs>
+            <BitOffs>1304194688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -79833,7 +79427,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194832</BitOffs>
+            <BitOffs>1304194704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79845,7 +79439,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304213504</BitOffs>
+            <BitOffs>1304213376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -79857,7 +79451,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304539392</BitOffs>
+            <BitOffs>1304539264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -79870,7 +79464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547328</BitOffs>
+            <BitOffs>1304547200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -79883,7 +79477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547336</BitOffs>
+            <BitOffs>1304547208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -79896,7 +79490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547344</BitOffs>
+            <BitOffs>1304547216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -79919,7 +79513,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547360</BitOffs>
+            <BitOffs>1304547232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -79932,7 +79526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547392</BitOffs>
+            <BitOffs>1304547264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -79945,7 +79539,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547456</BitOffs>
+            <BitOffs>1304547328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -79958,7 +79552,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547472</BitOffs>
+            <BitOffs>1304547344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79970,7 +79564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304566144</BitOffs>
+            <BitOffs>1304566016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -79982,7 +79576,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304892032</BitOffs>
+            <BitOffs>1304891904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -79995,7 +79589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899968</BitOffs>
+            <BitOffs>1304899840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -80008,7 +79602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899976</BitOffs>
+            <BitOffs>1304899848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -80021,7 +79615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899984</BitOffs>
+            <BitOffs>1304899856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -80044,7 +79638,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900000</BitOffs>
+            <BitOffs>1304899872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -80057,7 +79651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900032</BitOffs>
+            <BitOffs>1304899904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -80070,7 +79664,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900096</BitOffs>
+            <BitOffs>1304899968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -80083,7 +79677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900112</BitOffs>
+            <BitOffs>1304899984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80095,26 +79689,420 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304918784</BitOffs>
+            <BitOffs>1304918656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310867584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310867904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310868416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310868992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310869696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310870208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
+            <Comment> STO Button</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310873728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310873736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
+            <Comment> Encoders</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310873792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310873920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310874048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310874176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310874944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310875072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310885696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310885824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312711872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312712384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
+            <Comment> STO Button</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312731136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312731144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
+            <Comment> Encoders</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312731200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312731328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312731456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312731584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312732352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312732480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312743104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312743232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312755904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312782976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314690304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317025792</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1275470208</BitOffs>
-          </Symbol>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -80244,18 +80232,6 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1276136480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283989248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80616,7 +80592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295730984</BitOffs>
+            <BitOffs>1295730856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -80636,7 +80612,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296255336</BitOffs>
+            <BitOffs>1296255208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -80648,7 +80624,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296779904</BitOffs>
+            <BitOffs>1296779776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -80661,7 +80637,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788888</BitOffs>
+            <BitOffs>1296788760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80673,7 +80649,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296806656</BitOffs>
+            <BitOffs>1296806528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -80685,7 +80661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297132544</BitOffs>
+            <BitOffs>1297132416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -80698,7 +80674,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141528</BitOffs>
+            <BitOffs>1297141400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80710,7 +80686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297159296</BitOffs>
+            <BitOffs>1297159168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -80722,7 +80698,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297485184</BitOffs>
+            <BitOffs>1297485056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -80735,7 +80711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494168</BitOffs>
+            <BitOffs>1297494040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80747,7 +80723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297511936</BitOffs>
+            <BitOffs>1297511808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -80759,7 +80735,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297837824</BitOffs>
+            <BitOffs>1297837696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -80772,7 +80748,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846808</BitOffs>
+            <BitOffs>1297846680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80784,7 +80760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297864576</BitOffs>
+            <BitOffs>1297864448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -80796,7 +80772,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298190464</BitOffs>
+            <BitOffs>1298190336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -80809,7 +80785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199448</BitOffs>
+            <BitOffs>1298199320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -80821,7 +80797,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298215680</BitOffs>
+            <BitOffs>1298215552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -80834,7 +80810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224664</BitOffs>
+            <BitOffs>1298224536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -80846,7 +80822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298240896</BitOffs>
+            <BitOffs>1298240768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -80859,7 +80835,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249880</BitOffs>
+            <BitOffs>1298249752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -80871,7 +80847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266112</BitOffs>
+            <BitOffs>1298265984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -80884,7 +80860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275096</BitOffs>
+            <BitOffs>1298274968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -80896,7 +80872,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298291328</BitOffs>
+            <BitOffs>1298291200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -80909,7 +80885,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300312</BitOffs>
+            <BitOffs>1298300184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -80921,7 +80897,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298316544</BitOffs>
+            <BitOffs>1298316416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -80934,7 +80910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325528</BitOffs>
+            <BitOffs>1298325400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -80946,7 +80922,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298341760</BitOffs>
+            <BitOffs>1298341632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -80959,7 +80935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350744</BitOffs>
+            <BitOffs>1298350616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -80971,7 +80947,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298366976</BitOffs>
+            <BitOffs>1298366848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -80984,7 +80960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375960</BitOffs>
+            <BitOffs>1298375832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80996,7 +80972,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298393728</BitOffs>
+            <BitOffs>1298393600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -81008,7 +80984,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298719616</BitOffs>
+            <BitOffs>1298719488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -81021,7 +80997,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728600</BitOffs>
+            <BitOffs>1298728472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81033,7 +81009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298746368</BitOffs>
+            <BitOffs>1298746240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -81045,7 +81021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299072256</BitOffs>
+            <BitOffs>1299072128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -81058,7 +81034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081240</BitOffs>
+            <BitOffs>1299081112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81070,7 +81046,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299099008</BitOffs>
+            <BitOffs>1299098880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -81082,7 +81058,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299424896</BitOffs>
+            <BitOffs>1299424768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -81095,7 +81071,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433880</BitOffs>
+            <BitOffs>1299433752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81107,7 +81083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299451648</BitOffs>
+            <BitOffs>1299451520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -81119,7 +81095,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299777536</BitOffs>
+            <BitOffs>1299777408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -81132,7 +81108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786520</BitOffs>
+            <BitOffs>1299786392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -81144,7 +81120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299802752</BitOffs>
+            <BitOffs>1299802624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -81157,7 +81133,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811736</BitOffs>
+            <BitOffs>1299811608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81169,7 +81145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299829504</BitOffs>
+            <BitOffs>1299829376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -81181,7 +81157,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300155392</BitOffs>
+            <BitOffs>1300155264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -81194,7 +81170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164376</BitOffs>
+            <BitOffs>1300164248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81206,7 +81182,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300182144</BitOffs>
+            <BitOffs>1300182016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -81218,7 +81194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300508032</BitOffs>
+            <BitOffs>1300507904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -81231,7 +81207,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517016</BitOffs>
+            <BitOffs>1300516888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -81243,7 +81219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300533248</BitOffs>
+            <BitOffs>1300533120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -81256,7 +81232,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542232</BitOffs>
+            <BitOffs>1300542104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -81268,7 +81244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300558464</BitOffs>
+            <BitOffs>1300558336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -81281,7 +81257,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567448</BitOffs>
+            <BitOffs>1300567320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -81293,7 +81269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300583680</BitOffs>
+            <BitOffs>1300583552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -81306,7 +81282,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592664</BitOffs>
+            <BitOffs>1300592536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -81318,7 +81294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608896</BitOffs>
+            <BitOffs>1300608768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -81331,7 +81307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617880</BitOffs>
+            <BitOffs>1300617752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -81343,7 +81319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634112</BitOffs>
+            <BitOffs>1300633984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -81356,7 +81332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643096</BitOffs>
+            <BitOffs>1300642968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -81368,7 +81344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300659328</BitOffs>
+            <BitOffs>1300659200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -81381,7 +81357,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668312</BitOffs>
+            <BitOffs>1300668184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81393,7 +81369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300686080</BitOffs>
+            <BitOffs>1300685952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -81405,7 +81381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301011968</BitOffs>
+            <BitOffs>1301011840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -81418,7 +81394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020952</BitOffs>
+            <BitOffs>1301020824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81430,7 +81406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301038720</BitOffs>
+            <BitOffs>1301038592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -81442,7 +81418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301364608</BitOffs>
+            <BitOffs>1301364480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -81455,7 +81431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373592</BitOffs>
+            <BitOffs>1301373464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81467,7 +81443,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301391360</BitOffs>
+            <BitOffs>1301391232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -81479,7 +81455,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301717248</BitOffs>
+            <BitOffs>1301717120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -81492,7 +81468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726232</BitOffs>
+            <BitOffs>1301726104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81504,7 +81480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301744000</BitOffs>
+            <BitOffs>1301743872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -81516,7 +81492,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302069888</BitOffs>
+            <BitOffs>1302069760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -81529,7 +81505,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078872</BitOffs>
+            <BitOffs>1302078744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81541,7 +81517,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302096640</BitOffs>
+            <BitOffs>1302096512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -81553,7 +81529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302422528</BitOffs>
+            <BitOffs>1302422400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -81566,7 +81542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431512</BitOffs>
+            <BitOffs>1302431384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81578,7 +81554,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449280</BitOffs>
+            <BitOffs>1302449152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -81590,7 +81566,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302775168</BitOffs>
+            <BitOffs>1302775040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -81603,7 +81579,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784152</BitOffs>
+            <BitOffs>1302784024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81615,7 +81591,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302801920</BitOffs>
+            <BitOffs>1302801792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -81627,7 +81603,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303127808</BitOffs>
+            <BitOffs>1303127680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -81640,7 +81616,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136792</BitOffs>
+            <BitOffs>1303136664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81652,7 +81628,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303154560</BitOffs>
+            <BitOffs>1303154432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -81664,7 +81640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303480448</BitOffs>
+            <BitOffs>1303480320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -81677,7 +81653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489432</BitOffs>
+            <BitOffs>1303489304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81689,7 +81665,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303507200</BitOffs>
+            <BitOffs>1303507072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -81701,7 +81677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303833088</BitOffs>
+            <BitOffs>1303832960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -81714,7 +81690,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842072</BitOffs>
+            <BitOffs>1303841944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81726,7 +81702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303859840</BitOffs>
+            <BitOffs>1303859712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -81738,7 +81714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304185728</BitOffs>
+            <BitOffs>1304185600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -81751,7 +81727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194712</BitOffs>
+            <BitOffs>1304194584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81763,7 +81739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304212480</BitOffs>
+            <BitOffs>1304212352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -81775,7 +81751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304538368</BitOffs>
+            <BitOffs>1304538240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -81788,7 +81764,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547352</BitOffs>
+            <BitOffs>1304547224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81800,7 +81776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304565120</BitOffs>
+            <BitOffs>1304564992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -81812,7 +81788,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304891008</BitOffs>
+            <BitOffs>1304890880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -81825,7 +81801,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899992</BitOffs>
+            <BitOffs>1304899864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81837,14 +81813,38 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304917760</BitOffs>
+            <BitOffs>1304917632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314689280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317024768</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -88703,21 +88703,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1256411920</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Constants.cPiezoRange</Name>
-            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>60</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1256411936</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
             <BitSize>64000</BitSize>
             <BaseType PointerTo="1" Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">FB_TestSuite</BaseType>
@@ -88799,120 +88784,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264813120</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
-            <Comment> default gantry tolerance in encoder counts = nm</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Default>
-              <Value>50000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1264813440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoMaxVoltage</Name>
-            <Comment> in Volts</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>120</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1264813504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoMinVoltage</Name>
-            <Comment> in Volts</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>-10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1264813568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
-            <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.ReqPosLimHi</Name>
-                <Value>2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.ReqPosLimLo</Name>
-                <Value>-2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimHi</Name>
-                <Value>10768330</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimLo</Name>
-                <Value>8141680</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1264813632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_optics_nrw</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1264816128</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ControllerToolbox</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
@@ -88955,7 +88826,7 @@ Emergency Stop for MR1K1</Comment>
           <Symbol>
             <Name>Global_Variables.stCtrl_GLOBAL_CycleTimeInterpretation</Name>
             <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</BaseType>
+            <BaseType Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -89067,44 +88938,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1274210368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1</Name>
-            <BitSize>23552</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">DUT_HOMS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
-                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
-                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274219200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbYRMSErrorM1K1</Name>
-            <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:Y
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274242752</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxYRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89115,20 +88948,6 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1274630336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbXRMSErrorM1K1</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:X
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1274630400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxXRMSErrorM1K1</Name>
@@ -89143,20 +88962,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1275017984</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K1_BEND.fbPitchRMSErrorM1K1</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:PITCH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1275018048</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxPitchRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89167,13 +88972,6 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1275405632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl</Name>
-            <Comment> Pitch Control</Comment>
-            <BitSize>397888</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PitchControl</BaseType>
-            <BitOffs>1275405696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16</Name>
@@ -89473,22 +89271,6 @@ MR1K1 BEND US ENC REF</Comment>
             <BitOffs>1276138240</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR1K1 US BENDER ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:US
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1276138304</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89499,21 +89281,6 @@ MR1K1 US BENDER ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1276525888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
-            <Comment>MR1K1 DS BENDER ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:DS
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1276525952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendDSRMSErrorM1K1</Name>
@@ -89735,44 +89502,6 @@ M1K1 BEND US ENC CNT</Comment>
             <BitOffs>1282712320</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2</Name>
-            <BitSize>23552</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">DUT_HOMS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K2_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K2_STO]^Channel 2^Input;
-                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position;
-                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282738240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:ENC:Y
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1282761792</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89783,20 +89512,6 @@ M1K1 BEND US ENC CNT</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1283149376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:ENC:X
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283149440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
@@ -89811,20 +89526,6 @@ M1K1 BEND US ENC CNT</Comment>
             <BitOffs>1283537024</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:ENC:PITCH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283537088</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89835,13 +89536,6 @@ M1K1 BEND US ENC CNT</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1283924672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
-            <Comment> Pitch Control</Comment>
-            <BitSize>397888</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PitchControl</BaseType>
-            <BitOffs>1283924736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -91307,20 +91001,6 @@ MR2K2 X ENC REF</Comment>
             <BitOffs>1289680704</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR2K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR2K2:FLAT:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1289681408</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91333,19 +91013,6 @@ MR2K2 X ENC RMS</Comment>
             <BitOffs>1290068992</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
-            <Comment>MR2K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290069056</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91356,19 +91023,6 @@ MR2K2 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1290456640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
-            <Comment>MR2K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1290456704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
@@ -91487,39 +91141,104 @@ MR3K2 X ENC REF</Comment>
             <BitOffs>1290844512</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
-            <BitSize>1792</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</BaseType>
+            <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
+            <Comment> default gantry tolerance in encoder counts = nm</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Default>
+              <Value>50000</Value>
+            </Default>
             <Properties>
               <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
-                                 .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
-                              .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2K2:FLAT
-    </Value>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
             <BitOffs>1290844544</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR3K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
+            <Name>GVL_Constants.cPiezoMaxVoltage</Name>
+            <Comment> in Volts</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>120</Value>
+            </Default>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:X</Value>
+                <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1290846336</BitOffs>
+            <BitOffs>1290844608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoMinVoltage</Name>
+            <Comment> in Volts</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>-10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1290844672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoRange</Name>
+            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>60</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1290844736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>7</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>0.7.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1290844768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
@@ -91534,19 +91253,6 @@ MR3K2 X ENC RMS</Comment>
             <BitOffs>1291233920</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
-            <Comment>MR3K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1291233984</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91557,19 +91263,6 @@ MR3K2 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1291621568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
-            <Comment>MR3K2 rY ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1291621632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
@@ -91584,19 +91277,6 @@ MR3K2 X ENC RMS</Comment>
             <BitOffs>1292009216</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
-            <Comment>MR3K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292009280</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91607,19 +91287,6 @@ MR3K2 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1292396864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
-            <Comment>MR3K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292396928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
@@ -91911,151 +91578,64 @@ MR4K2 X ENC REF</Comment>
             <BitOffs>1292785120</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
-            <Comment> MR3K2 Flow Sensors</Comment>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
-                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR3K2:KBH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292785152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR4K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1292786368</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293173888</BitOffs>
+            <BitOffs>1293173824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293173952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
-            <Comment>MR4K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1293174016</BitOffs>
+            <BitOffs>1293173888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293561536</BitOffs>
+            <BitOffs>1293561472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293561600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
-            <Comment>MR4K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1293561664</BitOffs>
+            <BitOffs>1293561536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293949184</BitOffs>
+            <BitOffs>1293949120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293949248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
-            <Comment>MR4K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1293949312</BitOffs>
+            <BitOffs>1293949184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294336832</BitOffs>
+            <BitOffs>1294336768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294336896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
-            <Comment>MR4K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1294336960</BitOffs>
+            <BitOffs>1294336832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294724480</BitOffs>
+            <BitOffs>1294724416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294724544</BitOffs>
+            <BitOffs>1294724480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -92072,7 +91652,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724608</BitOffs>
+            <BitOffs>1294724544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -92089,7 +91669,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724640</BitOffs>
+            <BitOffs>1294724576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -92106,7 +91686,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724672</BitOffs>
+            <BitOffs>1294724608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -92123,7 +91703,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724704</BitOffs>
+            <BitOffs>1294724640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -92141,7 +91721,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724736</BitOffs>
+            <BitOffs>1294724672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -92158,7 +91738,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724768</BitOffs>
+            <BitOffs>1294724704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -92175,7 +91755,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724800</BitOffs>
+            <BitOffs>1294724736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -92192,7 +91772,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724832</BitOffs>
+            <BitOffs>1294724768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -92209,7 +91789,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724864</BitOffs>
+            <BitOffs>1294724800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -92228,7 +91808,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724896</BitOffs>
+            <BitOffs>1294724832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -92245,7 +91825,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724928</BitOffs>
+            <BitOffs>1294724864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -92262,7 +91842,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724960</BitOffs>
+            <BitOffs>1294724896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -92280,7 +91860,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724992</BitOffs>
+            <BitOffs>1294724928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -92297,7 +91877,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725024</BitOffs>
+            <BitOffs>1294724960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -92314,7 +91894,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725056</BitOffs>
+            <BitOffs>1294724992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -92337,7 +91917,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725120</BitOffs>
+            <BitOffs>1294725056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -92360,63 +91940,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
-            <Comment> MR4K2 Flow Sensors</Comment>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
-                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR4K2:KBV
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1294725696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch</Name>
-            <Comment> Pitch Mechanism:\
- Currently unused</Comment>
-            <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.ReqPosLimHi</Name>
-                <Value>24681</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.ReqPosLimLo</Name>
-                <Value>24321</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimHi</Name>
-                <Value>10139808</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimLo</Name>
-                <Value>9950984</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.diEncCnt:=TIIB[EL5042_M1K2_Pitch]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1294731968</BitOffs>
+            <BitOffs>1294725312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -92431,7 +91955,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734464</BitOffs>
+            <BitOffs>1294734336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -92445,7 +91969,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734528</BitOffs>
+            <BitOffs>1294734400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -92460,7 +91984,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734592</BitOffs>
+            <BitOffs>1294734464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -92475,7 +91999,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734656</BitOffs>
+            <BitOffs>1294734528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -92490,7 +92014,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734720</BitOffs>
+            <BitOffs>1294734592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -92505,7 +92029,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734784</BitOffs>
+            <BitOffs>1294734656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -92521,7 +92045,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734912</BitOffs>
+            <BitOffs>1294734784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -92535,7 +92059,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734976</BitOffs>
+            <BitOffs>1294734848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -92549,7 +92073,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294735040</BitOffs>
+            <BitOffs>1294734912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -92563,7 +92087,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294735104</BitOffs>
+            <BitOffs>1294734976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -92578,7 +92102,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737664</BitOffs>
+            <BitOffs>1294737536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -92593,7 +92117,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737728</BitOffs>
+            <BitOffs>1294737600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -92608,7 +92132,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737792</BitOffs>
+            <BitOffs>1294737664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -92624,7 +92148,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737856</BitOffs>
+            <BitOffs>1294737728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -92638,7 +92162,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737920</BitOffs>
+            <BitOffs>1294737792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -92652,7 +92176,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737984</BitOffs>
+            <BitOffs>1294737856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -92667,7 +92191,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738048</BitOffs>
+            <BitOffs>1294737920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -92682,7 +92206,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738112</BitOffs>
+            <BitOffs>1294737984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -92698,7 +92222,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738240</BitOffs>
+            <BitOffs>1294738112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -92712,7 +92236,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738304</BitOffs>
+            <BitOffs>1294738176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -92726,7 +92250,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738368</BitOffs>
+            <BitOffs>1294738240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -92741,7 +92265,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738432</BitOffs>
+            <BitOffs>1294738304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -92756,7 +92280,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738496</BitOffs>
+            <BitOffs>1294738368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -92771,7 +92295,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738560</BitOffs>
+            <BitOffs>1294738432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -92786,7 +92310,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738624</BitOffs>
+            <BitOffs>1294738496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -92801,7 +92325,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738688</BitOffs>
+            <BitOffs>1294738560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -92816,7 +92340,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738752</BitOffs>
+            <BitOffs>1294738624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -92831,7 +92355,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738912</BitOffs>
+            <BitOffs>1294738784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -92847,7 +92371,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738944</BitOffs>
+            <BitOffs>1294738816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -92861,7 +92385,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739008</BitOffs>
+            <BitOffs>1294738880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -92875,7 +92399,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739072</BitOffs>
+            <BitOffs>1294738944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -92889,7 +92413,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739136</BitOffs>
+            <BitOffs>1294739008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -92907,7 +92431,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739200</BitOffs>
+            <BitOffs>1294739072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -92925,7 +92449,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295234944</BitOffs>
+            <BitOffs>1295234816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -92954,7 +92478,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295730688</BitOffs>
+            <BitOffs>1295730560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -92983,7 +92507,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296255040</BitOffs>
+            <BitOffs>1296254912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -92994,7 +92518,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779392</BitOffs>
+            <BitOffs>1296779264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -93031,7 +92555,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779840</BitOffs>
+            <BitOffs>1296779712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -93042,7 +92566,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296805056</BitOffs>
+            <BitOffs>1296804928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -93079,7 +92603,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297132480</BitOffs>
+            <BitOffs>1297132352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -93090,7 +92614,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297157696</BitOffs>
+            <BitOffs>1297157568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -93127,7 +92651,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297485120</BitOffs>
+            <BitOffs>1297484992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -93138,7 +92662,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297510336</BitOffs>
+            <BitOffs>1297510208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -93175,7 +92699,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297837760</BitOffs>
+            <BitOffs>1297837632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -93186,7 +92710,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297862976</BitOffs>
+            <BitOffs>1297862848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -93223,7 +92747,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298190400</BitOffs>
+            <BitOffs>1298190272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -93261,7 +92785,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298215616</BitOffs>
+            <BitOffs>1298215488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -93299,7 +92823,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298266048</BitOffs>
+            <BitOffs>1298265920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -93337,7 +92861,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298291264</BitOffs>
+            <BitOffs>1298291136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -93374,7 +92898,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298316480</BitOffs>
+            <BitOffs>1298316352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -93406,7 +92930,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298341696</BitOffs>
+            <BitOffs>1298341568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -93444,7 +92968,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298366912</BitOffs>
+            <BitOffs>1298366784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -93455,7 +92979,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298392128</BitOffs>
+            <BitOffs>1298392000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -93492,7 +93016,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298719552</BitOffs>
+            <BitOffs>1298719424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -93503,7 +93027,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298744768</BitOffs>
+            <BitOffs>1298744640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -93540,7 +93064,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299072192</BitOffs>
+            <BitOffs>1299072064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -93551,7 +93075,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299097408</BitOffs>
+            <BitOffs>1299097280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -93588,7 +93112,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299424832</BitOffs>
+            <BitOffs>1299424704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -93599,7 +93123,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299450048</BitOffs>
+            <BitOffs>1299449920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -93637,7 +93161,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299777472</BitOffs>
+            <BitOffs>1299777344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -93670,7 +93194,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299802688</BitOffs>
+            <BitOffs>1299802560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -93681,7 +93205,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299827904</BitOffs>
+            <BitOffs>1299827776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -93715,7 +93239,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300155328</BitOffs>
+            <BitOffs>1300155200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -93726,7 +93250,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300180544</BitOffs>
+            <BitOffs>1300180416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -93760,7 +93284,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300507968</BitOffs>
+            <BitOffs>1300507840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -93794,7 +93318,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300533184</BitOffs>
+            <BitOffs>1300533056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -93828,7 +93352,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300558400</BitOffs>
+            <BitOffs>1300558272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -93862,7 +93386,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300583616</BitOffs>
+            <BitOffs>1300583488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -93896,7 +93420,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300608832</BitOffs>
+            <BitOffs>1300608704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -93925,7 +93449,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300634048</BitOffs>
+            <BitOffs>1300633920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -93957,7 +93481,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300659264</BitOffs>
+            <BitOffs>1300659136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -93968,7 +93492,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300684480</BitOffs>
+            <BitOffs>1300684352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -94000,7 +93524,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301011904</BitOffs>
+            <BitOffs>1301011776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -94011,7 +93535,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301037120</BitOffs>
+            <BitOffs>1301036992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -94043,7 +93567,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301364544</BitOffs>
+            <BitOffs>1301364416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -94054,7 +93578,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301389760</BitOffs>
+            <BitOffs>1301389632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -94086,7 +93610,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301717184</BitOffs>
+            <BitOffs>1301717056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -94097,7 +93621,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301742400</BitOffs>
+            <BitOffs>1301742272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -94129,7 +93653,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302069824</BitOffs>
+            <BitOffs>1302069696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -94140,7 +93664,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302095040</BitOffs>
+            <BitOffs>1302094912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -94172,7 +93696,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302422464</BitOffs>
+            <BitOffs>1302422336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -94183,7 +93707,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302447680</BitOffs>
+            <BitOffs>1302447552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -94215,7 +93739,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302775104</BitOffs>
+            <BitOffs>1302774976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -94226,7 +93750,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302800320</BitOffs>
+            <BitOffs>1302800192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -94258,7 +93782,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303127744</BitOffs>
+            <BitOffs>1303127616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -94269,7 +93793,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303152960</BitOffs>
+            <BitOffs>1303152832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -94301,7 +93825,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303480384</BitOffs>
+            <BitOffs>1303480256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -94312,7 +93836,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303505600</BitOffs>
+            <BitOffs>1303505472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -94344,7 +93868,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303833024</BitOffs>
+            <BitOffs>1303832896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -94355,7 +93879,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303858240</BitOffs>
+            <BitOffs>1303858112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -94387,7 +93911,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304185664</BitOffs>
+            <BitOffs>1304185536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -94398,7 +93922,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304210880</BitOffs>
+            <BitOffs>1304210752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -94430,7 +93954,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304538304</BitOffs>
+            <BitOffs>1304538176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -94441,7 +93965,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304563520</BitOffs>
+            <BitOffs>1304563392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -94473,7 +93997,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304890944</BitOffs>
+            <BitOffs>1304890816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -94484,7 +94008,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304916160</BitOffs>
+            <BitOffs>1304916032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -94495,7 +94019,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243584</BitOffs>
+            <BitOffs>1305243456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -94510,7 +94034,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243600</BitOffs>
+            <BitOffs>1305243472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -94525,7 +94049,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243608</BitOffs>
+            <BitOffs>1305243480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -94555,7 +94079,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243616</BitOffs>
+            <BitOffs>1305243488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -94585,7 +94109,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243680</BitOffs>
+            <BitOffs>1305243552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -94600,7 +94124,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243744</BitOffs>
+            <BitOffs>1305243616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -94615,7 +94139,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243760</BitOffs>
+            <BitOffs>1305243632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -94630,7 +94154,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243776</BitOffs>
+            <BitOffs>1305243648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -94644,7 +94168,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243784</BitOffs>
+            <BitOffs>1305243656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -94659,7 +94183,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243808</BitOffs>
+            <BitOffs>1305243680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -94674,7 +94198,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243840</BitOffs>
+            <BitOffs>1305243712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -94795,7 +94319,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243872</BitOffs>
+            <BitOffs>1305243744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -94809,7 +94333,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253344</BitOffs>
+            <BitOffs>1305253216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -94823,7 +94347,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253376</BitOffs>
+            <BitOffs>1305253248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -94844,7 +94368,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305257024</BitOffs>
+            <BitOffs>1305256896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -94916,7 +94440,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305274944</BitOffs>
+            <BitOffs>1305274816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -94988,7 +94512,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275072</BitOffs>
+            <BitOffs>1305274944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -95060,7 +94584,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275200</BitOffs>
+            <BitOffs>1305275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -95132,7 +94656,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275328</BitOffs>
+            <BitOffs>1305275200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -95204,7 +94728,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275456</BitOffs>
+            <BitOffs>1305275328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -95276,7 +94800,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275584</BitOffs>
+            <BitOffs>1305275456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -95302,14 +94826,490 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305308608</BitOffs>
+            <BitOffs>1305308480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
+            <BitSize>2496</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.ReqPosLimHi</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.ReqPosLimLo</Name>
+                <Value>-2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimHi</Name>
+                <Value>10768330</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimLo</Name>
+                <Value>8141680</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310865152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
+            <BitSize>1792</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
+                                 .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2K2:FLAT
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310867648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
+            <Comment> MR3K2 Flow Sensors</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310869440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1</Name>
+            <BitSize>23552</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
+                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
+                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310872512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
+            <Comment> MR4K2 Flow Sensors</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR4K2:KBV
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312711616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2</Name>
+            <BitSize>23552</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K2_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K2_STO]^Channel 2^Input;
+                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position;
+                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312729920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch</Name>
+            <Comment> Pitch Mechanism:\
+ Currently unused</Comment>
+            <BitSize>2496</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.ReqPosLimHi</Name>
+                <Value>24681</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.ReqPosLimLo</Name>
+                <Value>24321</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimHi</Name>
+                <Value>10139808</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimLo</Name>
+                <Value>9950984</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.diEncCnt:=TIIB[EL5042_M1K2_Pitch]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312753472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbYRMSErrorM1K1</Name>
+            <Comment> Encoder Arrays/RMS Watch:</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:Y
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313462208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbXRMSErrorM1K1</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:X
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313849728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbPitchRMSErrorM1K1</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:PITCH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314237248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl</Name>
+            <Comment> Pitch Control</Comment>
+            <BitSize>397888</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
+            <BitOffs>1314624768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR1K1 US BENDER ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:US
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1315022656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
+            <Comment>MR1K1 DS BENDER ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:DS
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1315410176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:ENC:Y
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1315797696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:ENC:X
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1316185216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:ENC:PITCH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1316572736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
+            <Comment> Pitch Control</Comment>
+            <BitSize>397888</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
+            <BitOffs>1316960256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR2K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR2K2:FLAT:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317358144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
+            <Comment>MR2K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317745664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
+            <Comment>MR2K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1318133184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR3K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1318520704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
+            <Comment>MR3K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1318908224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
+            <Comment>MR3K2 rY ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319295744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
+            <Comment>MR3K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319683264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
+            <Comment>MR3K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320070784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR4K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320458304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
+            <Comment>MR4K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320845824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
+            <Comment>MR4K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1321233344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
+            <Comment>MR4K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1321620864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
+            <Comment>MR4K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1322008384</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>165412864</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95389,11 +95389,11 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-07T16:41:13</Value>
+          <Value>2024-02-09T14:19:05</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>978944</Value>
+          <Value>925696</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- move cooling readbacks to optics library
- upgrade motion 2.0.1 -> 4.0.5
- upgrade optics 0.6.1 -> 0.7.0
- change G_PI lag monitoring 3urad -> 10urad to try and stop errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- implement alarm thresholds for NALMS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran on PLC.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
