### PR TITLE
Hard Stop Testing / SP1K1 RTD Scaling

### DIFF
--- a/lcls-plc-rixs-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 79 (EK1521-0010)/Term 306 (EK1501-0010)/Term 310 (EK1122)/EK1100_MR2K2/EL3054_MR2K2_FWM_PRSM.xti
+++ b/lcls-plc-rixs-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 79 (EK1521-0010)/Term 306 (EK1501-0010)/Term 310 (EK1122)/EK1100_MR2K2/EL3054_MR2K2_FWM_PRSM.xti
@@ -34,6 +34,7 @@
 			<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
 			<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
 			<BootStrapData>0010f400f410f400</BootStrapData>
+			<SuName>MR2K2</SuName>
 			<Pdo Name="AI Standard Channel 1" Index="#x1a00" Flags="#x0010" SyncMan="3">
 				<ExcludePdo>#x1a01</ExcludePdo>
 				<Entry Name="Status__Underrange" Index="#x6000" Sub="#x01">

--- a/lcls-plc-rixs-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 79 (EK1521-0010)/Term 306 (EK1501-0010)/Term 310 (EK1122)/EK1100_MR2K2/Term 263 (EL3204).xti
+++ b/lcls-plc-rixs-optics/_Config/IO/Device 1 (EtherCAT)/Term 1 (EK1200)/Term 79 (EK1521-0010)/Term 306 (EK1501-0010)/Term 310 (EK1122)/EK1100_MR2K2/Term 263 (EL3204).xti
@@ -25,6 +25,7 @@
 			<Fmmu>0000000000000000801100010100000002000000000000000000000000000000</Fmmu>
 			<Fmmu>00000000000000000d0800010100000003000000000000000000000000000000</Fmmu>
 			<BootStrapData>0010f400f410f400</BootStrapData>
+			<SuName>MR2K2</SuName>
 			<Pdo Name="RTD Inputs Channel 1" Index="#x1a00" Flags="#x0011" SyncMan="3">
 				<Entry Name="Status__Underrange" Index="#x6000" Sub="#x01">
 					<Type>BIT</Type>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Pitch.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Pitch.xti
@@ -1351,8 +1351,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.00244" Offset="-24484.38252" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-200"/>
-				<SoftEndMaxControl Enable="true" Range="400"/>
+				<SoftEndMinControl Enable="true" Range="-50"/>
+				<SoftEndMaxControl Enable="true" Range="300"/>
 				<ActPosCorrection Time="0.008"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Ydwn.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Ydwn.xti
@@ -1460,7 +1460,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="50" Time="0.2"/>
+				<PosDiffControl Range="30" Time="0.2"/>
 				<PID PosKp="25" PosTn="0.005" PosIOutputLimit="0.0001" PosDOutputLimit="0" PosIDisableWhenMoving="true" PosExtKp="10" DeadBandPosition="0.001"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Yup.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Yup.xti
@@ -1351,8 +1351,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-31911.458" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-18738"/>
-				<SoftEndMaxControl Enable="true" Range="1450"/>
+				<SoftEndMinControl Range="-18500"/>
+				<SoftEndMaxControl Range="2114"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1462,7 +1462,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="3">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="50" Time="0.2"/>
+				<PosDiffControl Range="30" Time="0.2"/>
 				<PID PosTn="0.005" PosIOutputLimit="0.0001" PosDOutputLimit="0" PosIDisableWhenMoving="true" DeadBandPosition="0.001"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Yup.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Yup.xti
@@ -1346,7 +1346,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<General UnitName="um"/>
 			<Dynamic Acceleration="5050" Deceleration="5050" Jerk="5100500" DelayTime="0.008"/>
-			<Velo Maximum="500"/>
+			<Velo Maximum="100"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Yup.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K1-Yup.xti
@@ -1351,8 +1351,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-31911.458" MaxCount="#xffffffff">
-				<SoftEndMinControl Range="-18500"/>
-				<SoftEndMaxControl Range="2114"/>
+				<SoftEndMinControl Enable="true" Range="-18500"/>
+				<SoftEndMaxControl Enable="true" Range="2114"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Pitch.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Pitch.xti
@@ -1327,8 +1327,8 @@ External Setpoint Generation:
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.00256" Offset="-25648.08" MaxCount="#xffffffff">
 				<FilterTime TPos="0.05"/>
-				<SoftEndMinControl Range="-500"/>
-				<SoftEndMaxControl Range="100"/>
+				<SoftEndMinControl Enable="true" Range="-350"/>
+				<SoftEndMaxControl Enable="true" Range="-25"/>
 				<ActPosCorrection Time="0.008"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Pitch.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Pitch.xti
@@ -1327,8 +1327,8 @@ External Setpoint Generation:
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.00256" Offset="-25648.08" MaxCount="#xffffffff">
 				<FilterTime TPos="0.05"/>
-				<SoftEndMinControl Enable="true" Range="-500"/>
-				<SoftEndMaxControl Enable="true" Range="100"/>
+				<SoftEndMinControl Range="-500"/>
+				<SoftEndMaxControl Range="100"/>
 				<ActPosCorrection Time="0.008"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Xdwn.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Xdwn.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -272,15 +272,13 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Drive Status 4 (automatically linked):
+				<Comment><![CDATA[Drive Status 4 (automatically linked):
 0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
 
 Drive Status 4 (manually linked):
 0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -329,6 +327,8 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>nState8</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+				<Comment><![CDATA[Digital Inputs 1..8
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>248</BitOffs>
 			</SubItem>
@@ -499,7 +499,7 @@ Drive Status 4 (manually linked):
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF_OLD</Name>
 			<BitSize>1024</BitSize>
 			<SubItem>
 				<Name>ControlDWord</Name>
@@ -622,7 +622,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1014,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1031,8 +1031,7 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1046,8 +1045,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1060,8 +1058,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1069,22 +1066,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1310,13 +1304,13 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -1332,8 +1326,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-21007.52" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-1668.52"/>
-				<SoftEndMaxControl Enable="true" Range="2441.7"/>
+				<SoftEndMinControl Range="-1668.52"/>
+				<SoftEndMaxControl Range="2441.7"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1341,28 +1335,23 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>6976</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
-						<Comment>
-							<![CDATA[Encoder State 1 (automatically linked):
+						<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nComState</Name>
-						<Comment>
-							<![CDATA[Encoder Communication State (automatically linked):
+						<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 				</Var>
 			</Vars>
@@ -1371,7 +1360,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>11072</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1385,24 +1373,11 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>7616</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn2</Name>
-					</SubVar>
-					<SubVar>
-						<Name>nState4</Name>
-						<Comment>
-							<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-						</Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn3</Name>
@@ -1423,7 +1398,6 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>11712</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1432,23 +1406,19 @@ Drive Status 4 (manually linked):
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl2</Name>
-						<Comment>
-							<![CDATA[Digital Outputs Setpoint Generator:
+						<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl3</Name>
-						<Comment>
-							<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+						<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut3</Name>
@@ -1476,61 +1446,14 @@ Drive Status 4 (manually linked):
 			<Name>Inputs</Name>
 			<Var>
 				<Name>FromPlc</Name>
-				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>5952</BitOffs>
+				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF_OLD</Type>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>9024</BitOffs>
-				<SubVar>
-					<Name>AxisState</Name>
-					<Comment>
-						<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>HomingState</Name>
-					<Comment>
-						<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>CoupleState</Name>
-					<Comment>
-						<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-					</Comment>
-				</SubVar>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 			</Var>
 		</Vars>
 	</Axis>
@@ -1538,14 +1461,14 @@ External Setpoint Generation:
 		<OwnerA>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL5042_M1K2_Xupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xdwn">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
@@ -1553,7 +1476,7 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -1561,8 +1484,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl2" VarB="STM Control^Control^Digital output 1" Size="1" OffsA="3"/>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Xup.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Xup.xti
@@ -1326,8 +1326,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-19847.2" MaxCount="#xffffffff">
-				<SoftEndMinControl Range="-1573.2"/>
-				<SoftEndMaxControl Range="2335.3"/>
+				<SoftEndMinControl Enable="true" Range="-1000"/>
+				<SoftEndMaxControl Enable="true" Range="1000"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Xup.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Xup.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -272,15 +272,13 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Drive Status 4 (automatically linked):
+				<Comment><![CDATA[Drive Status 4 (automatically linked):
 0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
 
 Drive Status 4 (manually linked):
 0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -329,6 +327,8 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>nState8</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+				<Comment><![CDATA[Digital Inputs 1..8
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>248</BitOffs>
 			</SubItem>
@@ -499,7 +499,7 @@ Drive Status 4 (manually linked):
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF_OLD</Name>
 			<BitSize>1024</BitSize>
 			<SubItem>
 				<Name>ControlDWord</Name>
@@ -622,7 +622,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1014,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1031,8 +1031,7 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1046,8 +1045,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1060,8 +1058,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1069,22 +1066,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1310,13 +1304,13 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -1332,8 +1326,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-19847.2" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-1573.2"/>
-				<SoftEndMaxControl Enable="true" Range="2335.3"/>
+				<SoftEndMinControl Range="-1573.2"/>
+				<SoftEndMaxControl Range="2335.3"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1341,28 +1335,23 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>4992</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
-						<Comment>
-							<![CDATA[Encoder State 1 (automatically linked):
+						<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nComState</Name>
-						<Comment>
-							<![CDATA[Encoder Communication State (automatically linked):
+						<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 				</Var>
 			</Vars>
@@ -1371,7 +1360,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>8064</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1385,24 +1373,11 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>5632</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn2</Name>
-					</SubVar>
-					<SubVar>
-						<Name>nState4</Name>
-						<Comment>
-							<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-						</Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn3</Name>
@@ -1423,7 +1398,6 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>8704</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1432,23 +1406,19 @@ Drive Status 4 (manually linked):
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl2</Name>
-						<Comment>
-							<![CDATA[Digital Outputs Setpoint Generator:
+						<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl3</Name>
-						<Comment>
-							<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+						<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut3</Name>
@@ -1476,61 +1446,14 @@ Drive Status 4 (manually linked):
 			<Name>Inputs</Name>
 			<Var>
 				<Name>FromPlc</Name>
-				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>3968</BitOffs>
+				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF_OLD</Type>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>6016</BitOffs>
-				<SubVar>
-					<Name>AxisState</Name>
-					<Comment>
-						<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>HomingState</Name>
-					<Comment>
-						<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>CoupleState</Name>
-					<Comment>
-						<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-					</Comment>
-				</SubVar>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 			</Var>
 		</Vars>
 	</Axis>
@@ -1538,14 +1461,14 @@ External Setpoint Generation:
 		<OwnerA>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL5042_M1K2_Xupdwn">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xup">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
@@ -1553,7 +1476,7 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -1561,8 +1484,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl2" VarB="STM Control^Control^Digital output 1" Size="1" OffsA="3"/>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M2K2 rX.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M2K2 rX.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.0025826446" Offset="-130197.25" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-930"/>
-				<SoftEndMaxControl Enable="true" Range="940"/>
+				<SoftEndMinControl Range="-917"/>
+				<SoftEndMaxControl Range="915"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M2K2 rX.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M2K2 rX.xti
@@ -1316,7 +1316,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Axis Id="27" CreateSymbols="true" AxisType="1" AxisFolder="M2K2">
-		<Name>__FILENAME__</Name>
+		<Name>M2K2 rX</Name>
 		<AxisPara>
 			<General UnitName="urad"/>
 			<Dynamic AccelerationMaximum="200" DecelerationMaximum="200" Acceleration="200" Deceleration="200" DelayTime="0.008"/>
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.0025826446" Offset="-130197.25" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Range="-917"/>
-				<SoftEndMaxControl Range="915"/>
+				<SoftEndMinControl Enable="true" Range="-917"/>
+				<SoftEndMaxControl Enable="true" Range="915"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 X.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 X.xti
@@ -1324,8 +1324,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-06" Offset="-29.756" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Range="-1.2"/>
-				<SoftEndMaxControl Range="1.2"/>
+				<SoftEndMinControl Enable="true" Range="-1"/>
+				<SoftEndMaxControl Enable="true" Range="1.2"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 X.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 X.xti
@@ -1324,8 +1324,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-06" Offset="-29.756" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-1.2"/>
-				<SoftEndMaxControl Enable="true" Range="1.2"/>
+				<SoftEndMinControl Range="-1.2"/>
+				<SoftEndMaxControl Range="1.2"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 rY.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 rY.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.005236" Offset="-209396" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-540"/>
-				<SoftEndMaxControl Enable="true" Range="-175"/>
+				<SoftEndMinControl Enable="true" Range="-670"/>
+				<SoftEndMaxControl Enable="true" Range="-300"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1436,7 +1436,6 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="10"/>
 				<PID PosKp="10" DeadBandPosition="0.1"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 rY.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M3K2 rY.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.005236" Offset="-209396" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-670"/>
-				<SoftEndMaxControl Enable="true" Range="-300"/>
+				<SoftEndMinControl Enable="true" Range="-1430"/>
+				<SoftEndMaxControl Enable="true" Range="230"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 Y.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 Y.xti
@@ -1324,8 +1324,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-06" Offset="-29.075" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-0.37"/>
-				<SoftEndMaxControl Enable="true" Range="1.8"/>
+				<SoftEndMinControl Range="-0.37"/>
+				<SoftEndMaxControl Range="1.8"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 Y.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 Y.xti
@@ -1324,8 +1324,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="5e-06" Offset="-29.075" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Range="-0.37"/>
-				<SoftEndMaxControl Range="1.8"/>
+				<SoftEndMinControl Enable="true" Range="-1.41"/>
+				<SoftEndMaxControl Enable="true" Range="1.42"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 rX.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 rX.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.002571" Offset="-130236.02" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-955"/>
-				<SoftEndMaxControl Enable="true" Range="605"/>
+				<SoftEndMinControl Range="-955"/>
+				<SoftEndMaxControl Range="605"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1436,7 +1436,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="10"/>
+				<PosDiffControl Range="3.5"/>
 				<PID PosKp="10" DeadBandPosition="0.1"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 rX.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 rX.xti
@@ -1316,7 +1316,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Axis Id="35" CreateSymbols="true" AxisType="1" AxisFolder="M4K2">
-		<Name>__FILENAME__</Name>
+		<Name>M4K2 rX</Name>
 		<AxisPara>
 			<General UnitName="urad"/>
 			<Dynamic AccelerationMaximum="200" DecelerationMaximum="200" Acceleration="200" Deceleration="200" DelayTime="0.008"/>
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.002571" Offset="-130236.02" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Range="-900"/>
-				<SoftEndMaxControl Range="875"/>
+				<SoftEndMinControl Enable="true" Range="-900"/>
+				<SoftEndMaxControl Enable="true" Range="875"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 rX.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M4K2 rX.xti
@@ -1325,8 +1325,8 @@ External Setpoint Generation:
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
 			<EncPara ScaleFactorNumerator="0.002571" Offset="-130236.02" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Range="-955"/>
-				<SoftEndMaxControl Range="605"/>
+				<SoftEndMinControl Range="-900"/>
+				<SoftEndMaxControl Range="875"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1436,7 +1436,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="3.5"/>
+				<PosDiffControl Range="10"/>
 				<PID PosKp="10" DeadBandPosition="0.1"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
@@ -1329,8 +1329,8 @@ External Setpoint Generation:
 		<Encoder Name="e_dwn" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="150" Offset="-260.047" MaxCount="#xffffffff">
 				<FilterTime TPos="0.05" TVelo="0.1"/>
-				<SoftEndMinControl Enable="true" Range="123375"/>
-				<SoftEndMaxControl Enable="true" Range="176006"/>
+				<SoftEndMinControl Range="123375"/>
+				<SoftEndMaxControl Range="176006"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1440,7 +1440,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
-				<PosDiffControl Range="10" Time="0.2"/>
+				<PosDiffControl Range="50" Time="0.2"/>
 				<PID PosKp="7" PosTn="0.001" PosIOutputLimit="0.0005" PosDOutputLimit="0" PosIDisableWhenMoving="true" PosExtKp="8" PosExtVelo="0.0001" DeadBandPosition="0.02"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
@@ -1330,7 +1330,7 @@ External Setpoint Generation:
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="150" Offset="-260.047" MaxCount="#xffffffff">
 				<FilterTime TPos="0.05" TVelo="0.1"/>
 				<SoftEndMinControl Enable="true" Range="130501"/>
-				<SoftEndMaxControl Enable="true" Range="158627"/>
+				<SoftEndMaxControl Enable="true" Range="159000"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
@@ -1329,8 +1329,8 @@ External Setpoint Generation:
 		<Encoder Name="e_dwn" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="150" Offset="-260.047" MaxCount="#xffffffff">
 				<FilterTime TPos="0.05" TVelo="0.1"/>
-				<SoftEndMinControl Enable="true" Range="123375"/>
-				<SoftEndMaxControl Enable="true" Range="176006"/>
+				<SoftEndMinControl Enable="true" Range="130501"/>
+				<SoftEndMaxControl Enable="true" Range="158627"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1441,7 +1441,7 @@ External Setpoint Generation:
 		<Controller Name="Ctrl" CtrType="2">
 			<CtrPara PriorControlFactor="1">
 				<PosDiffControl Range="50" Time="0.2"/>
-				<PID PosKp="7" PosTn="0.001" PosIOutputLimit="0.0005" PosDOutputLimit="0" PosIDisableWhenMoving="true" PosExtKp="8" PosExtVelo="0.0001" DeadBandPosition="0.02"/>
+				<PID PosKp="7" PosTn="0.001" PosIOutputLimit="0.0005" PosDOutputLimit="0" PosIDisableWhenMoving="true" PosExtKp="2" PosExtVelo="0.0001" DeadBandPosition="0.02"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>
 		</Controller>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/g_pi.xti
@@ -1329,8 +1329,8 @@ External Setpoint Generation:
 		<Encoder Name="e_dwn" EncType="29">
 			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="150" Offset="-260.047" MaxCount="#xffffffff">
 				<FilterTime TPos="0.05" TVelo="0.1"/>
-				<SoftEndMinControl Range="123375"/>
-				<SoftEndMaxControl Range="176006"/>
+				<SoftEndMinControl Enable="true" Range="123375"/>
+				<SoftEndMaxControl Enable="true" Range="176006"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/m_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/m_pi.xti
@@ -1327,8 +1327,8 @@ External Setpoint Generation:
 		<Encoder Name="e_dwn" EncType="29">
 			<EncPara ScaleFactorNumerator="0.004505" MaxCount="#xffffffff">
 				<FilterTime TPos="0.02"/>
-				<SoftEndMinControl Enable="true" Range="133475"/>
-				<SoftEndMaxControl Range="147461"/>
+				<SoftEndMinControl Enable="true" Range="133841"/>
+				<SoftEndMaxControl Enable="true" Range="147463"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/m_pi.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/m_pi.xti
@@ -1320,14 +1320,15 @@ External Setpoint Generation:
 		<AxisPara>
 			<General UnitName="urad"/>
 			<Dynamic Acceleration="2000" Deceleration="2000" Jerk="3000"/>
+			<Velo Maximum="200"/>
 			<TargetPosControl Range="0.05" Time="0.5"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="e_dwn" EncType="29">
 			<EncPara ScaleFactorNumerator="0.004505" MaxCount="#xffffffff">
 				<FilterTime TPos="0.02"/>
-				<SoftEndMinControl Enable="true" Range="123475"/>
-				<SoftEndMaxControl Enable="true" Range="155739"/>
+				<SoftEndMinControl Enable="true" Range="133475"/>
+				<SoftEndMaxControl Range="147461"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1437,7 +1438,7 @@ External Setpoint Generation:
 		</Drive>
 		<Controller Name="Ctrl" CtrType="3">
 			<CtrPara PriorControlFactor="0.8">
-				<PosDiffControl Range="100" Time="0.2"/>
+				<PosDiffControl Range="15" Time="0.2"/>
 				<PID PosKp="10" PosTn="1e-05" PosIOutputLimit="0.0005" PosDOutputLimit="0" PosIDisableWhenMoving="true" DeadBandPosition="0.01"/>
 				<Observer BandWidth="20"/>
 			</CtrPara>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{ED4D5D9F-FC60-174F-F845-FEC39D417C4D}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{82D15D0F-784A-EDEC-0951-8604808142FF}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -4598,10 +4598,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^Main.M2.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M2.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL1004_M1K1_STO">
-				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
-			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL3054_M1K1_FWM_PRSM">
 				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.fM1K1_Flow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.fM1K1_Flow_2.iRaw" VarB="AI Standard Channel 2^Value" AutoLink="true"/>
@@ -4635,11 +4631,9 @@ Emergency Stop for MR1K1]]></Comment>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL7047_M1K1_Ydwn">
 				<Link VarA="PlcTask Inputs^Main.M12.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M12.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M13.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M13.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
-			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL7047_M1K1_Yup">
-				<Link VarA="PlcTask Inputs^Main.M12.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1_BEND^EL1004_M1K1_BENDER_STO">
 				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{260DC897-92CC-1B18-6E76-E3ED3545641D}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{28463369-1E78-9975-DB5E-D0683DE89341}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -4525,6 +4525,8 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^GVL_M1K2.M1K2_Pitch.diEncCnt" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL5042_M1K2_Xupdwn">
+				<Link VarA="PlcTask Inputs^Main.M3.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^Main.M4.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc^Count" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc^Count" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 			</OwnerB>
@@ -4583,14 +4585,6 @@ Emergency Stop for MR1K1]]></Comment>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_PitchCoarse">
 				<Link VarA="PlcTask Inputs^Main.M5.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M5.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
-			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xdwn">
-				<Link VarA="PlcTask Inputs^Main.M4.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^Main.M4.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
-			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xup">
-				<Link VarA="PlcTask Inputs^Main.M3.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^Main.M3.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Yleft">
 				<Link VarA="PlcTask Inputs^Main.M1.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{C85B3384-5678-5727-ADC1-FE3E8545C97D}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{ED4D5D9F-FC60-174F-F845-FEC39D417C4D}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -4581,10 +4581,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="SerialIO Outputs^GVL_SerialIO.Serial_stComOut_M1K2^D[7]" VarB="COM Outputs^Data Out 7"/>
 				<Link VarA="SerialIO Outputs^GVL_SerialIO.Serial_stComOut_M1K2^D[8]" VarB="COM Outputs^Data Out 8"/>
 				<Link VarA="SerialIO Outputs^GVL_SerialIO.Serial_stComOut_M1K2^D[9]" VarB="COM Outputs^Data Out 9"/>
-			</OwnerB>
-			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_PitchCoarse">
-				<Link VarA="PlcTask Inputs^Main.M5.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^Main.M5.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xdwn">
 				<Link VarA="PlcTask Inputs^Main.M4.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{99BC765F-962C-CB1C-018B-126FBB19E481}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{0B1A3EB5-2374-3214-22E8-09A06099E82B}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -4677,6 +4677,10 @@ Emergency Stop for MR1K1]]></Comment>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Yright">
 				<Link VarA="PlcTask Inputs^Main.M2.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M2.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL1004_M1K1_STO">
+				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1" VarB="Channel 1^Input" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL3054_M1K1_FWM_PRSM">
 				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.fM1K1_Flow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{28463369-1E78-9975-DB5E-D0683DE89341}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{C85B3384-5678-5727-ADC1-FE3E8545C97D}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -4585,6 +4585,14 @@ Emergency Stop for MR1K1]]></Comment>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_PitchCoarse">
 				<Link VarA="PlcTask Inputs^Main.M5.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^Main.M5.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xdwn">
+				<Link VarA="PlcTask Inputs^Main.M4.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M4.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
+			</OwnerB>
+			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Xup">
+				<Link VarA="PlcTask Inputs^Main.M3.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M3.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Yleft">
 				<Link VarA="PlcTask Inputs^Main.M1.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{82D15D0F-784A-EDEC-0951-8604808142FF}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{64BADEED-7A46-6999-26C7-6F1A919E5DB8}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{64BADEED-7A46-6999-26C7-6F1A919E5DB8}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{99BC765F-962C-CB1C-018B-126FBB19E481}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1746,6 +1746,70 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>PRG_SP1K1_MONO.RTD8.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD9.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD9.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD9.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD9.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD10.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD10.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD10.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD10.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD11.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD11.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD11.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD11.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD12.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD12.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD12.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.RTD12.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -4409,8 +4473,8 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^Main.M20.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^E5 (EK1122)^SL1K2-EXIT (EK1100)^EL7047_SL1K2_YAG">
-				<Link VarA="PlcTask Inputs^Main.M23.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^Main.M23.bLimitForwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M23.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 1" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^Main.M23.bLimitForwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^E5 (EK1122)^X1 SP1K1-MONO(EK1100)^EL3054_SP1K1_FWM_PRSM">
 				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw" VarB="AI Standard Channel 1^Value" AutoLink="true"/>
@@ -4450,16 +4514,32 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD6.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD6.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD6.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.bError" VarB="RTD Inputs Channel 3^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.bOverrange" VarB="RTD Inputs Channel 3^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.bUnderrange" VarB="RTD Inputs Channel 3^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.iRaw" VarB="RTD Inputs Channel 3^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.bError" VarB="RTD Inputs Channel 4^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.bOverrange" VarB="RTD Inputs Channel 4^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.bUnderrange" VarB="RTD Inputs Channel 4^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.iRaw" VarB="RTD Inputs Channel 4^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^E5 (EK1122)^X1 SP1K1-MONO(EK1100)^SP1K1-EL3204-E16">
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD7.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD8.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD10.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD10.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD10.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD10.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD11.bError" VarB="RTD Inputs Channel 3^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD11.bOverrange" VarB="RTD Inputs Channel 3^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD11.bUnderrange" VarB="RTD Inputs Channel 3^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD11.iRaw" VarB="RTD Inputs Channel 3^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD12.bError" VarB="RTD Inputs Channel 4^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD12.bOverrange" VarB="RTD Inputs Channel 4^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD12.bUnderrange" VarB="RTD Inputs Channel 4^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD12.iRaw" VarB="RTD Inputs Channel 4^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD9.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD9.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD9.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_SP1K1_MONO.RTD9.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^E5 (EK1122)^X1 SP1K1-MONO(EK1100)^g_h_m">
 				<Link VarA="PlcTask Inputs^Main.M9.bLimitBackwardEnable" VarB="STM Status^Status^Digital input 2" AutoLink="true" Size="1"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{E3C294DB-8219-B920-2780-EBADF1F16FAF}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{260DC897-92CC-1B18-6E76-E3ED3545641D}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1393,6 +1393,61 @@ External Setpoint Generation:
 			</Vars>
 			<Vars VarGrpType="1" ContextId="4" AreaNo="64">
 				<Name>PlcTask Inputs</Name>
+				<Var>
+					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
+					<Comment><![CDATA[ STO Button]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
@@ -1463,6 +1518,56 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
 					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
+					<Comment><![CDATA[ STO Button]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -1778,6 +1883,21 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
 					<Comment><![CDATA[ RTD error bit]]></Comment>
 					<Type>BOOL</Type>
@@ -1810,6 +1930,16 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
 					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -1887,6 +2017,16 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
+					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
 					<Type>INT</Type>
 				</Var>
@@ -1894,6 +2034,11 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
 					<Comment><![CDATA[ M1K1 DS RTDs]]></Comment>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -1911,6 +2056,11 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -3494,159 +3644,13 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
-				<Var>
-					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
-					<Comment><![CDATA[ STO Button]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
-					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
-					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
-					<Comment><![CDATA[ STO Button]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
-					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
 			</Vars>
 			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
 				<Var>
 					<Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
@@ -3672,6 +3676,10 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>PRG_MR1K1_BEND.nMR1K1_Y_ENC_PMPS</Name>
 					<Comment><![CDATA[////////////////////////////////////]]></Comment>
 					<Type>UDINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -4193,14 +4201,6 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</TargetSelect>
-					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
+					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</TargetSelect>
-					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
+					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -101,17 +101,17 @@
     // need to fix Axis IDs for IOC to work
     // For now just want functional PLC project
     // Motors
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Yup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
+
+    {attribute 'TcLinkTo' := '.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
+                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
                               .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:YUP
     '}
     M12 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Yup
     fbMotionStage_m12 : FB_MotionStage;
-
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2'}
+                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2'}
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:YDWN
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -28,17 +28,14 @@
     '}
     M2 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yright
     fbMotionStage_m2 : FB_MotionStage;
-
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2'}
+    {attribute 'TcLinkTo' := '.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:XUP
     '}
     M3 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xup
     fbMotionStage_m3 : FB_MotionStage;
 
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2'}
+    {attribute 'TcLinkTo' := '.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:XDWN
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -46,9 +46,8 @@
     M4 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xdwn
     fbMotionStage_m4 : FB_MotionStage;
 
-    //{attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
-    //                          .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2'}
-    //disabled per Alireze and Matt Seaberg after hardstop re-alignment. 2-28-2024
+    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2'}
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:PITCH
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -194,8 +194,8 @@
     '}
     M22 : ST_MotionStage := (sName:= 'SL1K2:EXIT:MMS:GAP',fVelocity :=0.1); // GAP
 
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: SL1K2:EXIT:MMS:YAG

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -28,14 +28,18 @@
     '}
     M2 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yright
     fbMotionStage_m2 : FB_MotionStage;
-    {attribute 'TcLinkTo' := '.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position'}
+    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:XUP
     '}
     M3 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xup
     fbMotionStage_m3 : FB_MotionStage;
 
-    {attribute 'TcLinkTo' := '.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position'}
+    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:XDWN
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -46,8 +46,9 @@
     M4 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Xdwn
     fbMotionStage_m4 : FB_MotionStage;
 
-    {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2'}
+    //{attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
+    //                          .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2'}
+    //disabled per Alireze and Matt Seaberg after hardstop re-alignment. 2-28-2024
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:PITCH
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="PRG_MR1K1_BEND" Id="{f3f12a20-b8bd-4f8a-96c6-66ebb9fb57e3}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_MR1K1_BEND
 VAR
-    {attribute 'TcLinkTo' := '.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
+    {attribute 'TcLinkTo' := '
                               .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
                               .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
                               .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
@@ -284,7 +283,11 @@ nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm)
     fM1K1_Flow_2_val := fM1K1_Flow_2.fReal;
 
     fM1K1_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-    fM1K1_Press_1_val := fM1K1_Press_1.fReal;]]></ST>
+    fM1K1_Press_1_val := fM1K1_Press_1.fReal;
+
+
+
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -3,7 +3,8 @@
   <POU Name="PRG_MR1K1_BEND" Id="{f3f12a20-b8bd-4f8a-96c6-66ebb9fb57e3}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_MR1K1_BEND
 VAR
-    {attribute 'TcLinkTo' := '
+    {attribute 'TcLinkTo' := '.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
                               .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
                               .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
                               .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
@@ -241,12 +241,7 @@ fM1K2_Flow_1_val := fM1K2_Flow_1.fReal;
 fM1K2_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
 fM1K2_Flow_2_val := fM1K2_Flow_2.fReal;
 fM1K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fM1K2_Press_1_val := fM1K2_Press_1.fReal;
-
-main.M3.bLimitForwardEnable := True;
-main.M3.bLimitBackwardEnable := True;
-main.M4.bLimitBackwardEnable := True;
-main.M4.bLimitForwardEnable := True;]]></ST>
+fM1K2_Press_1_val := fM1K2_Press_1.fReal;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
@@ -241,10 +241,7 @@ fM1K2_Flow_1_val := fM1K2_Flow_1.fReal;
 fM1K2_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
 fM1K2_Flow_2_val := fM1K2_Flow_2.fReal;
 fM1K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fM1K2_Press_1_val := fM1K2_Press_1.fReal;
-
-main.M5.bLimitBackwardEnable := True;
-main.M5.bLimitForwardEnable := True;]]></ST>
+fM1K2_Press_1_val := fM1K2_Press_1.fReal;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
@@ -241,7 +241,10 @@ fM1K2_Flow_1_val := fM1K2_Flow_1.fReal;
 fM1K2_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
 fM1K2_Flow_2_val := fM1K2_Flow_2.fReal;
 fM1K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fM1K2_Press_1_val := fM1K2_Press_1.fReal;]]></ST>
+fM1K2_Press_1_val := fM1K2_Press_1.fReal;
+
+main.M5.bLimitBackwardEnable := True;
+main.M5.bLimitForwardEnable := True;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="PRG_MR1K2_SWITCH" Id="{5d1ad344-c9c3-47ff-86fa-37de6eb5129e}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_MR1K2_SWITCH
 VAR
@@ -242,7 +242,11 @@ fM1K2_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
 fM1K2_Flow_2_val := fM1K2_Flow_2.fReal;
 fM1K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
 fM1K2_Press_1_val := fM1K2_Press_1.fReal;
-]]></ST>
+
+main.M3.bLimitForwardEnable := True;
+main.M3.bLimitBackwardEnable := True;
+main.M4.bLimitBackwardEnable := True;
+main.M4.bLimitForwardEnable := True;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -252,7 +252,8 @@ fSP1K1_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
 fSP1K1_Flow_2_val := fSP1K1_Flow_2.fReal;
 
 fSP1K1_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fSP1K1_Press_1_val := fSP1K1_Press_1.fReal;]]></ST>
+fSP1K1_Press_1_val := fSP1K1_Press_1.fReal;
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -54,8 +54,7 @@ VAR
                               .bUnderrange := TIIB[SP1K1-EL3202-E13]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3202-E13]^RTD Inputs Channel 2^Status^Overrange'}
     RTD2 : FB_TempSensor;
-
-    {attribute 'pytmc' := '
+        {attribute 'pytmc' := '
         pv: SP1K1:MONO:RTD:03
         io: o
     '}
@@ -63,58 +62,91 @@ VAR
                               .bError := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 1^Status^Error;
                               .bUnderrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 1^Status^Overrange'}
-    RTD3 :FB_TempSensor;
-
-    {attribute 'pytmc' := '
+    RTD3 : FB_TempSensor;
+        {attribute 'pytmc' := '
         pv: SP1K1:MONO:RTD:04
         io: o
     '}
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Value;
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Value;
                               .bError := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Status^Error;
                               .bUnderrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3202-E14]^RTD Inputs Channel 2^Status^Overrange'}
     RTD4 : FB_TempSensor;
 
-        {attribute 'pytmc' := '
+    {attribute 'pytmc' := '
         pv: SP1K1:MONO:RTD:05
         io: o
     '}
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Value;
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Value;
                               .bError := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Error;
                               .bUnderrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Overrange'}
-    RTD5 : FB_TempSensor;
+    RTD5 :FB_TempSensor;
 
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:RTD:06
         io: o
     '}
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Value;
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Value;
                               .bError := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Error;
                               .bUnderrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Overrange'}
-    RTD6 : FB_TempSensor;
+    RTD6 :FB_TempSensor;
 
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:RTD:07
         io: o
     '}
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Value;
-                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Error;
-                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Underrange;
-                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange'}
-    RTD7 : FB_TempSensor;
-
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Value;
+                              .bError := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Overrange'}
+    RTD7 :FB_TempSensor;
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:RTD:08
         io: o
     '}
-    {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Value;
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Value;
+                              .bError := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Overrange'}
+    RTD8 :FB_TempSensor;
+    {attribute 'pytmc' := '
+        pv: SP1K1:MONO:RTD:09
+        io: o
+    '}
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Value;
+                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange'}
+    RTD9 :FB_TempSensor;
+        {attribute 'pytmc' := '
+        pv: SP1K1:MONO:RTD:10
+        io: o
+    '}
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Value;
                               .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Error;
                               .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange'}
-    RTD8 :FB_TempSensor;
-
+    RTD10 :FB_TempSensor;
+        {attribute 'pytmc' := '
+        pv: SP1K1:MONO:RTD:11
+        io: o
+    '}
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Value;
+                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Overrange'}
+    RTD11 :FB_TempSensor;
+    {attribute 'pytmc' := '
+        pv: SP1K1:MONO:RTD:12
+        io: o
+    '}
+     {attribute 'TcLinkTo' := '.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Value;
+                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Overrange'}
+    RTD12 :FB_TempSensor;
 
 
 

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -222,10 +222,10 @@ mpi_upeurad := ULINT_TO_LREAL(mpi_upe.Count)*0.004505;
 gpi_upeurad := ULINT_TO_LREAL(gpi_upe.Count)*0.0066667;
 
 (*RTDs*)
-RTD1();
-RTD2();
-RTD3();
-RTD4();
+RTD1(fResolution:=0.01);
+RTD2(fResolution:=0.01);
+RTD3(fResolution:=0.01);
+RTD4(fResolution:=0.01);
 RTD5();
 RTD6();
 RTD7();

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -262,7 +262,10 @@ RTD5();
 RTD6();
 RTD7();
 RTD8();
-
+RTD9();
+RTD10();
+RTD11();
+RTD12();
 //Evaluate the encoder reading for the screw driver encoder. Fast fault when it is not out.
 // i.e. encoder value must be greater than the out position (75000.29 - 1000u)
 IF( M10.Axis.NcToPlc.ActPos < sd_io_e_pmps) THEN

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{ED4D5D9F-FC60-174F-F845-FEC39D417C4D}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{82D15D0F-784A-EDEC-0951-8604808142FF}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -5349,15 +5349,15 @@ External Setpoint Generation:
         <Default>
           <SubItem>
             <Name>.tCtrlCycleTime</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#0MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTaskCycleTime</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#0MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTn</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#200MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.fKp</Name>
@@ -6819,7 +6819,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME</DateTime>
+          <DateTime>TIME#1s0ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -7113,7 +7113,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME</DateTime>
+          <DateTime>TIME#1S0MS</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -9120,7 +9120,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>128</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1h</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -11822,7 +11822,7 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -12021,6 +12021,9 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -12181,9 +12184,6 @@ External Setpoint Generation:
             </Property>
           </Properties>
         </Local>
-      </Method>
-      <Method>
-        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -12670,7 +12670,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12686,7 +12686,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#100ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12702,7 +12702,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10m</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13968,22 +13968,21 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14002,21 +14001,22 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14212,6 +14212,85 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -14270,85 +14349,6 @@ External Setpoint Generation:
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14552,13 +14552,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -14589,6 +14582,36 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Comment>
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14604,29 +14627,9 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-        <Comment>
-    Clears the contents of the entire buffer.
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -14647,20 +14650,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
+        <Name>ClearBuffer</Name>
         <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+    Clears the contents of the entire buffer.
 </Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
       </Method>
       <Properties>
         <Property>
@@ -15154,17 +15154,15 @@ External Setpoint Generation:
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsSkipped</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IsFailed</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
@@ -15206,12 +15204,14 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -15661,52 +15661,35 @@ External Setpoint Generation:
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15754,27 +15737,9 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
+        <Name>GetDetectionCountThisCycle</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15998,12 +15963,47 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -16143,7 +16143,37 @@ External Setpoint Generation:
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16151,7 +16181,9 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -16368,39 +16400,7 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16977,21 +16977,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_UINT</Name>
+        <Name>AssertEquals_STRING</Name>
         <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -17334,6 +17334,24 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_ULINT</Name>
         <Comment>
     Asserts that two ULINT arrays are equal. If they are not, an assertion error is created.
@@ -17428,6 +17446,21 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -17841,21 +17874,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_DINT</Name>
         <Comment>
     Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
@@ -17953,21 +17971,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_WSTRING</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> WSTRING expected value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> WSTRING actual value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18032,45 +18050,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
+        <Name>AssertEquals_WSTRING</Name>
         <Comment>
-    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> WSTRING expected value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> WSTRING actual value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18079,22 +18073,7 @@ External Setpoint Generation:
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -18102,127 +18081,6 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -18420,20 +18278,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertTrue</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that a condition is true. If it is not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -18442,16 +18294,6 @@ External Setpoint Generation:
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -18681,6 +18523,40 @@ External Setpoint Generation:
           <Name>Actual</Name>
           <Comment> DATE actual value</Comment>
           <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
@@ -18974,6 +18850,331 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UDINT</Name>
+        <Comment>
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -19071,211 +19272,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_STRING</Name>
-        <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -19309,14 +19305,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
+        <Name>AssertArrayEquals_LINT</Name>
         <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19330,8 +19326,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19555,21 +19551,6 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfSkippedTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>SkippedTestsCount</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -19849,22 +19830,19 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -20027,6 +20005,100 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UINT</Name>
+        <Comment>
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSkippedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>SkippedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -20124,58 +20196,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_LREAL</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20189,8 +20217,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20201,6 +20229,12 @@ External Setpoint Generation:
               <Value>1</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -20262,40 +20296,6 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -20648,33 +20648,6 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>WriteLog</Name>
         <Comment> Writes a new data set into the ring buffer </Comment>
         <Parameter>
@@ -20709,6 +20682,33 @@ External Setpoint Generation:
           <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -22961,14 +22961,6 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -23021,20 +23013,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23048,17 +23026,25 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>StartObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -23083,6 +23069,12 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -23102,36 +23094,36 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>StartObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -23158,6 +23150,20 @@ External Setpoint Generation:
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -23203,6 +23209,33 @@ External Setpoint Generation:
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -23254,153 +23287,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddBool</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddBase64</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddDcTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EndArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>EndObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>StartArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>CopyDocument</Name>
         <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
@@ -23433,6 +23319,120 @@ External Setpoint Generation:
               <Value>Output</Value>
             </Property>
           </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBase64</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EndArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>EndObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>StartArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -23750,11 +23750,22 @@ External Setpoint Generation:
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>Execute</Name>
-      </Action>
-      <Action>
         <Name>EvaluateOutput</Name>
       </Action>
+      <Action>
+        <Name>Execute</Name>
+      </Action>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
+      </Method>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -23813,51 +23824,6 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
-        <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IdxCheckIn</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>OK</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Reset</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stFF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
-        </Local>
-        <Local>
-          <Name>BeamPermitted</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Register</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23895,15 +23861,49 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>EvaluateVetos</Name>
+        <Name>IdxCheckIn</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>OK</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Reset</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stFF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
+        </Local>
+        <Local>
+          <Name>BeamPermitted</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
         <Properties>
           <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
+            <Name>no_check</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
+        <Parameter>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -24147,14 +24147,23 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <Method>
-        <Name>PopbackValue</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24241,15 +24250,19 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        <Name>PushbackFileTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -24293,6 +24306,33 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveMemberByName</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24316,6 +24356,16 @@ External Setpoint Generation:
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24350,23 +24400,34 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>PushbackUintValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ParseDocument</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -24406,17 +24467,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24432,7 +24482,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
+        <Name>PushbackBoolValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24442,8 +24492,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24508,6 +24558,16 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24544,60 +24604,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddJsonMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint</Name>
+        <Name>PushbackUint64Value</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24607,8 +24614,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24628,9 +24635,10 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveAllMembers</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24643,16 +24651,6 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -24663,17 +24661,12 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -24746,6 +24739,36 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>SetDcTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetArray</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24756,20 +24779,25 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -24829,9 +24857,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsBase64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24839,7 +24867,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
+        <Name>IsTrue</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -24938,7 +24966,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetArray</Name>
+        <Name>AddObjectMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24947,9 +24975,15 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -24969,6 +25003,21 @@ External Setpoint Generation:
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25016,38 +25065,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25084,34 +25101,8 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsHexBinary</Name>
+        <Name>Swap</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -25119,11 +25110,31 @@ External Setpoint Generation:
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsHexBinary</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25157,9 +25168,34 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -25222,9 +25258,10 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25232,17 +25269,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackFileTimeValue</Name>
+        <Name>AddJsonMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25251,9 +25278,26 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -25294,9 +25338,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25398,6 +25442,14 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25480,17 +25532,59 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
+        <Name>SetUint</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>dp</Name>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25544,42 +25638,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackBoolValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25606,23 +25664,13 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -25711,10 +25759,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25732,22 +25779,7 @@ External Setpoint Generation:
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
+          <Name>value</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -25779,28 +25811,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArrayValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25815,136 +25836,11 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackDoubleValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -25982,7 +25878,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
+        <Name>PushbackDoubleValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25992,8 +25888,112 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -30169,22 +30169,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30203,21 +30202,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30416,6 +30416,100 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -30474,100 +30568,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -30771,13 +30771,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -30808,6 +30801,36 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Comment>
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -30823,29 +30846,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-        <Comment>
-    Clears the contents of the entire buffer.
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -30866,20 +30869,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
+        <Name>ClearBuffer</Name>
         <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+    Clears the contents of the entire buffer.
 </Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
       </Method>
       <Properties>
         <Property>
@@ -31253,12 +31253,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -31270,6 +31264,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -31286,9 +31288,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -31328,17 +31330,15 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -31608,52 +31608,35 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31701,27 +31684,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
+        <Name>GetDetectionCountThisCycle</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31945,12 +31910,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -32096,7 +32096,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32104,7 +32134,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -32321,39 +32353,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32921,21 +32921,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -33672,688 +33672,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
-        <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -34663,6 +33981,533 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -35207,21 +35052,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -35713,24 +35543,56 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestName</Name>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -35801,21 +35663,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertArray2dEquals_REAL</Name>
         <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -35824,7 +35710,22 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -35832,6 +35733,124 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36105,37 +36124,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
           <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
+        </Parameter>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36482,7 +36482,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#10MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -36501,40 +36501,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10MS</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -36571,6 +36544,33 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -36788,44 +36788,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Init2</Name>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nTimestamp</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipMessage</Name>
-          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarm</Name>
-          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Release</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -36875,6 +36837,44 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>property</Name>
           </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Init2</Name>
+        <Parameter>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nTimestamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipMessage</Name>
+          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarm</Name>
+          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
@@ -37051,6 +37051,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>TcQueryInterface</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -37098,21 +37139,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>Execute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -37215,45 +37241,19 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
+        <Name>Execute</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38741,6 +38741,26 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>RequestRemote</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38846,45 +38866,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sEventText</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Request</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38914,6 +38895,25 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
           <BitSize>64</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventText</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38984,11 +38984,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> | generates a JSON string from a given symbol (via address/size).
+ | Method returns TRUE if succeeded.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -39002,16 +39002,28 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39024,16 +39036,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -39179,6 +39181,58 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39349,60 +39403,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> | generates a JSON string from a given symbol (via address/size).
- | Method returns TRUE if succeeded.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
-          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
@@ -39948,7 +39948,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>865952</BitOffs>
         <Default>
-          <Bool>udint</Bool>
+          <Bool>nt :=</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -39986,12 +39986,46 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -40121,40 +40155,6 @@ contributing fast faults, unless the FFO is currently vetoed.
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -40365,7 +40365,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40465,7 +40465,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40793,7 +40793,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#1h</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40805,7 +40805,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#1s</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40817,7 +40817,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#10s</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -50329,7 +50329,7 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1s</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -52114,6 +52114,9 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_Error</Name>
       </Action>
       <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
         <Name>M_Manual</Name>
       </Action>
       <Action>
@@ -52123,13 +52126,10 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Init</Name>
       </Action>
       <Properties>
         <Property>
@@ -52404,6 +52404,9 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_Error</Name>
       </Action>
       <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
         <Name>M_Manual</Name>
       </Action>
       <Action>
@@ -52413,13 +52416,10 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Init</Name>
       </Action>
       <Properties>
         <Property>
@@ -52573,19 +52573,19 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>704</BitOffs>
       </SubItem>
       <Action>
-        <Name>M_Active</Name>
+        <Name>M_Reset</Name>
       </Action>
       <Action>
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
+        <Name>M_Active</Name>
       </Action>
       <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Init</Name>
       </Action>
       <Properties>
         <Property>
@@ -52841,7 +52841,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#2S</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -52853,7 +52853,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#500MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -53159,7 +53159,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#100MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -53204,7 +53204,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#2S</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -55657,10 +55657,10 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>256448</BitOffs>
       </SubItem>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Properties>
         <Property>
@@ -55749,6 +55749,37 @@ Use this thing to have a simple indexer with rollover.
       </Method>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -55793,37 +55824,6 @@ Use this thing to have a simple indexer with rollover.
 	</Value>
           </Property>
         </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -56439,28 +56439,28 @@ Use this thing to have a simple indexer with rollover.
         </Default>
       </SubItem>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Properties>
         <Property>
@@ -56687,7 +56687,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>237128</BitOffs>
         <Default>
-          <Bool>true</Bool>
+          <Bool> : u</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -56721,30 +56721,42 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>409664</BitOffs>
       </SubItem>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqId</Name>
+          <Name>nReqID</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>86080</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
         </Local>
       </Method>
       <Method>
@@ -56875,42 +56887,6 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -56952,20 +56928,44 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqId</Name>
+          <Type>DWORD</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>86080</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
         </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -57116,7 +57116,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -57369,13 +57369,13 @@ ELSE:
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -58263,13 +58263,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
-      </Action>
-      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
+      </Action>
+      <Action>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -58290,7 +58290,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>AssertFinalBP</Name>
+        <Name>DeauthorizeTransition</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -58539,10 +58539,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -58893,7 +58893,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>257952</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -59932,7 +59932,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>144960</BitOffs>
         <Default>
-          <Bool>,</Bool>
+          <Bool>,
+  </Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -72249,7 +72250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72272,7 +72273,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72293,7 +72294,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72391,7 +72392,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72409,7 +72410,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72567,13 +72568,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265714560</BitOffs>
+            <BitOffs>1264933760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -72664,7 +72665,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72680,7 +72681,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934464</BitOffs>
+            <BitOffs>1265050560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -72696,7 +72697,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934528</BitOffs>
+            <BitOffs>1265050624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -72712,14 +72713,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934592</BitOffs>
+            <BitOffs>1265050688</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72733,6 +72734,95 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               </Property>
             </Properties>
             <BitOffs>3072272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
+            <Comment> TwinCAT System Service </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>200</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
+            <Comment> Hint icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
+            <Comment> Error icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
+            <Comment> Write message to log file </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
+            <Comment> Default ADS timeout value </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <DateTime>5000</DateTime>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3163488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -72792,14 +72882,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1264934656</BitOffs>
+            <BitOffs>1265050752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1264935304</BitOffs>
+            <BitOffs>1265051400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -72814,29 +72904,29 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1264935312</BitOffs>
+            <BitOffs>1265051408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1264935328</BitOffs>
+            <BitOffs>1265051424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264935360</BitOffs>
+            <BitOffs>1265051456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264935424</BitOffs>
+            <BitOffs>1265051520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -72845,19 +72935,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1264935488</BitOffs>
+            <BitOffs>1265051584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264935552</BitOffs>
+            <BitOffs>1265051648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264935616</BitOffs>
+            <BitOffs>1265051712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -72872,25 +72962,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1264935680</BitOffs>
+            <BitOffs>1265051776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1264935744</BitOffs>
+            <BitOffs>1265051840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264936000</BitOffs>
+            <BitOffs>1265052096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264936064</BitOffs>
+            <BitOffs>1265052160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -72899,79 +72989,79 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1264936128</BitOffs>
+            <BitOffs>1265052224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264936192</BitOffs>
+            <BitOffs>1265052288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264936256</BitOffs>
+            <BitOffs>1265052352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1264936320</BitOffs>
+            <BitOffs>1265052416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264937344</BitOffs>
+            <BitOffs>1265053440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264937408</BitOffs>
+            <BitOffs>1265053504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264937472</BitOffs>
+            <BitOffs>1265053568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264937536</BitOffs>
+            <BitOffs>1265053632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1264937600</BitOffs>
+            <BitOffs>1265053696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265048192</BitOffs>
+            <BitOffs>1265164288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265323392</BitOffs>
+            <BitOffs>1265439488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265433984</BitOffs>
+            <BitOffs>1265550080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265709184</BitOffs>
+            <BitOffs>1265825280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -72983,7 +73073,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265709696</BitOffs>
+            <BitOffs>1265825792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -72995,14 +73085,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265710272</BitOffs>
+            <BitOffs>1265826368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265711104</BitOffs>
+            <BitOffs>1265827200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -73018,7 +73108,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711424</BitOffs>
+            <BitOffs>1265827520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -73033,7 +73123,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711456</BitOffs>
+            <BitOffs>1265827552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -73107,7 +73197,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -80012,7 +80102,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -81754,7 +81844,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -81905,7 +81995,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#1ms</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -81920,7 +82010,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#100ms</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -81935,7 +82025,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#10s</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -81950,7 +82040,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#10m</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82408,21 +82498,6 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>3160400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
-            <Comment> TwinCAT System Service </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3160416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -83432,20 +83507,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>3162240</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>200</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162272</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
@@ -83573,21 +83634,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>3162560</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
-            <Comment> Hint icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162592</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
             <Comment> Warning icon </Comment>
             <BitSize>32</BitSize>
@@ -83601,36 +83647,6 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>3162624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
-            <Comment> Error icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
-            <Comment> Write message to log file </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
@@ -84027,21 +84043,6 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>3163472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
-            <Comment> Default ADS timeout value </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <DateTime>5000</DateTime>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3163488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -88627,7 +88628,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#0MS</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -88963,41 +88964,10 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264816704</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265711360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265711376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265711392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>1265711408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>1265711416</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265827200</BitOffs>
+            <BitOffs>1265046400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -89007,10 +88977,41 @@ Emergency Stop for MR1K1</Comment>
             <Default>
               <SubItem>
                 <Name>.PT</Name>
-                <DateTime>T</DateTime>
+                <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265827328</BitOffs>
+            <BitOffs>1265046528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265827456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265827472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265827488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>1265827504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>1265827512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -89072,8 +89073,7 @@ Emergency Stop for MR1K1</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
+                <Value>
                               .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
                               .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
                               .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
@@ -93426,9 +93426,9 @@ M4K2 KBV X ENC CNT</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Yup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
+							  .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+							  .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -93476,7 +93476,7 @@ M4K2 KBV X ENC CNT</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
+						.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -95305,7 +95305,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164429824</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95385,7 +95385,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-28T16:53:16</Value>
+          <Value>2024-03-27T14:34:04</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{E3C294DB-8219-B920-2780-EBADF1F16FAF}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{260DC897-92CC-1B18-6E76-E3ED3545641D}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -5134,6 +5134,12 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_System">T_MaxString</Name>
+      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
+      <BitSize>2048</BitSize>
+      <BaseType>STRING(255)</BaseType>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
       <BitSize>384</BitSize>
       <SubItem>
@@ -5343,15 +5349,15 @@ External Setpoint Generation:
         <Default>
           <SubItem>
             <Name>.tCtrlCycleTime</Name>
-            <DateTime>T#0MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTaskCycleTime</Name>
-            <DateTime>T#0MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTn</Name>
-            <DateTime>T#200MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
           <SubItem>
             <Name>.fKp</Name>
@@ -5391,66 +5397,6 @@ External Setpoint Generation:
           <Value>-10</Value>
         </Default>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">HOMS_PitchMechanism</Name>
-      <BitSize>2496</BitSize>
-      <SubItem>
-        <Name>Piezo</Name>
-        <Type Namespace="lcls_twincat_optics">ST_PiezoAxis</Type>
-        <Comment>Piezo</Comment>
-        <BitSize>2240</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ReqPosLimHi</Name>
-        <Type>REAL</Type>
-        <Comment> Soft limits, egu urad </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2240</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ReqPosLimLo</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diEncPosLimHi</Name>
-        <Type>LINT</Type>
-        <Comment> Hard limits, egu INC 
- These are discovered during installation, and represent encoder ticks, unbiased 
- We changed to these when our pitch mechanism limit switches were insufficient for
-    good control. They had too much hysteresis/ lack of precision. At this point the limit
-    switches are ignored, and instead their function is carried out by these. </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2304</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diEncPosLimLo</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>2368</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>diEncCnt</Name>
-        <Type>LINT</Type>
-        <Comment>Raw encoder count</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>2432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">T_MaxString</Name>
-      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
-      <BitSize>2048</BitSize>
-      <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ClearComBuffer</Name>
@@ -6873,7 +6819,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME#1s0ms</DateTime>
+          <DateTime>TIME</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -7167,7 +7113,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME#1S0MS</DateTime>
+          <DateTime>TIME</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -7351,6 +7297,60 @@ External Setpoint Generation:
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">HOMS_PitchMechanism</Name>
+      <BitSize>2496</BitSize>
+      <SubItem>
+        <Name>Piezo</Name>
+        <Type Namespace="lcls_twincat_optics">ST_PiezoAxis</Type>
+        <Comment>Piezo</Comment>
+        <BitSize>2240</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ReqPosLimHi</Name>
+        <Type>REAL</Type>
+        <Comment> Soft limits, egu urad </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ReqPosLimLo</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diEncPosLimHi</Name>
+        <Type>LINT</Type>
+        <Comment> Hard limits, egu INC 
+ These are discovered during installation, and represent encoder ticks, unbiased 
+ We changed to these when our pitch mechanism limit switches were insufficient for
+    good control. They had too much hysteresis/ lack of precision. At this point the limit
+    switches are ignored, and instead their function is carried out by these. </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diEncPosLimLo</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>2368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>diEncCnt</Name>
+        <Type>LINT</Type>
+        <Comment>Raw encoder count</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>2432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
     </DataType>
     <DataType>
       <Name GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}" Namespace="PLC" TcBaseType="true">PlcTaskSystemInfo</Name>
@@ -9120,7 +9120,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>128</BitOffs>
         <Default>
-          <DateTime>T#1h</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -10194,31 +10194,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163192136</GetCodeOffs>
+        <GetCodeOffs>163192152</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163192208</GetCodeOffs>
+        <GetCodeOffs>163192224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192224</GetCodeOffs>
+        <GetCodeOffs>163192240</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192184</GetCodeOffs>
+        <GetCodeOffs>163192200</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192216</GetCodeOffs>
+        <GetCodeOffs>163192232</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11470,15 +11470,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192008</GetCodeOffs>
-        <SetCodeOffs>163192056</SetCodeOffs>
+        <GetCodeOffs>163192024</GetCodeOffs>
+        <SetCodeOffs>163192072</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192088</GetCodeOffs>
-        <SetCodeOffs>163192112</SetCodeOffs>
+        <GetCodeOffs>163192104</GetCodeOffs>
+        <SetCodeOffs>163192128</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11719,31 +11719,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>163192320</GetCodeOffs>
+        <GetCodeOffs>163192336</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163192280</GetCodeOffs>
+        <GetCodeOffs>163192296</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192456</GetCodeOffs>
+        <GetCodeOffs>163192472</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192464</GetCodeOffs>
+        <GetCodeOffs>163192480</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192376</GetCodeOffs>
+        <GetCodeOffs>163192392</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11755,7 +11755,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192472</GetCodeOffs>
+        <GetCodeOffs>163192488</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11822,7 +11822,7 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -12021,9 +12021,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -12184,6 +12181,9 @@ External Setpoint Generation:
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -12348,7 +12348,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163192528</GetCodeOffs>
+        <GetCodeOffs>163192544</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -12670,7 +12670,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T#1ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12686,7 +12686,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T#100ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12702,7 +12702,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T#10m</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13968,21 +13968,22 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14001,22 +14002,21 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14212,85 +14212,6 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -14349,6 +14270,85 @@ External Setpoint Generation:
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14552,6 +14552,13 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -14582,36 +14589,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14627,9 +14604,29 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -14650,17 +14647,20 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -15154,15 +15154,17 @@ External Setpoint Generation:
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>IsSkipped</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsSkipped</Name>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsFailed</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
@@ -15204,14 +15206,12 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -15661,35 +15661,52 @@ External Setpoint Generation:
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15737,9 +15754,27 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15963,47 +15998,12 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -16143,37 +16143,7 @@ External Setpoint Generation:
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16181,9 +16151,7 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -16400,7 +16368,39 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16977,21 +16977,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -17334,24 +17334,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_ULINT</Name>
         <Comment>
     Asserts that two ULINT arrays are equal. If they are not, an assertion error is created.
@@ -17446,21 +17428,6 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -17874,6 +17841,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_DINT</Name>
         <Comment>
     Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
@@ -17971,21 +17953,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertEquals_WSTRING</Name>
         <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Comment> WSTRING expected value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Comment> WSTRING actual value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18050,21 +18032,45 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_WSTRING</Name>
+        <Name>AssertArray3dEquals_REAL</Name>
         <Comment>
-    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> WSTRING expected value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> WSTRING actual value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18073,7 +18079,22 @@ External Setpoint Generation:
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -18081,6 +18102,127 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -18278,14 +18420,20 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -18294,6 +18442,16 @@ External Setpoint Generation:
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -18523,40 +18681,6 @@ External Setpoint Generation:
           <Name>Actual</Name>
           <Comment> DATE actual value</Comment>
           <Type>DATE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
@@ -18850,331 +18974,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Comment>
-    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -19272,6 +19071,211 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -19305,14 +19309,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19326,8 +19330,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19551,6 +19555,21 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSkippedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>SkippedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -19830,19 +19849,22 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -20005,100 +20027,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetNumberOfSkippedTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>SkippedTestsCount</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -20196,14 +20124,58 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
         <Comment>
-    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20217,8 +20189,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20229,12 +20201,6 @@ External Setpoint Generation:
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -20296,6 +20262,40 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -20648,6 +20648,33 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>WriteLog</Name>
         <Comment> Writes a new data set into the ring buffer </Comment>
         <Parameter>
@@ -20682,33 +20709,6 @@ External Setpoint Generation:
           <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -22961,6 +22961,14 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -23013,6 +23021,20 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23026,25 +23048,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -23069,12 +23083,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -23094,36 +23102,36 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
         <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
         </Parameter>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -23150,20 +23158,6 @@ External Setpoint Generation:
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -23209,33 +23203,6 @@ External Setpoint Generation:
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -23287,6 +23254,153 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddBase64</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EndArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>EndObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>StartArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>CopyDocument</Name>
         <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
@@ -23319,120 +23433,6 @@ External Setpoint Generation:
               <Value>Output</Value>
             </Property>
           </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddFileTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddBool</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddBase64</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddDcTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddKeyNull</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EndArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>EndObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>StartArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -23750,22 +23750,11 @@ External Setpoint Generation:
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -23824,41 +23813,14 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -23896,14 +23858,52 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -24147,23 +24147,14 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24250,19 +24241,15 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -24306,33 +24293,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24356,16 +24316,6 @@ External Setpoint Generation:
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24400,34 +24350,23 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -24467,6 +24406,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24482,7 +24432,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24492,8 +24442,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24558,16 +24508,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24604,7 +24544,60 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24614,8 +24607,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24635,10 +24628,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24651,6 +24643,16 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -24661,12 +24663,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -24739,36 +24746,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24779,25 +24756,20 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -24857,9 +24829,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24867,7 +24839,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -24966,7 +24938,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24975,15 +24947,9 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -25003,21 +24969,6 @@ External Setpoint Generation:
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25065,6 +25016,38 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25101,40 +25084,46 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25168,34 +25157,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -25258,10 +25222,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25269,7 +25232,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25278,26 +25251,9 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -25338,9 +25294,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25442,14 +25398,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25532,59 +25480,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25638,6 +25544,42 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25664,13 +25606,23 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -25759,9 +25711,10 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25779,7 +25732,22 @@ External Setpoint Generation:
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -25811,17 +25779,28 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25836,11 +25815,136 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -25878,7 +25982,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25888,112 +25992,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -30169,21 +30169,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30202,22 +30203,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30416,100 +30416,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -30568,6 +30474,100 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -30771,6 +30771,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -30801,36 +30808,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -30846,9 +30823,29 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -30869,17 +30866,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -31253,6 +31253,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -31264,14 +31270,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -31288,9 +31286,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -31330,15 +31328,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -31608,35 +31608,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31684,9 +31701,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31910,47 +31945,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -32096,37 +32096,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32134,9 +32104,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -32353,7 +32321,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32921,21 +32921,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -33672,6 +33672,688 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -33981,533 +34663,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -35052,6 +35207,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -35543,56 +35713,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -35663,45 +35801,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -35710,22 +35824,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -35733,124 +35832,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36124,18 +36105,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36482,7 +36482,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -36501,13 +36501,40 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T#10MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -36544,33 +36571,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -36760,7 +36760,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163204160</GetCodeOffs>
+        <GetCodeOffs>163204176</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -36784,6 +36784,44 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>TcDisplayTypeGUID</Name>
             <Value>18071995-0000-0000-0000-000000000046</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Init2</Name>
+        <Parameter>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nTimestamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipMessage</Name>
+          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarm</Name>
+          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </Method>
@@ -36837,44 +36875,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>Init2</Name>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nTimestamp</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipMessage</Name>
-          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarm</Name>
-          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
@@ -37051,47 +37051,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -37139,6 +37098,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -37241,19 +37215,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38688,31 +38688,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163203560</GetCodeOffs>
+        <GetCodeOffs>163203576</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163203648</GetCodeOffs>
+        <GetCodeOffs>163203664</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163203576</GetCodeOffs>
+        <GetCodeOffs>163203592</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163203624</GetCodeOffs>
+        <GetCodeOffs>163203640</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163203664</GetCodeOffs>
+        <GetCodeOffs>163203680</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -38732,26 +38732,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Local>
           <Name>b32IsBusy</Name>
           <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
         </Local>
         <Properties>
@@ -38866,6 +38846,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventText</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>Request</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38895,25 +38914,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
           <BitSize>64</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sEventText</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38984,11 +38984,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> | generates a JSON string from a given symbol (via address/size).
- | Method returns TRUE if succeeded.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -39002,28 +39002,16 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39036,6 +39024,16 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Parameter>
+        <Local>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -39181,58 +39179,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39403,6 +39349,60 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> | generates a JSON string from a given symbol (via address/size).
+ | Method returns TRUE if succeeded.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
@@ -39948,7 +39948,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>865952</BitOffs>
         <Default>
-          <Bool>nt :=</Bool>
+          <Bool>udint</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -39986,46 +39986,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -40155,6 +40121,40 @@ contributing fast faults, unless the FFO is currently vetoed.
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -40365,7 +40365,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40465,7 +40465,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40793,7 +40793,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1h</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40805,7 +40805,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40817,7 +40817,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40847,34 +40847,276 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_MC2">_E_TcMC_STATES</Name>
+      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
+      <BitSize>0</BitSize>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Name>
+      <Comment> Renishaw BiSS-C absolute encoder used with an EL5042</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>Count</Name>
+        <Type>ULINT</Type>
+        <Comment> Connect to encoder "Position" input</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Status</Name>
+        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
+        <Comment> Status struct placeholder</Comment>
+        <BitSize>0</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Ref</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder zero position (useful for aligned position with gantries)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Name>
+      <BitSize>512</BitSize>
+      <SubItem>
+        <Name>PEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Primary axis encoder (usually the upstream one)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Secondary axis encoder (couples to the primary)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GantDiffTol</Name>
+        <Type>LINT</Type>
+        <Comment> Gantry differenace tolerance in encoder counts</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PLimFwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Primary axis forward direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PLimBwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Primary axis reverse direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SLimFwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Secondary axis forward direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SLimBwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Secondary axis reverse direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GantryDiff</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_BufferMode</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>MC_Aborting</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_Buffered</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingLow</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingPrevious</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingNext</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MC_BlendingHigh</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
-        <Text>STATE_INITIALIZATION</Text>
-        <Enum>100</Enum>
+        <Text>TCNC_SLAVETYPE_LINEAR</Text>
+        <Enum>1</Enum>
+        <Comment> Lineare Kopplung (Geradengleichung) </Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>STATE_ORDER</Text>
-        <Enum>101</Enum>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONVELOCITY</Text>
+        <Enum>2</Enum>
+        <Comment> diagonal synchron. Aufkoppeln schnellstens auf Geschwindigkeit </Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>STATE_RUNNING</Text>
-        <Enum>102</Enum>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONPOSITION</Text>
+        <Enum>3</Enum>
+        <Comment> diagonal synchron. Aufkoppeln auf Position und Geschwindigkeit </Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>STATE_WAITING</Text>
-        <Enum>103</Enum>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_QUADRATIC</Text>
+        <Enum>4</Enum>
+        <Comment> diagonal synchron. Aufkoppeln (quadratisches Geschw.-Profil) </Comment>
       </EnumInfo>
       <EnumInfo>
-        <Text>STATE_MOTIONCOMMANDSLOCKED</Text>
-        <Enum>104</Enum>
+        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONVELO</Text>
+        <Enum>5</Enum>
+        <Comment> synchron. Aufkoppeln instantan auf Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONPOS</Text>
+        <Enum>6</Enum>
+        <Comment> synchron. Aufkoppeln auf Positionen und Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCJERKSETTER_ONVELO</Text>
+        <Enum>7</Enum>
+        <Comment> synchron. Aufkoppeln auf Geschwindigkeit (zeitbasiert mittels Ruck-Steller) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_TABULAR</Text>
+        <Enum>10</Enum>
+        <Comment> Tabellen-Kopplung ("simple/standard tabular slave") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_MULTITABULAR</Text>
+        <Enum>11</Enum>
+        <Comment> Tabellen-Kopplung ("multiscalable multi-tabular slave") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGMODULO_LINEAR</Text>
+        <Enum>12</Enum>
+        <Comment> Modulo Kopplung auf Position und/oder Geschwindigkeit mit anschliessender Linear Kopplung ("Schuette") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_MOTIONFUNCTIONTABULAR</Text>
+        <Enum>13</Enum>
+        <Comment> Tabellen-Kopplung "motion functions" </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_UNIVERSALTABULAR</Text>
+        <Enum>14</Enum>
+        <Comment> Tabellen-Kopplung, universal tabular type substitues TABULAR, MULTITABULAR and MOTIONFUNCTION - 08.07.05 </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR_CYCLICCHANGES_RAMP</Text>
+        <Enum>15</Enum>
+        <Comment> Lineare Kopplung (Geradengleichung) mit zyklischer Koppelfaktoraenderung </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_BILINEAR</Text>
+        <Enum>16</Enum>
+        <Comment> 27.04.01: Zweifach Lineare Kopplung (Geradengleichung)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR_MULTIMASTER</Text>
+        <Enum>17</Enum>
+        <Comment> 29.05.08: Lineare Multi-Master-Kopplung ('MC_GearInMultiMaster') </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_CONST_SURFACEVELO_RAMP</Text>
+        <Enum>18</Enum>
+        <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
       </EnumInfo>
       <Properties>
         <Property>
           <Name>conditionalshow</Name>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
+      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>SlaveType</Name>
+        <Type Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_ST_FunctionBlockResults</Name>
@@ -40925,6 +41167,2305 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Properties>
         <Property>
           <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_E_TcMC_STATES</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>STATE_INITIALIZATION</Text>
+        <Enum>100</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>STATE_ORDER</Text>
+        <Enum>101</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>STATE_RUNNING</Text>
+        <Enum>102</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>STATE_WAITING</Text>
+        <Enum>103</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>STATE_MOTIONCOMMANDSLOCKED</Text>
+        <Enum>104</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Name>
+      <BitSize>384</BitSize>
+      <SubItem>
+        <Name>nSlaveType</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nMasterAxisId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nMasterSubIdx</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nSlaveSubIdx</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam2</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam3</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCoupleParam4</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearInDynOptions</Name>
+      <BitSize>8</BitSize>
+      <SubItem>
+        <Name>CCVmode</Name>
+        <Type>BOOL</Type>
+        <Comment> constant circumference velocity mode </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearInDyn</Name>
+      <BitSize>4416</BitSize>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Enable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GearRatio</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Acceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deceleration</Name>
+        <Type>LREAL</Type>
+        <Comment> not used </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Jerk</Name>
+        <Type>LREAL</Type>
+        <Comment> not used </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BufferMode</Name>
+        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearInDynOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Active</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>552</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CommandAborted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>720</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>iSubState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRead</Name>
+        <Type Namespace="Tc2_System">ADSREAD</Type>
+        <BitSize>1408</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCouple</Name>
+        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>3520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>v_max</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3904</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>pa_limit</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WasInGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iAcceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>4096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>4160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearIn</Name>
+      <BitSize>7360</BitSize>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Execute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RatioNumerator</Name>
+        <Type>LREAL</Type>
+        <Comment> changed from INT (PLCopen) to LREAL </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RatioDenominator</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Acceleration</Name>
+        <Type>LREAL</Type>
+        <Comment>	MasterValueSource :	MC_SOURCE; 
+ not available </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Jerk</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BufferMode</Name>
+        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearInOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>616</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Active</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CommandAborted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>632</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>816</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCouple</Name>
+        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>2176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOptGearInDyn</Name>
+        <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
+        <BitSize>4416</BitSize>
+        <BitOffs>2560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOnTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>7104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ActGearInDyn</Name>
+      </Action>
+      <Action>
+        <Name>WriteGearRatio</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearOutOptions</Name>
+      <BitSize>8</BitSize>
+      <SubItem>
+        <Name>reserved</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearOut</Name>
+      <BitSize>2112</BitSize>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Execute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearOutOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Done</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>336</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1344</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOnTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_SetEnables</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Name>
+      <BitSize>10752</BitSize>
+      <SubItem>
+        <Name>nGantryTol</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MasterEnc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SlaveEnc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCouple</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecouple</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>gantry_diff_limit</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>couple</Name>
+        <Type Namespace="Tc2_MC2">MC_GearIn</Type>
+        <BitSize>7360</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>decouple</Name>
+        <Type Namespace="Tc2_MC2">MC_GearOut</Type>
+        <BitSize>2112</BitSize>
+        <BitOffs>8448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInitComplete</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>10560</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbSetEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>10624</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_RunHOMS</Name>
+      <BitSize>23296</BitSize>
+      <SubItem>
+        <Name>nYupEncRef</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder Reference Values</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nYdwnEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nXupEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nXdwnEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTolY</Name>
+        <Type>LINT</Type>
+        <Comment> Encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>50000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTolX</Name>
+        <Type>LINT</Type>
+        <Comment> Encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>50000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledY</Name>
+        <Type>BOOL</Type>
+        <Comment> Gantry coupling status</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryY</Name>
+        <Type>LINT</Type>
+        <Comment> Current gantry difference</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryX</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYup</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor Structs</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYdwn</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXup</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXdwn</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPitch</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleY</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <Comment> Manual coupling Gantried Axes</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleX</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleY</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleX</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable1</Name>
+        <Type>BOOL</Type>
+        <Comment> STO Button</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable2</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYupEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Encoders</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>1280</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYdwnEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXupEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1536</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXdwnEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1664</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAutoCoupleY</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
+        <Comment> Autocoupling Gantried Axes</Comment>
+        <BitSize>10752</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAutoCoupleX</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
+        <BitSize>10752</BitSize>
+        <BitOffs>12544</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">DUT_HOMS</Name>
+      <BitSize>23552</BitSize>
+      <SubItem>
+        <Name>fbRunHOMS</Name>
+        <Type Namespace="lcls_twincat_optics">FB_RunHOMS</Type>
+        <Comment> System initializiation</Comment>
+        <BitSize>23296</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleY</Name>
+        <Type>BOOL</Type>
+        <Comment> Couple/Decouple motors</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>23296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: COUPLE_Y
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DECOUPLE_Y
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: COUPLE_X
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DECOUPLE_X
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledY</Name>
+        <Type>BOOL</Type>
+        <Comment> Coupling status</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>23328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ALREADY_COUPLED_Y
+        io: i
+        field: ZSV MAJOR
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ALREADY_COUPLED_X
+        io: i
+        field: ZSV MAJOR
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryY</Name>
+        <Type>LINT</Type>
+        <Comment> encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>23360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryX</Name>
+        <Type>LINT</Type>
+        <Comment> encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>23424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrGantryY_um</Name>
+        <Type>REAL</Type>
+        <Comment> Y Gantry difference in um</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>23488</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GANTRY_Y
+        field: EGU um
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrGantryX_um</Name>
+        <Type>REAL</Type>
+        <Comment> X Gantry difference in um</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>23520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GANTRY_X
+        field: EGU um
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
+      <BitSize>128704</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we'll accumulate a value on this cycle.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fInput</Name>
+        <Type>LREAL</Type>
+        <Comment> The value to accumulate.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrOutput</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bNewArray</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrPartial</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>64256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataBuffer</Name>
+        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>128256</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
+      <BitSize>387520</BitSize>
+      <SubItem>
+        <Name>fMaxRMSError</Name>
+        <Type>LREAL</Type>
+        <Comment> RMS Error</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMinRMSError</Name>
+        <Type>LREAL</Type>
+        <Comment> start at something huge, FB will update with any smaller measured value</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScalingNum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScalingDenom</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncOffset</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScale</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataEncPos</Name>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
+        <Comment> ActPos Data Acquisition FB</Comment>
+        <BitSize>128704</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataSetPos</Name>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
+        <Comment> SetPos Data Acquisition FB</Comment>
+        <BitSize>128704</BitSize>
+        <BitOffs>129216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDataStorage</Name>
+        <Type>BOOL</Type>
+        <Comment> Take data of both ActPos and SetPos</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>257920</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bNewEncArray</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>257928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStats</Name>
+        <Type Namespace="LCLS_General">FB_BasicStats</Type>
+        <Comment> Calculate mean/standard deviation of ActPos</Comment>
+        <BitSize>1152</BitSize>
+        <BitOffs>257984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncMean</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MEAN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEncStDev</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STDEV
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrRMSError</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259264</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RMS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>259328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSum</Name>
+        <Type>LREAL</Type>
+        <Comment> Just for calculating rms</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>259392</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fDiff</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>259456</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>aEncActPos</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>259520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ACTPOSARRAY
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>aEncSetPos</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>323520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: SETPOSARRAY
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_Index</Name>
+      <Comment> Index FB
+A. Wallace 2016-9-3
+
+Why doesn't beckhoff have this as a builtin type?
+
+Use this thing to have a simple indexer with rollover.
+
+</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>LowerLimit</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer will rollver over to this value (and initialize to this value)</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>naming</Name>
+            <Value>off</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ValInc</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer increments by this value</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>UpperLimit</Name>
+        <Type>INT</Type>
+        <Comment>Incrementer will rollover at this value to lower limit</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nVal</Name>
+        <Type>INT</Type>
+        <Comment>Internal incrementer value, initialized to LowerLimit</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>112</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>off</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>Dec</Name>
+      </Action>
+      <Action>
+        <Name>Inc</Name>
+      </Action>
+      <Method>
+        <Name>DecVal</Name>
+        <Comment>Decrement the counter and return new value</Comment>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IncVal</Name>
+        <Comment>Increment the counter and return new value</Comment>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">ST_FbDiagnostics</Name>
+      <Comment>Stuff to log messages within function blocks</Comment>
+      <BitSize>49664</BitSize>
+      <SubItem>
+        <Name>asResults</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>20</Elements>
+        </ArrayInfo>
+        <Comment>Diagnostic messages, use to record state changes or other important events.</Comment>
+        <BitSize>40960</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>resultIdx</Name>
+        <Type Namespace="LCLS_General">FB_Index</Type>
+        <Comment>Incrementer, included here to facilitate using asResults</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>40960</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.LowerLimit</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.UpperLimit</Name>
+            <Value>20</Value>
+          </SubItem>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>omit</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fString</Name>
+        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+        <Comment>Use to create good log messages, similar to C++ fstring</Comment>
+        <BitSize>8576</BitSize>
+        <BitOffs>41088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>naming</Name>
+            <Value>omit</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">E_MotionRequest</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>WAIT</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>INTERRUPT</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ABORT</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionRequest</Name>
+      <BitSize>1920</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start move on rising edge, stop move on falling edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset errors on rising edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when the motor is already moving</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Goal position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVel</Name>
+        <Type>LREAL</Type>
+        <Comment> Move velocity</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAcc</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional acceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDec</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional deceleration</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> True if in error state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> What the error code means</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are moving the motor</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are not moving the motor and our most recent move was successful</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bMyMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1744</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCausedError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>INIT</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1760</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_EXEC</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1776</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>PICK_REQUEST</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_OTHER_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>STOP_OTHER_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1824</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>START_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1840</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_MY_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Default>
+          <Value>6</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>STOP_MY_MOVE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1872</BitOffs>
+        <Default>
+          <Value>7</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>DONE_MOVING</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1888</BitOffs>
+        <Default>
+          <Value>8</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ERROR</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1904</BitOffs>
+        <Default>
+          <Value>9</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -41051,35 +43592,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Value>FunctionBlock</Value>
         </Property>
       </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_BufferMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>MC_Aborting</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_Buffered</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingLow</Text>
-        <Enum>18</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingPrevious</Text>
-        <Enum>19</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingNext</Text>
-        <Enum>20</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MC_BlendingHigh</Text>
-        <Enum>21</Enum>
-      </EnumInfo>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_PowerOptions</Name>
@@ -46952,525 +49464,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearInDynOptions</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>CCVmode</Name>
-        <Type>BOOL</Type>
-        <Comment> constant circumference velocity mode </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Name>
-      <BitSize>384</BitSize>
-      <SubItem>
-        <Name>nSlaveType</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nMasterAxisId</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nMasterSubIdx</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nSlaveSubIdx</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam2</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam3</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCoupleParam4</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearInDyn</Name>
-      <BitSize>4416</BitSize>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GearRatio</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Acceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Deceleration</Name>
-        <Type>LREAL</Type>
-        <Comment> not used </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Jerk</Name>
-        <Type>LREAL</Type>
-        <Comment> not used </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>BufferMode</Name>
-        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearInDynOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>InGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>536</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>544</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Active</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>552</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CommandAborted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>568</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>720</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>iSubState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1344</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsRead</Name>
-        <Type Namespace="Tc2_System">ADSREAD</Type>
-        <BitSize>1408</BitSize>
-        <BitOffs>2112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sCouple</Name>
-        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>3520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>v_max</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>3904</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pa_limit</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>3968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>WasInGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>4032</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iAcceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>4096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>4160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearOutOptions</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>reserved</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearOut</Name>
-      <BitSize>2112</BitSize>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Execute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearOutOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Done</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>336</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1344</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOnTrigger</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_DriveVirtual</Name>
       <BitSize>181056</BitSize>
       <SubItem>
@@ -48336,7 +50329,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -48454,28 +50447,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Type>
         <BitSize>384</BitSize>
         <BitOffs>87104</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_SetEnables</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
       </SubItem>
       <Properties>
         <Property>
@@ -48885,6 +50856,2389 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>128</BitSize>
         <BitOffs>327296</BitOffs>
       </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ENUM_MotionRequest</Name>
+      <BitSize>16</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">E_MotionRequest</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use E_MotionRequest</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">E_PiezoControl</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>EPC_Idle</Text>
+        <Enum>0</Enum>
+        <Comment>Piezo Control Machine</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_Init</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MoveRequested</Text>
+        <Enum>50</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MovingPositive</Text>
+        <Enum>100</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MovingNegative</Text>
+        <Enum>200</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_MoveCompleted</Text>
+        <Enum>350</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EPC_Error</Text>
+        <Enum>500</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eCTRL_MODE_IDLE</Text>
+        <Enum>0</Enum>
+        <Comment> mode idle					</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_PASSIVE</Text>
+        <Enum>1</Enum>
+        <Comment> mode passive				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_ACTIVE</Text>
+        <Enum>2</Enum>
+        <Comment> mode active					</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_RESET</Text>
+        <Enum>3</Enum>
+        <Comment> mode reset					</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_MANUAL</Text>
+        <Enum>4</Enum>
+        <Comment> mode manual				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_TUNE</Text>
+        <Enum>5</Enum>
+        <Comment> mode tuning				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_SELFTEST</Text>
+        <Enum>6</Enum>
+        <Comment> mode selftest				</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_SYNC_MOVEMENT</Text>
+        <Enum>7</Enum>
+        <Comment> mode synchronize			</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_MODE_FREEZE</Text>
+        <Enum>8</Enum>
+        <Comment> mode freeze				</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eCTRL_STATE_IDLE</Text>
+        <Enum>0</Enum>
+        <Comment> state idle		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_PASSIVE</Text>
+        <Enum>1</Enum>
+        <Comment> state passive	</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_ACTIVE</Text>
+        <Enum>2</Enum>
+        <Comment> state active		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_RESET</Text>
+        <Enum>3</Enum>
+        <Comment> state reset		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_MANUAL</Text>
+        <Enum>4</Enum>
+        <Comment> state manual	</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_TUNING</Text>
+        <Enum>5</Enum>
+        <Comment> state tuning		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_TUNED</Text>
+        <Enum>6</Enum>
+        <Comment> state tuning ready - tuned		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_SELFTEST</Text>
+        <Enum>7</Enum>
+        <Comment> state selftest		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_ERROR</Text>
+        <Enum>8</Enum>
+        <Comment> state error		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_SYNC_MOVEMENT</Text>
+        <Enum>9</Enum>
+        <Comment> state synchronizing movement		</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_STATE_FREEZE</Text>
+        <Enum>10</Enum>
+        <Comment> state freeze 	</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_NOERROR</Text>
+        <Enum>0</Enum>
+        <Comment> no error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDTASKCYCLETIME</Text>
+        <Enum>1</Enum>
+        <Comment> invalid task cycle time </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDCTRLCYCLETIME</Text>
+        <Enum>2</Enum>
+        <Comment> invalid ctrl cycle time </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM</Text>
+        <Enum>3</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tv</Text>
+        <Enum>4</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Td</Text>
+        <Enum>5</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tn</Text>
+        <Enum>6</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Ti</Text>
+        <Enum>7</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fHystereisisRange</Text>
+        <Enum>8</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fPosOutOn_Off</Text>
+        <Enum>9</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fNegOutOn_Off</Text>
+        <Enum>10</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_TableDescription</Text>
+        <Enum>11</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_TableData</Text>
+        <Enum>12</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableADR</Text>
+        <Enum>13</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T0</Text>
+        <Enum>14</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T1</Text>
+        <Enum>15</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T2</Text>
+        <Enum>16</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_T3</Text>
+        <Enum>17</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Theta</Text>
+        <Enum>18</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nOrder</Text>
+        <Enum>19</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tt</Text>
+        <Enum>20</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tu</Text>
+        <Enum>21</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tg</Text>
+        <Enum>22</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_infinite_slope</Text>
+        <Enum>23</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxIsLessThanfMin</Text>
+        <Enum>24</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOutMaxLimitIsLessThanfOutMinLimit</Text>
+        <Enum>25</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindow</Text>
+        <Enum>26</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fInnerWindow</Text>
+        <Enum>27</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindowIsLessThanfInnerWindow</Text>
+        <Enum>28</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandInput</Text>
+        <Enum>29</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandOutput</Text>
+        <Enum>30</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_PWM_Cycletime</Text>
+        <Enum>31</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_no_Parameterset</Text>
+        <Enum>32</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOn</Text>
+        <Enum>33</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOff</Text>
+        <Enum>34</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fGain</Text>
+        <Enum>35</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOffset</Text>
+        <Enum>36</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_MODE_NOT_SUPPORTED</Text>
+        <Enum>37</Enum>
+        <Comment> invalid mode: mode not supported </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_heating</Text>
+        <Enum>38</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Td_heating</Text>
+        <Enum>39</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_heating</Text>
+        <Enum>40</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_cooling</Text>
+        <Enum>41</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Td_cooling</Text>
+        <Enum>42</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_cooling</Text>
+        <Enum>43</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_RANGE_NOT_SUPPORTED</Text>
+        <Enum>44</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nParameterChangeCycleTicks</Text>
+        <Enum>45</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_ParameterEstimationFailed</Text>
+        <Enum>46</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_NoiseLevelToHigh</Text>
+        <Enum>47</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_0</Text>
+        <Enum>48</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_1</Text>
+        <Enum>49</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_2</Text>
+        <Enum>50</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_3</Text>
+        <Enum>51</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_4</Text>
+        <Enum>52</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_5</Text>
+        <Enum>53</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_6</Text>
+        <Enum>54</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_7</Text>
+        <Enum>55</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_8</Text>
+        <Enum>56</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INTERNAL_ERROR_9</Text>
+        <Enum>57</Enum>
+        <Comment> internal error </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArrayADR</Text>
+        <Enum>58</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tOnTime</Text>
+        <Enum>59</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tOffTime</Text>
+        <Enum>60</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nMaxMovingPulses</Text>
+        <Enum>61</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nAdditionalPulsesAtLimits</Text>
+        <Enum>62</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fCtrlOutMax_Min</Text>
+        <Enum>63</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeltaMax</Text>
+        <Enum>64</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tMovingTime</Text>
+        <Enum>65</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tDeadTime</Text>
+        <Enum>66</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tAdditionalMoveTimeAtLimits</Text>
+        <Enum>67</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fThreshold</Text>
+        <Enum>68</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_MEMCPY</Text>
+        <Enum>69</Enum>
+        <Comment> MEMCPY failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_MEMSET</Text>
+        <Enum>70</Enum>
+        <Comment> MEMSET failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfColumns</Text>
+        <Enum>71</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileClose</Text>
+        <Enum>72</Enum>
+        <Comment> File Close  failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileOpen</Text>
+        <Enum>73</Enum>
+        <Comment> File Open failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileWrite</Text>
+        <Enum>74</Enum>
+        <Comment> File Write failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloNeg</Text>
+        <Enum>75</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloPos</Text>
+        <Enum>76</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandInput</Text>
+        <Enum>77</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandOutput</Text>
+        <Enum>78</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_CycleDuration</Text>
+        <Enum>79</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tStart</Text>
+        <Enum>80</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_StepHeigthTuningToLow</Text>
+        <Enum>81</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsLessThanZero</Text>
+        <Enum>82</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxLimitIsGreaterThan100</Text>
+        <Enum>83</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fStepSize</Text>
+        <Enum>84</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fOkRangeIsLessOrEqualZero</Text>
+        <Enum>85</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fForceRangeIsLessOrEqualfOkRange</Text>
+        <Enum>86</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPWMPeriod</Text>
+        <Enum>87</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_tMinimumPulseTime</Text>
+        <Enum>88</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileDelete</Text>
+        <Enum>89</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfPwmOutputs</Text>
+        <Enum>90</Enum>
+        <Comment> File Delete failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_SIZEOF</Text>
+        <Enum>91</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_SIZEOF</Text>
+        <Enum>92</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_SIZEOF</Text>
+        <Enum>93</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_SIZEOF</Text>
+        <Enum>94</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_SIZEOF</Text>
+        <Enum>95</Enum>
+        <Comment> SiZEOF failed </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction</Text>
+        <Enum>96</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_SIZEOF</Text>
+        <Enum>97</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_SIZEOF</Text>
+        <Enum>98</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_a_n_IsZero</Text>
+        <Enum>99</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArraySIZEOF</Text>
+        <Enum>100</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGRANGE_MIN_MAX</Text>
+        <Enum>101</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGTIME</Text>
+        <Enum>102</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DEADTIME</Text>
+        <Enum>103</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsGreaterThanfMaxLimit</Text>
+        <Enum>104</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableSIZEOF</Text>
+        <Enum>105</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_OutputVectorDescription</Text>
+        <Enum>106</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_TaskCycleTimeIsLessThanOneMillisecond</Text>
+        <Enum>107</Enum>
+        <Comment>  </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nMinMovingPulses</Text>
+        <Enum>108</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fAcceleration</Text>
+        <Enum>109</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fDeceleration</Text>
+        <Enum>110</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_StartAndTargetPos</Text>
+        <Enum>111</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fVelocity</Text>
+        <Enum>112</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetPos</Text>
+        <Enum>113</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fStartPos</Text>
+        <Enum>114</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fMovingLength</Text>
+        <Enum>115</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_NT_GetTime</Text>
+        <Enum>116</Enum>
+        <Comment> internal error NT_GetTime </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_No3PhaseSolutionPossible</Text>
+        <Enum>117</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fStartVelo</Text>
+        <Enum>118</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetVelo</Text>
+        <Enum>119</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALID_NEW_PARAMETER_TYPE</Text>
+        <Enum>120</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fBaseTime</Text>
+        <Enum>121</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction_SIZEOF</Text>
+        <Enum>122</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nFilterOrder</Text>
+        <Enum>124</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_SIZEOF</Text>
+        <Enum>125</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_SIZEOF</Text>
+        <Enum>126</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_SIZEOF</Text>
+        <Enum>127</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_SIZEOF</Text>
+        <Enum>128</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_LogBufferOverflow</Text>
+        <Enum>129</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_ADR</Text>
+        <Enum>130</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_ADR</Text>
+        <Enum>131</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_ADR</Text>
+        <Enum>132</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_ADR</Text>
+        <Enum>133</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_ADR</Text>
+        <Enum>134</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_ADR</Text>
+        <Enum>135</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_ADR</Text>
+        <Enum>136</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_ADR</Text>
+        <Enum>137</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_ADR</Text>
+        <Enum>138</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_ADR</Text>
+        <Enum>139</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction1Data_ADR</Text>
+        <Enum>140</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction2Data_ADR</Text>
+        <Enum>141</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_FileSeek</Text>
+        <Enum>142</Enum>
+        <Comment> internal error FB_FileSeek </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_AmbientTempMaxIsLessThanAmbientTempMin</Text>
+        <Enum>143</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_ForerunTempMaxIsLessThanForerunTempMin</Text>
+        <Enum>144</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDLOGCYCLETIME</Text>
+        <Enum>145</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDVERSION_TcControllerToolbox</Text>
+        <Enum>146</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_Bandwidth</Text>
+        <Enum>147</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_NotchFrequency</Text>
+        <Enum>148</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_DampingCoefficient</Text>
+        <Enum>149</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_fKpIsLessThanZero</Text>
+        <Enum>150</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eCTRL_ERROR_INVALIDPARAM_nSamplesToFilter</Text>
+        <Enum>151</Enum>
+        <Comment> invalid parameter </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Name>
+      <BitSize>2240</BitSize>
+      <SubItem>
+        <Name>fSetpointValue</Name>
+        <Type>LREAL</Type>
+        <Comment> setpoint value of controlled variable </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fActualValue</Name>
+        <Type>LREAL</Type>
+        <Comment> actual value of the controlled variable </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fManSyncValue</Name>
+        <Type>LREAL</Type>
+        <Comment> manual value to synchronize controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSync</Name>
+        <Type>BOOL</Type>
+        <Comment> rising edge sets controller output manual sync value </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eMode</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Comment> operating mode </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHold</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE will hold the controller output at current value </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fOut</Name>
+        <Type>LREAL</Type>
+        <Comment> controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bARWactive</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE indicates that the controller output is restricted </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Comment> current state of the function block </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eErrorId</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Comment> error code </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if error occurs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_PI_PARAMS</Type>
+        <Comment> parameter structure </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalCycleTimeInterpretation</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCallAfterAStateChange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1032</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fD_I</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTaskCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fHalfCtrlCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fTn</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bIPartEnabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSyncValueInternal</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLimitValue</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fE</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1600</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fE_1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY_I</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY_I_1</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY_P</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fY</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1920</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlCycleTicks</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nActCtrlCycleTick</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eMode_old</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMaxLimitReached</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMinLimitReached</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bSyncRequest</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbR_TRIG</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>M_Error</Name>
+      </Action>
+      <Action>
+        <Name>M_Manual</Name>
+      </Action>
+      <Action>
+        <Name>M_Active</Name>
+      </Action>
+      <Action>
+        <Name>M_StateChange</Name>
+      </Action>
+      <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Action>
+        <Name>M_Passive</Name>
+      </Action>
+      <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</Name>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>tTaskCycleTime</Name>
+        <Type>TIME</Type>
+        <Comment> task cycle time			[TIME]		</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tCtrlCycleTime</Name>
+        <Type>TIME</Type>
+        <Comment> controller cycle time 	[TIME]		</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloPos</Name>
+        <Type>LREAL</Type>
+        <Comment> velocity ramp by time, range &gt; 0.0 	</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloNeg</Name>
+        <Type>LREAL</Type>
+        <Comment> velocity ramp by time, range &gt; 0.0	</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Name>
+      <BitSize>192</BitSize>
+      <BaseType Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Name>
+      <BitSize>1280</BitSize>
+      <SubItem>
+        <Name>fStartValue</Name>
+        <Type>LREAL</Type>
+        <Comment> starting value of the ramp </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTargetValue</Name>
+        <Type>LREAL</Type>
+        <Comment> target value of the ramp </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fManValue</Name>
+        <Type>LREAL</Type>
+        <Comment> manual value to synchronize controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bHold</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE will hold the controller output at current value </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eMode</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Comment> operating mode </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fOut</Name>
+        <Type>LREAL</Type>
+        <Comment> controller output </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVeloOut</Name>
+        <Type>LREAL</Type>
+        <Comment> current velocity of the ramp generator </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValueReached</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE indicates that target value is reached </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Comment> current state of the function block </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eErrorId</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Comment> error code </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if error occurs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
+        <Comment> parameter structure </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTaskCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCtrlCycleTime</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutLocal</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bGetStartValue</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalParams</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInternalCycleTimeInterpretation</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCtrlCycleTicks</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nActCtrlCycleTick</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eMode_old</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1232</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>M_Error</Name>
+      </Action>
+      <Action>
+        <Name>M_Manual</Name>
+      </Action>
+      <Action>
+        <Name>M_Active</Name>
+      </Action>
+      <Action>
+        <Name>M_StateChange</Name>
+      </Action>
+      <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Action>
+        <Name>M_Passive</Name>
+      </Action>
+      <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>eMode</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <Comment> operating mode </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTaskCycleTime</Name>
+        <Type>TIME</Type>
+        <Comment> resolution  1ms</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bCycleTimeValid</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if cycle time is valid </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eState</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
+        <Comment> current state of the function block </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eErrorId</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
+        <Comment> error code </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE, if error occurs </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>184</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nCpuCntLoDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCpuCntHiDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLastcpuCntLoDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLastcpuCntHiDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCycleTimeDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCycleTimeDWold</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCallReady</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGETCPUCOUNTER</Name>
+        <Type Namespace="Tc2_System">GETCPUCOUNTER</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eMode_old</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>M_Active</Name>
+      </Action>
+      <Action>
+        <Name>M_StateChange</Name>
+      </Action>
+      <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Action>
+        <Name>M_Passive</Name>
+      </Action>
+      <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_PiezoControl</Name>
+      <BitSize>6720</BitSize>
+      <SubItem>
+        <Name>iq_Piezo</Name>
+        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xExecute</Name>
+        <Type>BOOL</Type>
+        <Comment>Rising edge being piezo motion</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Enable_Positive</Name>
+        <Type>BOOL</Type>
+        <Comment>Reverse of Positive Limit Switch</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Enable_Negative</Name>
+        <Type>BOOL</Type>
+        <Comment>Reverse of Negative Limit Switch</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xBusy</Name>
+        <Type>BOOL</Type>
+        <Comment>Busy remains true while piezo position is being adjusted</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xDone</Name>
+        <Type>BOOL</Type>
+        <Comment>Reached target position</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>168</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xError</Name>
+        <Type>BOOL</Type>
+        <Comment>General error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xLimited</Name>
+        <Type>BOOL</Type>
+        <Comment>Piezo move was limited</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>E_State</Name>
+        <Type Namespace="lcls_twincat_optics">E_PiezoControl</Type>
+        <Comment>ENUM for Piezo Control State</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtStartMove</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment>Rising Trigger for Execution</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <Comment>Rising Trigger for Error reset</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rSetpoint</Name>
+        <Type>REAL</Type>
+        <Comment>Internal Storage of Setpoint</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rReqVoltage</Name>
+        <Type>REAL</Type>
+        <Comment>requested voltage</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rLLSV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rHLSV</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+        <Default>
+          <Value>120</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbPI</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbRamp</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Type>
+        <BitSize>1280</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInitialized</Name>
+        <Type>BOOL</Type>
+        <Comment> FB initialized flag</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>4160</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCycleTime</Name>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Type>
+        <Comment>Get cycle time for control FBs</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>4224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tTaskCycleTime</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>4992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bCycleTimeValid</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtVoltMode</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>5056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOut</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>5184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fPiezoBias</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>5248</BitOffs>
+        <Default>
+          <Value>60</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fScale</Name>
+        <Type>REAL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>5312</BitOffs>
+        <Default>
+          <Value>-60</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tonPiezoDone</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>5376</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tonPiezoLimited</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>5632</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>xVoltageLimited</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>5888</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftEnPos</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>5952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftEnNeg</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtEnPos</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtEnNeg</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>6336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutLimitHolder</Name>
+        <Type>LREAL</Type>
+        <Comment>holds the limit value until restored</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>6464</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutHiLimHolder</Name>
+        <Type>LREAL</Type>
+        <Comment>holds the limit value until restored</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>6528</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fOutLoLimHolder</Name>
+        <Type>LREAL</Type>
+        <Comment>holds the limit value until restored</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>6592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFirstPass</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>6656</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ACT_CheckLimits</Name>
+      </Action>
+      <Action>
+        <Name>ACT_Controller</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">E_PitchControl</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>PCM_Init</Text>
+        <Enum>0</Enum>
+        <Comment>Pitch Control Machine</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Standby</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_MoveRequested</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Coarse50Piezo</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_CoarseMove</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_CoarseMoveCleanup</Text>
+        <Enum>22</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_FineMove</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Halt</Text>
+        <Enum>50</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Done</Text>
+        <Enum>8000</Enum>
+        <Comment>why is 8000 done? Where did this come from??</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_Error</Text>
+        <Enum>9000</Enum>
+        <Comment>Anything above 9000 is considered an error</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_StepperError</Text>
+        <Enum>9100</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_PiezoError</Text>
+        <Enum>9200</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_OtherError</Text>
+        <Enum>9300</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PCM_STOHit</Text>
+        <Enum>9400</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_PitchControl</Name>
+      <BitSize>397888</BitSize>
+      <SubItem>
+        <Name>Pitch</Name>
+        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">HOMS_PitchMechanism</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Stepper</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>lrCurrentSetpoint</Name>
+        <Type>LREAL</Type>
+        <Comment> Setpoint: Epics writes to ST_MotionStage which gets fed into this</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_bDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>q_bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDiag</Name>
+        <Type Namespace="LCLS_General">ST_FbDiagnostics</Type>
+        <Comment> Logging</Comment>
+        <BitSize>49664</BitSize>
+        <BitOffs>320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbFormatString</Name>
+        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+        <BitSize>8576</BitSize>
+        <BitOffs>49984</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>POUName</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Name of the POU for logging/error reporting</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>58560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>no_init</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>lrActPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Actual Position of piezo mechanism</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60608</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrPrevStepperPos</Name>
+        <Type>LREAL</Type>
+        <Comment> Previous successfully achieved stepper position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftLimitSwitch</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>60736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrOriginalPosRequest</Name>
+        <Type>LREAL</Type>
+        <Comment> Used for logging</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60864</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>lrLastSetpoint</Name>
+        <Type>LREAL</Type>
+        <Comment> Previous successfully achieved setpoint</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>60928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
+        <BitSize>1920</BitSize>
+        <BitOffs>60992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
+        <BitSize>327424</BitSize>
+        <BitOffs>62912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLimitHit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>390336</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonStepperHold</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Timer to hold stepper position while the system relaxes</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>390400</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rSettledRange</Name>
+        <Type>REAL</Type>
+        <Comment> Units = urad</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>390656</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bResetStepper</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>390688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteStepper</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>390696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
+        <Comment> Wait for move to complete before taking another request</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>390704</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tonPiezoSettled</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Piezo</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>390720</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PT</Name>
+            <DateTime>T</DateTime>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbPiezoControl</Name>
+        <Type Namespace="lcls_twincat_optics">FB_PiezoControl</Type>
+        <BitSize>6720</BitSize>
+        <BitOffs>390976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtPiezoMoveDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>397696</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>PC_State</Name>
+        <Type Namespace="lcls_twincat_optics">E_PitchControl</Type>
+        <Comment> State Machine</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>397824</BitOffs>
+        <Default>
+          <EnumText>E_PitchControl.PCM_Init</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bCoarse50PiezoMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>397840</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>ACT_ResetSetpoint</Name>
+      </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -50199,42 +54553,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
-      <BitSize>0</BitSize>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Name>
-      <Comment> Renishaw BiSS-C absolute encoder used with an EL5042</Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>Count</Name>
-        <Type>ULINT</Type>
-        <Comment> Connect to encoder "Position" input</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Status</Name>
-        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
-        <Comment> Status struct placeholder</Comment>
-        <BitSize>0</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Ref</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder zero position (useful for aligned position with gantries)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="LCLS_General">FB_TempSensor</Name>
       <BitSize>256</BitSize>
       <SubItem>
@@ -50593,348 +54911,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">E_MotionRequest</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>WAIT</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>INTERRUPT</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ABORT</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionRequest</Name>
-      <BitSize>1920</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start move on rising edge, stop move on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Reset errors on rising edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
-        <Comment> Define behavior for when the motor is already moving</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Goal position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVel</Name>
-        <Type>LREAL</Type>
-        <Comment> Move velocity</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAcc</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional acceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDec</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional deceleration</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if in error state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> What the error code means</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and our most recent move was successful</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftExec</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nState</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bMyMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCausedError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>INIT</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1760</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_EXEC</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1776</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>PICK_REQUEST</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1792</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_OTHER_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1808</BitOffs>
-        <Default>
-          <Value>3</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>STOP_OTHER_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1824</BitOffs>
-        <Default>
-          <Value>4</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>START_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1840</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_MY_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Default>
-          <Value>6</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>STOP_MY_MOVE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1872</BitOffs>
-        <Default>
-          <Value>7</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>DONE_MOVING</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1888</BitOffs>
-        <Default>
-          <Value>8</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ERROR</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1904</BitOffs>
-        <Default>
-          <Value>9</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
@@ -51681,10 +55657,10 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>256448</BitOffs>
       </SubItem>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Properties>
         <Property>
@@ -51773,37 +55749,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -51848,6 +55793,37 @@ contributing fast faults, unless the FFO is currently vetoed.
 	</Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -52463,28 +56439,28 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -52711,7 +56687,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>237128</BitOffs>
         <Default>
-          <Bool> : u</Bool>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -52745,42 +56721,30 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>409664</BitOffs>
       </SubItem>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>86080</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -52911,6 +56875,42 @@ ELSE:
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -52952,44 +56952,20 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>86080</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -53140,7 +57116,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -53393,13 +57369,13 @@ ELSE:
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -53822,110 +57798,6 @@ ELSE:
         <Text>Error</Text>
         <Enum>9000</Enum>
       </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_Index</Name>
-      <Comment> Index FB
-A. Wallace 2016-9-3
-
-Why doesn't beckhoff have this as a builtin type?
-
-Use this thing to have a simple indexer with rollover.
-
-</Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>LowerLimit</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer will rollver over to this value (and initialize to this value)</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>naming</Name>
-            <Value>off</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ValInc</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer increments by this value</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>UpperLimit</Name>
-        <Type>INT</Type>
-        <Comment>Incrementer will rollover at this value to lower limit</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nVal</Name>
-        <Type>INT</Type>
-        <Comment>Internal incrementer value, initialized to LowerLimit</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>112</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>off</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>Dec</Name>
-      </Action>
-      <Action>
-        <Name>Inc</Name>
-      </Action>
-      <Method>
-        <Name>DecVal</Name>
-        <Comment>Decrement the counter and return new value</Comment>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IncVal</Name>
-        <Comment>Increment the counter and return new value</Comment>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">BeamParameterTransitionManager</Name>
@@ -54391,13 +58263,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -54418,7 +58290,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -54667,10 +58539,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -55021,7 +58893,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>257952</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -56060,8 +59932,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>144960</BitOffs>
         <Default>
-          <Bool>,
-  </Bool>
+          <Bool>,</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -56130,6 +60001,124 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</Name>
+      <BitSize>1216</BitSize>
+      <SubItem>
+        <Name>fFlow_1_val</Name>
+        <Type>LREAL</Type>
+        <Comment> Mirrors with 1 Cooling Flow Meter and 1 Pressure Meter</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM:1
+        field: EGU lpm
+        field: HIGH 2.3
+        field: HIHI 3.0
+        field: LOW 1.7
+        field: LOLO 1.5
+        field: LSV MINOR
+        field: LLSV MAJOR
+        field: HSV MINOR
+        field: HHSV MAJOR
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPress_1_val</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PRSM:1
+        field: EGU bar
+        field: LOW 0.1
+        field: LSV MAJOR
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlow_1</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPress_1</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</Name>
+      <BitSize>1792</BitSize>
+      <ExtendsType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</ExtendsType>
+      <SubItem>
+        <Name>fFlow_2_val</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FWM:2
+        field: EGU lpm
+        field: HIGH 2.3
+        field: HIHI 3.0
+        field: LOW 1.7
+        field: LOLO 1.5
+        field: LSV MINOR
+        field: LLSV MAJOR
+        field: HSV MINOR
+        field: HHSV MAJOR
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFlow_2</Name>
+        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>1280</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -68182,3996 +72171,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Property>
       </Properties>
     </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</Name>
-      <BitSize>1216</BitSize>
-      <SubItem>
-        <Name>fFlow_1_val</Name>
-        <Type>LREAL</Type>
-        <Comment> Mirrors with 1 Cooling Flow Meter and 1 Pressure Meter</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: FWM:1
-        field: EGU lpm
-        field: HIGH 2.3
-        field: HIHI 3.0
-        field: LOW 1.7
-        field: LOLO 1.5
-        field: LSV MINOR
-        field: LLSV MAJOR
-        field: HSV MINOR
-        field: HHSV MAJOR
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPress_1_val</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PRSM:1
-        field: EGU bar
-        field: LOW 0.1
-        field: LSV MAJOR
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFlow_1</Name>
-        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbPress_1</Name>
-        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</Name>
-      <BitSize>1792</BitSize>
-      <ExtendsType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</ExtendsType>
-      <SubItem>
-        <Name>fFlow_2_val</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: FWM:2
-        field: EGU lpm
-        field: HIGH 2.3
-        field: HIHI 3.0
-        field: LOW 1.7
-        field: LOLO 1.5
-        field: LSV MINOR
-        field: LLSV MAJOR
-        field: HSV MINOR
-        field: HHSV MAJOR
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFlow_2</Name>
-        <Type Namespace="LCLS_General">FB_AnalogInput</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Name>
-      <BitSize>512</BitSize>
-      <SubItem>
-        <Name>PEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Primary axis encoder (usually the upstream one)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Secondary axis encoder (couples to the primary)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GantDiffTol</Name>
-        <Type>LINT</Type>
-        <Comment> Gantry differenace tolerance in encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PLimFwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Primary axis forward direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PLimBwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Primary axis reverse direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SLimFwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Secondary axis forward direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SLimBwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Secondary axis reverse direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GantryDiff</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR</Text>
-        <Enum>1</Enum>
-        <Comment> Lineare Kopplung (Geradengleichung) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONVELOCITY</Text>
-        <Enum>2</Enum>
-        <Comment> diagonal synchron. Aufkoppeln schnellstens auf Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONPOSITION</Text>
-        <Enum>3</Enum>
-        <Comment> diagonal synchron. Aufkoppeln auf Position und Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_QUADRATIC</Text>
-        <Enum>4</Enum>
-        <Comment> diagonal synchron. Aufkoppeln (quadratisches Geschw.-Profil) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONVELO</Text>
-        <Enum>5</Enum>
-        <Comment> synchron. Aufkoppeln instantan auf Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONPOS</Text>
-        <Enum>6</Enum>
-        <Comment> synchron. Aufkoppeln auf Positionen und Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCJERKSETTER_ONVELO</Text>
-        <Enum>7</Enum>
-        <Comment> synchron. Aufkoppeln auf Geschwindigkeit (zeitbasiert mittels Ruck-Steller) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_TABULAR</Text>
-        <Enum>10</Enum>
-        <Comment> Tabellen-Kopplung ("simple/standard tabular slave") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_MULTITABULAR</Text>
-        <Enum>11</Enum>
-        <Comment> Tabellen-Kopplung ("multiscalable multi-tabular slave") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGMODULO_LINEAR</Text>
-        <Enum>12</Enum>
-        <Comment> Modulo Kopplung auf Position und/oder Geschwindigkeit mit anschliessender Linear Kopplung ("Schuette") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_MOTIONFUNCTIONTABULAR</Text>
-        <Enum>13</Enum>
-        <Comment> Tabellen-Kopplung "motion functions" </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_UNIVERSALTABULAR</Text>
-        <Enum>14</Enum>
-        <Comment> Tabellen-Kopplung, universal tabular type substitues TABULAR, MULTITABULAR and MOTIONFUNCTION - 08.07.05 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR_CYCLICCHANGES_RAMP</Text>
-        <Enum>15</Enum>
-        <Comment> Lineare Kopplung (Geradengleichung) mit zyklischer Koppelfaktoraenderung </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_BILINEAR</Text>
-        <Enum>16</Enum>
-        <Comment> 27.04.01: Zweifach Lineare Kopplung (Geradengleichung)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR_MULTIMASTER</Text>
-        <Enum>17</Enum>
-        <Comment> 29.05.08: Lineare Multi-Master-Kopplung ('MC_GearInMultiMaster') </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_CONST_SURFACEVELO_RAMP</Text>
-        <Enum>18</Enum>
-        <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
-      <BitSize>16</BitSize>
-      <SubItem>
-        <Name>SlaveType</Name>
-        <Type Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearIn</Name>
-      <BitSize>7360</BitSize>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Execute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>RatioNumerator</Name>
-        <Type>LREAL</Type>
-        <Comment> changed from INT (PLCopen) to LREAL </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>RatioDenominator</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Acceleration</Name>
-        <Type>LREAL</Type>
-        <Comment>	MasterValueSource :	MC_SOURCE; 
- not available </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Deceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Jerk</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>BufferMode</Name>
-        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearInOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>592</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>InGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>608</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>616</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Active</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CommandAborted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>632</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>640</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>672</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>816</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1344</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sCouple</Name>
-        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>2176</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOptGearInDyn</Name>
-        <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
-        <BitSize>4416</BitSize>
-        <BitOffs>2560</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOnTrigger</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6976</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>7104</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ActGearInDyn</Name>
-      </Action>
-      <Action>
-        <Name>WriteGearRatio</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Name>
-      <BitSize>10752</BitSize>
-      <SubItem>
-        <Name>nGantryTol</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>MasterEnc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SlaveEnc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCouple</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecouple</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>gantry_diff_limit</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>couple</Name>
-        <Type Namespace="Tc2_MC2">MC_GearIn</Type>
-        <BitSize>7360</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>decouple</Name>
-        <Type Namespace="Tc2_MC2">MC_GearOut</Type>
-        <BitSize>2112</BitSize>
-        <BitOffs>8448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInitComplete</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>10560</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbSetEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>10624</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_RunHOMS</Name>
-      <BitSize>23296</BitSize>
-      <SubItem>
-        <Name>nYupEncRef</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder Reference Values</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nYdwnEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nXupEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nXdwnEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTolY</Name>
-        <Type>LINT</Type>
-        <Comment> Encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>50000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTolX</Name>
-        <Type>LINT</Type>
-        <Comment> Encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>50000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledY</Name>
-        <Type>BOOL</Type>
-        <Comment> Gantry coupling status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryY</Name>
-        <Type>LINT</Type>
-        <Comment> Current gantry difference</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryX</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor Structs</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPitch</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleY</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <Comment> Manual coupling Gantried Axes</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleX</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleY</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleX</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable1</Name>
-        <Type>BOOL</Type>
-        <Comment> STO Button</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable2</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYupEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Encoders</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>1280</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYdwnEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXupEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1536</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXdwnEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1664</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbAutoCoupleY</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
-        <Comment> Autocoupling Gantried Axes</Comment>
-        <BitSize>10752</BitSize>
-        <BitOffs>1792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAutoCoupleX</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
-        <BitSize>10752</BitSize>
-        <BitOffs>12544</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">DUT_HOMS</Name>
-      <BitSize>23552</BitSize>
-      <SubItem>
-        <Name>fbRunHOMS</Name>
-        <Type Namespace="lcls_twincat_optics">FB_RunHOMS</Type>
-        <Comment> System initializiation</Comment>
-        <BitSize>23296</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleY</Name>
-        <Type>BOOL</Type>
-        <Comment> Couple/Decouple motors</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>23296</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: COUPLE_Y
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleY</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DECOUPLE_Y
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: COUPLE_X
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DECOUPLE_X
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledY</Name>
-        <Type>BOOL</Type>
-        <Comment> Coupling status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>23328</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ALREADY_COUPLED_Y
-        io: i
-        field: ZSV MAJOR
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ALREADY_COUPLED_X
-        io: i
-        field: ZSV MAJOR
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryY</Name>
-        <Type>LINT</Type>
-        <Comment> encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>23360</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryX</Name>
-        <Type>LINT</Type>
-        <Comment> encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>23424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrGantryY_um</Name>
-        <Type>REAL</Type>
-        <Comment> Y Gantry difference in um</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>23488</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GANTRY_Y
-        field: EGU um
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrGantryX_um</Name>
-        <Type>REAL</Type>
-        <Comment> X Gantry difference in um</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>23520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GANTRY_X
-        field: EGU um
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
-      <BitSize>128704</BitSize>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we'll accumulate a value on this cycle.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fInput</Name>
-        <Type>LREAL</Type>
-        <Comment> The value to accumulate.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrOutput</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bNewArray</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrPartial</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>64256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataBuffer</Name>
-        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
-        <BitSize>448</BitSize>
-        <BitOffs>128256</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
-      <BitSize>387520</BitSize>
-      <SubItem>
-        <Name>fMaxRMSError</Name>
-        <Type>LREAL</Type>
-        <Comment> RMS Error</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMinRMSError</Name>
-        <Type>LREAL</Type>
-        <Comment> start at something huge, FB will update with any smaller measured value</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScalingNum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScalingDenom</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncOffset</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScale</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataEncPos</Name>
-        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
-        <Comment> ActPos Data Acquisition FB</Comment>
-        <BitSize>128704</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataSetPos</Name>
-        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
-        <Comment> SetPos Data Acquisition FB</Comment>
-        <BitSize>128704</BitSize>
-        <BitOffs>129216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDataStorage</Name>
-        <Type>BOOL</Type>
-        <Comment> Take data of both ActPos and SetPos</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>257920</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bNewEncArray</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>257928</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStats</Name>
-        <Type Namespace="LCLS_General">FB_BasicStats</Type>
-        <Comment> Calculate mean/standard deviation of ActPos</Comment>
-        <BitSize>1152</BitSize>
-        <BitOffs>257984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncMean</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MEAN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fEncStDev</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STDEV
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrRMSError</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259264</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RMS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>259328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSum</Name>
-        <Type>LREAL</Type>
-        <Comment> Just for calculating rms</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>259392</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fDiff</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>259456</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>aEncActPos</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>259520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ACTPOSARRAY
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>aEncSetPos</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>323520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SETPOSARRAY
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">ST_FbDiagnostics</Name>
-      <Comment>Stuff to log messages within function blocks</Comment>
-      <BitSize>49664</BitSize>
-      <SubItem>
-        <Name>asResults</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>20</Elements>
-        </ArrayInfo>
-        <Comment>Diagnostic messages, use to record state changes or other important events.</Comment>
-        <BitSize>40960</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>resultIdx</Name>
-        <Type Namespace="LCLS_General">FB_Index</Type>
-        <Comment>Incrementer, included here to facilitate using asResults</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>40960</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.LowerLimit</Name>
-            <Value>1</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.UpperLimit</Name>
-            <Value>20</Value>
-          </SubItem>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>omit</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fString</Name>
-        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-        <Comment>Use to create good log messages, similar to C++ fstring</Comment>
-        <BitSize>8576</BitSize>
-        <BitOffs>41088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>omit</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_MotionRequest</Name>
-      <BitSize>16</BitSize>
-      <BaseType Namespace="lcls_twincat_motion">E_MotionRequest</BaseType>
-      <Properties>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use E_MotionRequest</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">E_PiezoControl</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>EPC_Idle</Text>
-        <Enum>0</Enum>
-        <Comment>Piezo Control Machine</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_Init</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MoveRequested</Text>
-        <Enum>50</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MovingPositive</Text>
-        <Enum>100</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MovingNegative</Text>
-        <Enum>200</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_MoveCompleted</Text>
-        <Enum>350</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EPC_Error</Text>
-        <Enum>500</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eCTRL_MODE_IDLE</Text>
-        <Enum>0</Enum>
-        <Comment> mode idle					</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_PASSIVE</Text>
-        <Enum>1</Enum>
-        <Comment> mode passive				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_ACTIVE</Text>
-        <Enum>2</Enum>
-        <Comment> mode active					</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_RESET</Text>
-        <Enum>3</Enum>
-        <Comment> mode reset					</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_MANUAL</Text>
-        <Enum>4</Enum>
-        <Comment> mode manual				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_TUNE</Text>
-        <Enum>5</Enum>
-        <Comment> mode tuning				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_SELFTEST</Text>
-        <Enum>6</Enum>
-        <Comment> mode selftest				</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_SYNC_MOVEMENT</Text>
-        <Enum>7</Enum>
-        <Comment> mode synchronize			</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_MODE_FREEZE</Text>
-        <Enum>8</Enum>
-        <Comment> mode freeze				</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eCTRL_STATE_IDLE</Text>
-        <Enum>0</Enum>
-        <Comment> state idle		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_PASSIVE</Text>
-        <Enum>1</Enum>
-        <Comment> state passive	</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_ACTIVE</Text>
-        <Enum>2</Enum>
-        <Comment> state active		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_RESET</Text>
-        <Enum>3</Enum>
-        <Comment> state reset		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_MANUAL</Text>
-        <Enum>4</Enum>
-        <Comment> state manual	</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_TUNING</Text>
-        <Enum>5</Enum>
-        <Comment> state tuning		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_TUNED</Text>
-        <Enum>6</Enum>
-        <Comment> state tuning ready - tuned		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_SELFTEST</Text>
-        <Enum>7</Enum>
-        <Comment> state selftest		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_ERROR</Text>
-        <Enum>8</Enum>
-        <Comment> state error		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_SYNC_MOVEMENT</Text>
-        <Enum>9</Enum>
-        <Comment> state synchronizing movement		</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_STATE_FREEZE</Text>
-        <Enum>10</Enum>
-        <Comment> state freeze 	</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_NOERROR</Text>
-        <Enum>0</Enum>
-        <Comment> no error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDTASKCYCLETIME</Text>
-        <Enum>1</Enum>
-        <Comment> invalid task cycle time </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDCTRLCYCLETIME</Text>
-        <Enum>2</Enum>
-        <Comment> invalid ctrl cycle time </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM</Text>
-        <Enum>3</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tv</Text>
-        <Enum>4</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Td</Text>
-        <Enum>5</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tn</Text>
-        <Enum>6</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Ti</Text>
-        <Enum>7</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fHystereisisRange</Text>
-        <Enum>8</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fPosOutOn_Off</Text>
-        <Enum>9</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fNegOutOn_Off</Text>
-        <Enum>10</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_TableDescription</Text>
-        <Enum>11</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_TableData</Text>
-        <Enum>12</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableADR</Text>
-        <Enum>13</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T0</Text>
-        <Enum>14</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T1</Text>
-        <Enum>15</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T2</Text>
-        <Enum>16</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_T3</Text>
-        <Enum>17</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Theta</Text>
-        <Enum>18</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nOrder</Text>
-        <Enum>19</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tt</Text>
-        <Enum>20</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tu</Text>
-        <Enum>21</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tg</Text>
-        <Enum>22</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_infinite_slope</Text>
-        <Enum>23</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxIsLessThanfMin</Text>
-        <Enum>24</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOutMaxLimitIsLessThanfOutMinLimit</Text>
-        <Enum>25</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindow</Text>
-        <Enum>26</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fInnerWindow</Text>
-        <Enum>27</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOuterWindowIsLessThanfInnerWindow</Text>
-        <Enum>28</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandInput</Text>
-        <Enum>29</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeadBandOutput</Text>
-        <Enum>30</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_PWM_Cycletime</Text>
-        <Enum>31</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_no_Parameterset</Text>
-        <Enum>32</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOn</Text>
-        <Enum>33</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOutOff</Text>
-        <Enum>34</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fGain</Text>
-        <Enum>35</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOffset</Text>
-        <Enum>36</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_MODE_NOT_SUPPORTED</Text>
-        <Enum>37</Enum>
-        <Comment> invalid mode: mode not supported </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_heating</Text>
-        <Enum>38</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Td_heating</Text>
-        <Enum>39</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_heating</Text>
-        <Enum>40</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tv_cooling</Text>
-        <Enum>41</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Td_cooling</Text>
-        <Enum>42</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Tn_cooling</Text>
-        <Enum>43</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_RANGE_NOT_SUPPORTED</Text>
-        <Enum>44</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nParameterChangeCycleTicks</Text>
-        <Enum>45</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_ParameterEstimationFailed</Text>
-        <Enum>46</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_NoiseLevelToHigh</Text>
-        <Enum>47</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_0</Text>
-        <Enum>48</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_1</Text>
-        <Enum>49</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_2</Text>
-        <Enum>50</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_3</Text>
-        <Enum>51</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_4</Text>
-        <Enum>52</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_5</Text>
-        <Enum>53</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_6</Text>
-        <Enum>54</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_7</Text>
-        <Enum>55</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_8</Text>
-        <Enum>56</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INTERNAL_ERROR_9</Text>
-        <Enum>57</Enum>
-        <Comment> internal error </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArrayADR</Text>
-        <Enum>58</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tOnTime</Text>
-        <Enum>59</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tOffTime</Text>
-        <Enum>60</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nMaxMovingPulses</Text>
-        <Enum>61</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nAdditionalPulsesAtLimits</Text>
-        <Enum>62</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fCtrlOutMax_Min</Text>
-        <Enum>63</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeltaMax</Text>
-        <Enum>64</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tMovingTime</Text>
-        <Enum>65</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tDeadTime</Text>
-        <Enum>66</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tAdditionalMoveTimeAtLimits</Text>
-        <Enum>67</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fThreshold</Text>
-        <Enum>68</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_MEMCPY</Text>
-        <Enum>69</Enum>
-        <Comment> MEMCPY failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_MEMSET</Text>
-        <Enum>70</Enum>
-        <Comment> MEMSET failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfColumns</Text>
-        <Enum>71</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileClose</Text>
-        <Enum>72</Enum>
-        <Comment> File Close  failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileOpen</Text>
-        <Enum>73</Enum>
-        <Comment> File Open failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileWrite</Text>
-        <Enum>74</Enum>
-        <Comment> File Write failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloNeg</Text>
-        <Enum>75</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fVeloPos</Text>
-        <Enum>76</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandInput</Text>
-        <Enum>77</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DeadBandOutput</Text>
-        <Enum>78</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_CycleDuration</Text>
-        <Enum>79</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tStart</Text>
-        <Enum>80</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_StepHeigthTuningToLow</Text>
-        <Enum>81</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsLessThanZero</Text>
-        <Enum>82</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMaxLimitIsGreaterThan100</Text>
-        <Enum>83</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fStepSize</Text>
-        <Enum>84</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fOkRangeIsLessOrEqualZero</Text>
-        <Enum>85</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fForceRangeIsLessOrEqualfOkRange</Text>
-        <Enum>86</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPWMPeriod</Text>
-        <Enum>87</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_tMinimumPulseTime</Text>
-        <Enum>88</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileDelete</Text>
-        <Enum>89</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumberOfPwmOutputs</Text>
-        <Enum>90</Enum>
-        <Comment> File Delete failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_SIZEOF</Text>
-        <Enum>91</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_SIZEOF</Text>
-        <Enum>92</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_SIZEOF</Text>
-        <Enum>93</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_SIZEOF</Text>
-        <Enum>94</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_SIZEOF</Text>
-        <Enum>95</Enum>
-        <Comment> SiZEOF failed </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction</Text>
-        <Enum>96</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_SIZEOF</Text>
-        <Enum>97</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_SIZEOF</Text>
-        <Enum>98</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_a_n_IsZero</Text>
-        <Enum>99</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_WorkArraySIZEOF</Text>
-        <Enum>100</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGRANGE_MIN_MAX</Text>
-        <Enum>101</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_MOVINGTIME</Text>
-        <Enum>102</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DEADTIME</Text>
-        <Enum>103</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMinLimitIsGreaterThanfMaxLimit</Text>
-        <Enum>104</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DataTableSIZEOF</Text>
-        <Enum>105</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_OutputVectorDescription</Text>
-        <Enum>106</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_TaskCycleTimeIsLessThanOneMillisecond</Text>
-        <Enum>107</Enum>
-        <Comment>  </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nMinMovingPulses</Text>
-        <Enum>108</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fAcceleration</Text>
-        <Enum>109</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fDeceleration</Text>
-        <Enum>110</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_StartAndTargetPos</Text>
-        <Enum>111</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fVelocity</Text>
-        <Enum>112</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetPos</Text>
-        <Enum>113</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fStartPos</Text>
-        <Enum>114</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fMovingLength</Text>
-        <Enum>115</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_NT_GetTime</Text>
-        <Enum>116</Enum>
-        <Comment> internal error NT_GetTime </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_No3PhaseSolutionPossible</Text>
-        <Enum>117</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fStartVelo</Text>
-        <Enum>118</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fTargetVelo</Text>
-        <Enum>119</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALID_NEW_PARAMETER_TYPE</Text>
-        <Enum>120</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fBaseTime</Text>
-        <Enum>121</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nOrderOfTheTransferfunction_SIZEOF</Text>
-        <Enum>122</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nFilterOrder</Text>
-        <Enum>124</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_SIZEOF</Text>
-        <Enum>125</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_SIZEOF</Text>
-        <Enum>126</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_SIZEOF</Text>
-        <Enum>127</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_SIZEOF</Text>
-        <Enum>128</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_LogBufferOverflow</Text>
-        <Enum>129</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nLogBuffer_ADR</Text>
-        <Enum>130</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_a_ADR</Text>
-        <Enum>131</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nCoefficientsArray_b_ADR</Text>
-        <Enum>132</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInputArray_ADR</Text>
-        <Enum>133</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmOutputArray_ADR</Text>
-        <Enum>134</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmWaitTimesConfig_ADR</Text>
-        <Enum>135</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nPwmInternalData_ADR</Text>
-        <Enum>136</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDigitalFiterData_ADR</Text>
-        <Enum>137</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nNumeratorArray_ADR</Text>
-        <Enum>138</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nDenominatorArray_ADR</Text>
-        <Enum>139</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction1Data_ADR</Text>
-        <Enum>140</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nTransferfunction2Data_ADR</Text>
-        <Enum>141</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_FileSeek</Text>
-        <Enum>142</Enum>
-        <Comment> internal error FB_FileSeek </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_AmbientTempMaxIsLessThanAmbientTempMin</Text>
-        <Enum>143</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_ForerunTempMaxIsLessThanForerunTempMin</Text>
-        <Enum>144</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDLOGCYCLETIME</Text>
-        <Enum>145</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDVERSION_TcControllerToolbox</Text>
-        <Enum>146</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_Bandwidth</Text>
-        <Enum>147</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_NotchFrequency</Text>
-        <Enum>148</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_DampingCoefficient</Text>
-        <Enum>149</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_fKpIsLessThanZero</Text>
-        <Enum>150</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eCTRL_ERROR_INVALIDPARAM_nSamplesToFilter</Text>
-        <Enum>151</Enum>
-        <Comment> invalid parameter </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Name>
-      <BitSize>2240</BitSize>
-      <SubItem>
-        <Name>fSetpointValue</Name>
-        <Type>LREAL</Type>
-        <Comment> setpoint value of controlled variable </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fActualValue</Name>
-        <Type>LREAL</Type>
-        <Comment> actual value of the controlled variable </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fManSyncValue</Name>
-        <Type>LREAL</Type>
-        <Comment> manual value to synchronize controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSync</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge sets controller output manual sync value </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <Comment> operating mode </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHold</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE will hold the controller output at current value </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fOut</Name>
-        <Type>LREAL</Type>
-        <Comment> controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bARWactive</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE indicates that the controller output is restricted </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
-        <Comment> current state of the function block </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
-        <Comment> error code </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if error occurs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_PI_PARAMS</Type>
-        <Comment> parameter structure </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalCycleTimeInterpretation</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCallAfterAStateChange</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1032</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fD_I</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTaskCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fHalfCtrlCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTn</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bIPartEnabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSyncValueInternal</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLimitValue</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fE</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1600</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fE_1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1664</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY_I</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1728</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY_I_1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1792</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY_P</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fY</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1920</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nCtrlCycleTicks</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nActCtrlCycleTick</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2016</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>2048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMaxLimitReached</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2064</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMinLimitReached</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2072</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bSyncRequest</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>2080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbR_TRIG</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>2112</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>M_Error</Name>
-      </Action>
-      <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
-        <Name>M_Manual</Name>
-      </Action>
-      <Action>
-        <Name>M_Active</Name>
-      </Action>
-      <Action>
-        <Name>M_StateChange</Name>
-      </Action>
-      <Action>
-        <Name>M_Passive</Name>
-      </Action>
-      <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</Name>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>tTaskCycleTime</Name>
-        <Type>TIME</Type>
-        <Comment> task cycle time			[TIME]		</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tCtrlCycleTime</Name>
-        <Type>TIME</Type>
-        <Comment> controller cycle time 	[TIME]		</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloPos</Name>
-        <Type>LREAL</Type>
-        <Comment> velocity ramp by time, range &gt; 0.0 	</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloNeg</Name>
-        <Type>LREAL</Type>
-        <Comment> velocity ramp by time, range &gt; 0.0	</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Name>
-      <BitSize>192</BitSize>
-      <BaseType Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_PARAMS</BaseType>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Name>
-      <BitSize>1280</BitSize>
-      <SubItem>
-        <Name>fStartValue</Name>
-        <Type>LREAL</Type>
-        <Comment> starting value of the ramp </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fTargetValue</Name>
-        <Type>LREAL</Type>
-        <Comment> target value of the ramp </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fManValue</Name>
-        <Type>LREAL</Type>
-        <Comment> manual value to synchronize controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHold</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE will hold the controller output at current value </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <Comment> operating mode </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fOut</Name>
-        <Type>LREAL</Type>
-        <Comment> controller output </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVeloOut</Name>
-        <Type>LREAL</Type>
-        <Comment> current velocity of the ramp generator </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValueReached</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE indicates that target value is reached </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
-        <Comment> current state of the function block </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
-        <Comment> error code </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if error occurs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox" ReferenceTo="true">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
-        <Comment> parameter structure </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fTaskCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCtrlCycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutLocal</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bGetStartValue</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>768</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_RAMP_GENERATOR_EXT_PARAMS</Type>
-        <BitSize>192</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stInternalCycleTimeInterpretation</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_CYCLE_TIME_INTERPRETATION</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCtrlCycleTicks</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nActCtrlCycleTick</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1232</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>M_Error</Name>
-      </Action>
-      <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
-        <Name>M_Manual</Name>
-      </Action>
-      <Action>
-        <Name>M_Active</Name>
-      </Action>
-      <Action>
-        <Name>M_StateChange</Name>
-      </Action>
-      <Action>
-        <Name>M_Passive</Name>
-      </Action>
-      <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Name>
-      <BitSize>768</BitSize>
-      <SubItem>
-        <Name>eMode</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <Comment> operating mode </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tTaskCycleTime</Name>
-        <Type>TIME</Type>
-        <Comment> resolution  1ms</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bCycleTimeValid</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if cycle time is valid </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eState</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_STATE</Type>
-        <Comment> current state of the function block </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eErrorId</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_ERRORCODES</Type>
-        <Comment> error code </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE, if error occurs </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>184</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>nCpuCntLoDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCpuCntHiDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLastcpuCntLoDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLastcpuCntHiDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCycleTimeDW</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCycleTimeDWold</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>352</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCallReady</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGETCPUCOUNTER</Name>
-        <Type Namespace="Tc2_System">GETCPUCOUNTER</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eMode_old</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">E_CTRL_MODE</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
-        <Name>M_StateChange</Name>
-      </Action>
-      <Action>
-        <Name>M_Active</Name>
-      </Action>
-      <Action>
-        <Name>M_Passive</Name>
-      </Action>
-      <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PiezoControl</Name>
-      <BitSize>6720</BitSize>
-      <SubItem>
-        <Name>iq_Piezo</Name>
-        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xExecute</Name>
-        <Type>BOOL</Type>
-        <Comment>Rising edge being piezo motion</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable_Positive</Name>
-        <Type>BOOL</Type>
-        <Comment>Reverse of Positive Limit Switch</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable_Negative</Name>
-        <Type>BOOL</Type>
-        <Comment>Reverse of Negative Limit Switch</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xBusy</Name>
-        <Type>BOOL</Type>
-        <Comment>Busy remains true while piezo position is being adjusted</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xDone</Name>
-        <Type>BOOL</Type>
-        <Comment>Reached target position</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xError</Name>
-        <Type>BOOL</Type>
-        <Comment>General error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>xLimited</Name>
-        <Type>BOOL</Type>
-        <Comment>Piezo move was limited</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>E_State</Name>
-        <Type Namespace="lcls_twincat_optics">E_PiezoControl</Type>
-        <Comment>ENUM for Piezo Control State</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtStartMove</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <Comment>Rising Trigger for Execution</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <Comment>Rising Trigger for Error reset</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rSetpoint</Name>
-        <Type>REAL</Type>
-        <Comment>Internal Storage of Setpoint</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rReqVoltage</Name>
-        <Type>REAL</Type>
-        <Comment>requested voltage</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rLLSV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rHLSV</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>608</BitOffs>
-        <Default>
-          <Value>120</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbPI</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_PI</Type>
-        <BitSize>2240</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbRamp</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_RAMP_GENERATOR_EXT</Type>
-        <BitSize>1280</BitSize>
-        <BitOffs>2880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInitialized</Name>
-        <Type>BOOL</Type>
-        <Comment> FB initialized flag</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>4160</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCycleTime</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">FB_CTRL_GET_TASK_CYCLETIME</Type>
-        <Comment>Get cycle time for control FBs</Comment>
-        <BitSize>768</BitSize>
-        <BitOffs>4224</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tTaskCycleTime</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>4992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bCycleTimeValid</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>5024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtVoltMode</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>5056</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOut</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>5184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPiezoBias</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>5248</BitOffs>
-        <Default>
-          <Value>60</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fScale</Name>
-        <Type>REAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>5312</BitOffs>
-        <Default>
-          <Value>-60</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tonPiezoDone</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>5376</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#2S</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tonPiezoLimited</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>5632</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#500MS</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>xVoltageLimited</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>5888</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftEnPos</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>5952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftEnNeg</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtEnPos</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtEnNeg</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>6336</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutLimitHolder</Name>
-        <Type>LREAL</Type>
-        <Comment>holds the limit value until restored</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>6464</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutHiLimHolder</Name>
-        <Type>LREAL</Type>
-        <Comment>holds the limit value until restored</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>6528</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fOutLoLimHolder</Name>
-        <Type>LREAL</Type>
-        <Comment>holds the limit value until restored</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>6592</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFirstPass</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>6656</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>ACT_CheckLimits</Name>
-      </Action>
-      <Action>
-        <Name>ACT_Controller</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">E_PitchControl</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>PCM_Init</Text>
-        <Enum>0</Enum>
-        <Comment>Pitch Control Machine</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Standby</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_MoveRequested</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Coarse50Piezo</Text>
-        <Enum>20</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_CoarseMove</Text>
-        <Enum>21</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_CoarseMoveCleanup</Text>
-        <Enum>22</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_FineMove</Text>
-        <Enum>30</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Halt</Text>
-        <Enum>50</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Done</Text>
-        <Enum>8000</Enum>
-        <Comment>why is 8000 done? Where did this come from??</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_Error</Text>
-        <Enum>9000</Enum>
-        <Comment>Anything above 9000 is considered an error</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_StepperError</Text>
-        <Enum>9100</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_PiezoError</Text>
-        <Enum>9200</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_OtherError</Text>
-        <Enum>9300</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PCM_STOHit</Text>
-        <Enum>9400</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PitchControl</Name>
-      <BitSize>397888</BitSize>
-      <SubItem>
-        <Name>Pitch</Name>
-        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">HOMS_PitchMechanism</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Stepper</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>lrCurrentSetpoint</Name>
-        <Type>LREAL</Type>
-        <Comment> Setpoint: Epics writes to ST_MotionStage which gets fed into this</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_bDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>264</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>q_bBusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDiag</Name>
-        <Type Namespace="LCLS_General">ST_FbDiagnostics</Type>
-        <Comment> Logging</Comment>
-        <BitSize>49664</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbFormatString</Name>
-        <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>49984</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>POUName</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <Comment> Name of the POU for logging/error reporting</Comment>
-        <BitSize>2048</BitSize>
-        <BitOffs>58560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>no_init</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>lrActPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Actual Position of piezo mechanism</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60608</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrPrevStepperPos</Name>
-        <Type>LREAL</Type>
-        <Comment> Previous successfully achieved stepper position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftLimitSwitch</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>60736</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrOriginalPosRequest</Name>
-        <Type>LREAL</Type>
-        <Comment> Used for logging</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60864</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrLastSetpoint</Name>
-        <Type>LREAL</Type>
-        <Comment> Previous successfully achieved setpoint</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>60928</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
-        <BitSize>1920</BitSize>
-        <BitOffs>60992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionStage</Type>
-        <BitSize>327424</BitSize>
-        <BitOffs>62912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLimitHit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>390336</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonStepperHold</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Timer to hold stepper position while the system relaxes</Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>390400</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#100MS</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>rSettledRange</Name>
-        <Type>REAL</Type>
-        <Comment> Units = urad</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>390656</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bResetStepper</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>390688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteStepper</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>390696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_MotionRequest</Type>
-        <Comment> Wait for move to complete before taking another request</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>390704</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tonPiezoSettled</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Piezo</Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>390720</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.PT</Name>
-            <DateTime>T#2S</DateTime>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbPiezoControl</Name>
-        <Type Namespace="lcls_twincat_optics">FB_PiezoControl</Type>
-        <BitSize>6720</BitSize>
-        <BitOffs>390976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtPiezoMoveDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>397696</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>PC_State</Name>
-        <Type Namespace="lcls_twincat_optics">E_PitchControl</Type>
-        <Comment> State Machine</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>397824</BitOffs>
-        <Default>
-          <EnumText>E_PitchControl.PCM_Init</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bCoarse50PiezoMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>397840</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>ACT_ResetSetpoint</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{5356792D-144F-4F3E-8B04-D35060997D7C}" TcSmClass="TComPlcObjDef" TargetPlatform="TwinCAT RT (x64)">
@@ -72250,7 +72249,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72266,14 +72265,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779296</BitOffs>
+            <BitOffs>1296779424</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72287,14 +72286,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779488</BitOffs>
+            <BitOffs>1296779616</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72311,7 +72310,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294726784</BitOffs>
+            <BitOffs>1294726912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -72322,7 +72321,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294729296</BitOffs>
+            <BitOffs>1294729424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -72336,7 +72335,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305245792</BitOffs>
+            <BitOffs>1305245920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -72350,7 +72349,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305245824</BitOffs>
+            <BitOffs>1305245952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -72364,7 +72363,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305252992</BitOffs>
+            <BitOffs>1305253120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -72385,14 +72384,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253312</BitOffs>
+            <BitOffs>1305253440</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72403,14 +72402,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298241792</BitOffs>
+            <BitOffs>1298241920</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72512,7 +72511,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298240704</BitOffs>
+            <BitOffs>1298240832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -72526,7 +72525,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253024</BitOffs>
+            <BitOffs>1305253152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -72540,7 +72539,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253056</BitOffs>
+            <BitOffs>1305253184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -72561,62 +72560,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305254208</BitOffs>
+            <BitOffs>1305254336</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305253088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
-            <BitSize>32</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
-            <Properties>
-              <Property>
-                <Name>no_init</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305253120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
-            <BitSize>896</BitSize>
-            <BaseType>_Implicit_Task_Info</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.dwVersion</Name>
-                <Value>2</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcContextName</Name>
-                <Value>PiezoDriver</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305255104</BitOffs>
+            <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
+            <Comment>PI Serial</Comment>
+            <BitSize>112640</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
+            <BitOffs>1265714560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -72651,21 +72608,63 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1312780544</BitOffs>
+            <BitOffs>1294735168</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
-            <Comment>PI Serial</Comment>
-            <BitSize>112640</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1312800832</BitOffs>
+            <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305253216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
+            <BitSize>32</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+            <Properties>
+              <Property>
+                <Name>no_init</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305253248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
+            <BitSize>896</BitSize>
+            <BaseType>_Implicit_Task_Info</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.dwVersion</Name>
+                <Value>2</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcContextName</Name>
+                <Value>PiezoDriver</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1305255232</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72720,7 +72719,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72911,7 +72910,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#8ms</DateTime>
+              <DateTime>8</DateTime>
             </Default>
             <BitOffs>1264935328</BitOffs>
           </Symbol>
@@ -73141,7 +73140,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305247872</BitOffs>
+            <BitOffs>1305248000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -73155,7 +73154,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253152</BitOffs>
+            <BitOffs>1305253280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -73169,7 +73168,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253184</BitOffs>
+            <BitOffs>1305253312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -73190,14 +73189,165 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305256000</BitOffs>
+            <BitOffs>1305256128</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
+          <Symbol>
+            <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1264816064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
+            <Comment> STO Button</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274220416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274220424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
+            <Comment> Encoders</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274220480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274220608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274220736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274220864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274221632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274221760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274232384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274232512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1275471232</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -73420,6 +73570,144 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1276913976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
+            <Comment> STO Button</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
+            <Comment> Encoders</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282739904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282740672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282740800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282751424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282751552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283990272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74537,6 +74825,45 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1289652952</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290844800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290845312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290845888</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
             <Comment> RTD error bit</Comment>
             <BitSize>8</BitSize>
@@ -74643,6 +74970,32 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1292785112</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292785408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292785920</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
             <Comment> RTD error bit</Comment>
             <BitSize>8</BitSize>
@@ -74653,7 +75006,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725024</BitOffs>
+            <BitOffs>1294725088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -74665,7 +75018,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725032</BitOffs>
+            <BitOffs>1294725096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -74677,7 +75030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725040</BitOffs>
+            <BitOffs>1294725104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -74689,7 +75042,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725048</BitOffs>
+            <BitOffs>1294725112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -74713,7 +75066,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725256</BitOffs>
+            <BitOffs>1294725320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -74725,7 +75078,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725264</BitOffs>
+            <BitOffs>1294725328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -74737,7 +75090,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725272</BitOffs>
+            <BitOffs>1294725336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -74749,7 +75102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725280</BitOffs>
+            <BitOffs>1294725344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -74773,7 +75126,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725512</BitOffs>
+            <BitOffs>1294725576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -74785,7 +75138,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725520</BitOffs>
+            <BitOffs>1294725584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -74797,7 +75150,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725528</BitOffs>
+            <BitOffs>1294725592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -74809,7 +75162,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725536</BitOffs>
+            <BitOffs>1294725600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -74821,7 +75174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725568</BitOffs>
+            <BitOffs>1294725632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -74833,7 +75186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725576</BitOffs>
+            <BitOffs>1294725640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -74850,7 +75203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725584</BitOffs>
+            <BitOffs>1294725648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -74866,7 +75219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725592</BitOffs>
+            <BitOffs>1294725656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -74886,7 +75239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294725600</BitOffs>
+            <BitOffs>1294725664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -74905,7 +75258,33 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294725616</BitOffs>
+            <BitOffs>1294725680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294725952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294726464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -74924,7 +75303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731808</BitOffs>
+            <BitOffs>1294731936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -74944,7 +75323,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731824</BitOffs>
+            <BitOffs>1294731952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294734400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -74963,7 +75355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734720</BitOffs>
+            <BitOffs>1294734848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -74982,7 +75374,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734736</BitOffs>
+            <BitOffs>1294734864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -75002,7 +75394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734752</BitOffs>
+            <BitOffs>1294734880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -75021,7 +75413,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734768</BitOffs>
+            <BitOffs>1294734896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294737600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -75040,7 +75445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738048</BitOffs>
+            <BitOffs>1294738176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -75060,7 +75465,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738064</BitOffs>
+            <BitOffs>1294738192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -75079,7 +75484,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738080</BitOffs>
+            <BitOffs>1294738208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -75098,7 +75503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738096</BitOffs>
+            <BitOffs>1294738224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -75118,7 +75523,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738688</BitOffs>
+            <BitOffs>1294738816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -75137,7 +75542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738704</BitOffs>
+            <BitOffs>1294738832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -75156,7 +75561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738720</BitOffs>
+            <BitOffs>1294738848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -75176,7 +75581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738736</BitOffs>
+            <BitOffs>1294738864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -75195,7 +75600,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738752</BitOffs>
+            <BitOffs>1294738880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -75214,7 +75619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738768</BitOffs>
+            <BitOffs>1294738896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -75229,7 +75634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779680</BitOffs>
+            <BitOffs>1296779808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -75244,7 +75649,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779696</BitOffs>
+            <BitOffs>1296779824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -75256,7 +75661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296780800</BitOffs>
+            <BitOffs>1296780928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -75269,7 +75674,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788736</BitOffs>
+            <BitOffs>1296788864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -75282,7 +75687,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788744</BitOffs>
+            <BitOffs>1296788872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -75295,7 +75700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788752</BitOffs>
+            <BitOffs>1296788880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -75318,7 +75723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788768</BitOffs>
+            <BitOffs>1296788896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -75331,7 +75736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788800</BitOffs>
+            <BitOffs>1296788928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -75344,7 +75749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788864</BitOffs>
+            <BitOffs>1296788992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -75357,7 +75762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788880</BitOffs>
+            <BitOffs>1296789008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75369,7 +75774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296807552</BitOffs>
+            <BitOffs>1296807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -75381,7 +75786,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297133440</BitOffs>
+            <BitOffs>1297133568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -75394,7 +75799,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141376</BitOffs>
+            <BitOffs>1297141504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -75407,7 +75812,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141384</BitOffs>
+            <BitOffs>1297141512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -75420,7 +75825,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141392</BitOffs>
+            <BitOffs>1297141520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -75443,7 +75848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141408</BitOffs>
+            <BitOffs>1297141536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -75456,7 +75861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141440</BitOffs>
+            <BitOffs>1297141568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -75469,7 +75874,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141504</BitOffs>
+            <BitOffs>1297141632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -75482,7 +75887,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141520</BitOffs>
+            <BitOffs>1297141648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75494,7 +75899,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297160192</BitOffs>
+            <BitOffs>1297160320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -75506,7 +75911,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297486080</BitOffs>
+            <BitOffs>1297486208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -75519,7 +75924,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494016</BitOffs>
+            <BitOffs>1297494144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -75532,7 +75937,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494024</BitOffs>
+            <BitOffs>1297494152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -75545,7 +75950,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494032</BitOffs>
+            <BitOffs>1297494160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -75568,7 +75973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494048</BitOffs>
+            <BitOffs>1297494176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -75581,7 +75986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494080</BitOffs>
+            <BitOffs>1297494208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -75594,7 +75999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494144</BitOffs>
+            <BitOffs>1297494272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -75607,7 +76012,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494160</BitOffs>
+            <BitOffs>1297494288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75619,7 +76024,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297512832</BitOffs>
+            <BitOffs>1297512960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -75631,7 +76036,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297838720</BitOffs>
+            <BitOffs>1297838848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -75644,7 +76049,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846656</BitOffs>
+            <BitOffs>1297846784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -75657,7 +76062,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846664</BitOffs>
+            <BitOffs>1297846792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -75670,7 +76075,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846672</BitOffs>
+            <BitOffs>1297846800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -75693,7 +76098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846688</BitOffs>
+            <BitOffs>1297846816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -75706,7 +76111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846720</BitOffs>
+            <BitOffs>1297846848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -75719,7 +76124,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846784</BitOffs>
+            <BitOffs>1297846912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -75732,7 +76137,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846800</BitOffs>
+            <BitOffs>1297846928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75744,7 +76149,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297865472</BitOffs>
+            <BitOffs>1297865600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -75756,7 +76161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298191360</BitOffs>
+            <BitOffs>1298191488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -75769,7 +76174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199296</BitOffs>
+            <BitOffs>1298199424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -75782,7 +76187,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199304</BitOffs>
+            <BitOffs>1298199432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -75795,7 +76200,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199312</BitOffs>
+            <BitOffs>1298199440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -75818,7 +76223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199328</BitOffs>
+            <BitOffs>1298199456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -75831,7 +76236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199360</BitOffs>
+            <BitOffs>1298199488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -75844,7 +76249,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199424</BitOffs>
+            <BitOffs>1298199552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -75857,7 +76262,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199440</BitOffs>
+            <BitOffs>1298199568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -75869,7 +76274,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298216576</BitOffs>
+            <BitOffs>1298216704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -75882,7 +76287,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224512</BitOffs>
+            <BitOffs>1298224640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -75895,7 +76300,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224520</BitOffs>
+            <BitOffs>1298224648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -75908,7 +76313,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224528</BitOffs>
+            <BitOffs>1298224656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -75931,7 +76336,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224544</BitOffs>
+            <BitOffs>1298224672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -75944,7 +76349,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224576</BitOffs>
+            <BitOffs>1298224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -75957,7 +76362,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224640</BitOffs>
+            <BitOffs>1298224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -75970,7 +76375,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224656</BitOffs>
+            <BitOffs>1298224784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -75983,7 +76388,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249728</BitOffs>
+            <BitOffs>1298249856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -75996,7 +76401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249736</BitOffs>
+            <BitOffs>1298249864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -76009,7 +76414,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249744</BitOffs>
+            <BitOffs>1298249872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -76032,7 +76437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249760</BitOffs>
+            <BitOffs>1298249888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -76045,7 +76450,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249792</BitOffs>
+            <BitOffs>1298249920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -76058,7 +76463,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249856</BitOffs>
+            <BitOffs>1298249984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -76071,7 +76476,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249872</BitOffs>
+            <BitOffs>1298250000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -76083,7 +76488,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298267008</BitOffs>
+            <BitOffs>1298267136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -76096,7 +76501,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298274944</BitOffs>
+            <BitOffs>1298275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -76109,7 +76514,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298274952</BitOffs>
+            <BitOffs>1298275080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -76122,7 +76527,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298274960</BitOffs>
+            <BitOffs>1298275088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -76145,7 +76550,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298274976</BitOffs>
+            <BitOffs>1298275104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -76158,7 +76563,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275008</BitOffs>
+            <BitOffs>1298275136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -76171,7 +76576,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275072</BitOffs>
+            <BitOffs>1298275200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -76184,7 +76589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275088</BitOffs>
+            <BitOffs>1298275216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -76196,7 +76601,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298292224</BitOffs>
+            <BitOffs>1298292352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -76209,7 +76614,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300160</BitOffs>
+            <BitOffs>1298300288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -76222,7 +76627,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300168</BitOffs>
+            <BitOffs>1298300296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -76235,7 +76640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300176</BitOffs>
+            <BitOffs>1298300304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -76258,7 +76663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300192</BitOffs>
+            <BitOffs>1298300320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -76271,7 +76676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300224</BitOffs>
+            <BitOffs>1298300352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -76284,7 +76689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300288</BitOffs>
+            <BitOffs>1298300416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -76297,7 +76702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300304</BitOffs>
+            <BitOffs>1298300432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -76309,7 +76714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298317440</BitOffs>
+            <BitOffs>1298317568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -76322,7 +76727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325376</BitOffs>
+            <BitOffs>1298325504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -76335,7 +76740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325384</BitOffs>
+            <BitOffs>1298325512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -76348,7 +76753,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325392</BitOffs>
+            <BitOffs>1298325520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -76371,7 +76776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325408</BitOffs>
+            <BitOffs>1298325536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -76384,7 +76789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325440</BitOffs>
+            <BitOffs>1298325568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -76397,7 +76802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325504</BitOffs>
+            <BitOffs>1298325632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -76410,7 +76815,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325520</BitOffs>
+            <BitOffs>1298325648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -76422,7 +76827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298342656</BitOffs>
+            <BitOffs>1298342784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -76435,7 +76840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350592</BitOffs>
+            <BitOffs>1298350720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -76448,7 +76853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350600</BitOffs>
+            <BitOffs>1298350728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -76461,7 +76866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350608</BitOffs>
+            <BitOffs>1298350736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -76484,7 +76889,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350624</BitOffs>
+            <BitOffs>1298350752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -76497,7 +76902,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350656</BitOffs>
+            <BitOffs>1298350784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -76510,7 +76915,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350720</BitOffs>
+            <BitOffs>1298350848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -76523,7 +76928,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350736</BitOffs>
+            <BitOffs>1298350864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -76535,7 +76940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298367872</BitOffs>
+            <BitOffs>1298368000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -76548,7 +76953,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375808</BitOffs>
+            <BitOffs>1298375936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -76561,7 +76966,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375816</BitOffs>
+            <BitOffs>1298375944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -76574,7 +76979,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375824</BitOffs>
+            <BitOffs>1298375952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -76597,7 +77002,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375840</BitOffs>
+            <BitOffs>1298375968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -76610,7 +77015,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375872</BitOffs>
+            <BitOffs>1298376000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -76623,7 +77028,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375936</BitOffs>
+            <BitOffs>1298376064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -76636,7 +77041,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375952</BitOffs>
+            <BitOffs>1298376080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76648,7 +77053,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298394624</BitOffs>
+            <BitOffs>1298394752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -76660,7 +77065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298720512</BitOffs>
+            <BitOffs>1298720640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -76673,7 +77078,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728448</BitOffs>
+            <BitOffs>1298728576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -76686,7 +77091,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728456</BitOffs>
+            <BitOffs>1298728584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -76699,7 +77104,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728464</BitOffs>
+            <BitOffs>1298728592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -76722,7 +77127,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728480</BitOffs>
+            <BitOffs>1298728608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -76735,7 +77140,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728512</BitOffs>
+            <BitOffs>1298728640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -76748,7 +77153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728576</BitOffs>
+            <BitOffs>1298728704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -76761,7 +77166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728592</BitOffs>
+            <BitOffs>1298728720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76773,7 +77178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298747264</BitOffs>
+            <BitOffs>1298747392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -76785,7 +77190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299073152</BitOffs>
+            <BitOffs>1299073280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -76798,7 +77203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081088</BitOffs>
+            <BitOffs>1299081216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -76811,7 +77216,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081096</BitOffs>
+            <BitOffs>1299081224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -76824,7 +77229,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081104</BitOffs>
+            <BitOffs>1299081232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -76847,7 +77252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081120</BitOffs>
+            <BitOffs>1299081248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -76860,7 +77265,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081152</BitOffs>
+            <BitOffs>1299081280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -76873,7 +77278,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081216</BitOffs>
+            <BitOffs>1299081344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -76886,7 +77291,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081232</BitOffs>
+            <BitOffs>1299081360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76898,7 +77303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299099904</BitOffs>
+            <BitOffs>1299100032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -76910,7 +77315,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299425792</BitOffs>
+            <BitOffs>1299425920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -76923,7 +77328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433728</BitOffs>
+            <BitOffs>1299433856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -76936,7 +77341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433736</BitOffs>
+            <BitOffs>1299433864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -76949,7 +77354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433744</BitOffs>
+            <BitOffs>1299433872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -76972,7 +77377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433760</BitOffs>
+            <BitOffs>1299433888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -76985,7 +77390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433792</BitOffs>
+            <BitOffs>1299433920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -76998,7 +77403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433856</BitOffs>
+            <BitOffs>1299433984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -77011,7 +77416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433872</BitOffs>
+            <BitOffs>1299434000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77023,7 +77428,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299452544</BitOffs>
+            <BitOffs>1299452672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -77035,7 +77440,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299778432</BitOffs>
+            <BitOffs>1299778560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -77048,7 +77453,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786368</BitOffs>
+            <BitOffs>1299786496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -77061,7 +77466,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786376</BitOffs>
+            <BitOffs>1299786504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -77074,7 +77479,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786384</BitOffs>
+            <BitOffs>1299786512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -77097,7 +77502,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786400</BitOffs>
+            <BitOffs>1299786528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -77110,7 +77515,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786432</BitOffs>
+            <BitOffs>1299786560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -77123,7 +77528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786496</BitOffs>
+            <BitOffs>1299786624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -77136,7 +77541,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786512</BitOffs>
+            <BitOffs>1299786640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -77148,7 +77553,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299803648</BitOffs>
+            <BitOffs>1299803776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -77161,7 +77566,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811584</BitOffs>
+            <BitOffs>1299811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -77174,7 +77579,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811592</BitOffs>
+            <BitOffs>1299811720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -77187,7 +77592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811600</BitOffs>
+            <BitOffs>1299811728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -77210,7 +77615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811616</BitOffs>
+            <BitOffs>1299811744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -77223,7 +77628,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811648</BitOffs>
+            <BitOffs>1299811776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -77236,7 +77641,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811712</BitOffs>
+            <BitOffs>1299811840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -77249,7 +77654,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811728</BitOffs>
+            <BitOffs>1299811856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77261,7 +77666,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299830400</BitOffs>
+            <BitOffs>1299830528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -77273,7 +77678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300156288</BitOffs>
+            <BitOffs>1300156416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -77286,7 +77691,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164224</BitOffs>
+            <BitOffs>1300164352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -77299,7 +77704,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164232</BitOffs>
+            <BitOffs>1300164360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -77312,7 +77717,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164240</BitOffs>
+            <BitOffs>1300164368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -77335,7 +77740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164256</BitOffs>
+            <BitOffs>1300164384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -77348,7 +77753,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164288</BitOffs>
+            <BitOffs>1300164416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -77361,7 +77766,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164352</BitOffs>
+            <BitOffs>1300164480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -77374,7 +77779,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164368</BitOffs>
+            <BitOffs>1300164496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77386,7 +77791,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300183040</BitOffs>
+            <BitOffs>1300183168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -77398,7 +77803,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300508928</BitOffs>
+            <BitOffs>1300509056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -77411,7 +77816,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516864</BitOffs>
+            <BitOffs>1300516992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -77424,7 +77829,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516872</BitOffs>
+            <BitOffs>1300517000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -77437,7 +77842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516880</BitOffs>
+            <BitOffs>1300517008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -77460,7 +77865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516896</BitOffs>
+            <BitOffs>1300517024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -77473,7 +77878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516928</BitOffs>
+            <BitOffs>1300517056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -77486,7 +77891,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516992</BitOffs>
+            <BitOffs>1300517120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -77499,7 +77904,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517008</BitOffs>
+            <BitOffs>1300517136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -77511,7 +77916,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300534144</BitOffs>
+            <BitOffs>1300534272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -77524,7 +77929,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542080</BitOffs>
+            <BitOffs>1300542208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -77537,7 +77942,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542088</BitOffs>
+            <BitOffs>1300542216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -77550,7 +77955,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542096</BitOffs>
+            <BitOffs>1300542224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -77573,7 +77978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542112</BitOffs>
+            <BitOffs>1300542240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -77586,7 +77991,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542144</BitOffs>
+            <BitOffs>1300542272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -77599,7 +78004,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542208</BitOffs>
+            <BitOffs>1300542336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -77612,7 +78017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542224</BitOffs>
+            <BitOffs>1300542352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -77624,7 +78029,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300559360</BitOffs>
+            <BitOffs>1300559488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -77637,7 +78042,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567296</BitOffs>
+            <BitOffs>1300567424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -77650,7 +78055,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567304</BitOffs>
+            <BitOffs>1300567432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -77663,7 +78068,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567312</BitOffs>
+            <BitOffs>1300567440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -77686,7 +78091,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567328</BitOffs>
+            <BitOffs>1300567456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -77699,7 +78104,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567360</BitOffs>
+            <BitOffs>1300567488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -77712,7 +78117,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567424</BitOffs>
+            <BitOffs>1300567552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -77725,7 +78130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567440</BitOffs>
+            <BitOffs>1300567568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -77737,7 +78142,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300584576</BitOffs>
+            <BitOffs>1300584704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -77750,7 +78155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592512</BitOffs>
+            <BitOffs>1300592640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -77763,7 +78168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592520</BitOffs>
+            <BitOffs>1300592648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -77776,7 +78181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592528</BitOffs>
+            <BitOffs>1300592656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -77799,7 +78204,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592544</BitOffs>
+            <BitOffs>1300592672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -77812,7 +78217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592576</BitOffs>
+            <BitOffs>1300592704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -77825,7 +78230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592640</BitOffs>
+            <BitOffs>1300592768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -77838,7 +78243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592656</BitOffs>
+            <BitOffs>1300592784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -77850,7 +78255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300609792</BitOffs>
+            <BitOffs>1300609920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -77863,7 +78268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617728</BitOffs>
+            <BitOffs>1300617856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -77876,7 +78281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617736</BitOffs>
+            <BitOffs>1300617864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -77889,7 +78294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617744</BitOffs>
+            <BitOffs>1300617872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -77912,7 +78317,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617760</BitOffs>
+            <BitOffs>1300617888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -77925,7 +78330,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617792</BitOffs>
+            <BitOffs>1300617920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -77938,7 +78343,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617856</BitOffs>
+            <BitOffs>1300617984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -77951,7 +78356,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617872</BitOffs>
+            <BitOffs>1300618000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -77963,7 +78368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300635008</BitOffs>
+            <BitOffs>1300635136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -77976,7 +78381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300642944</BitOffs>
+            <BitOffs>1300643072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -77989,7 +78394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300642952</BitOffs>
+            <BitOffs>1300643080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -78002,7 +78407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300642960</BitOffs>
+            <BitOffs>1300643088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -78025,7 +78430,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300642976</BitOffs>
+            <BitOffs>1300643104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -78038,7 +78443,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643008</BitOffs>
+            <BitOffs>1300643136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -78051,7 +78456,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643072</BitOffs>
+            <BitOffs>1300643200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -78064,7 +78469,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643088</BitOffs>
+            <BitOffs>1300643216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -78076,7 +78481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300660224</BitOffs>
+            <BitOffs>1300660352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -78089,7 +78494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668160</BitOffs>
+            <BitOffs>1300668288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -78102,7 +78507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668168</BitOffs>
+            <BitOffs>1300668296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -78115,7 +78520,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668176</BitOffs>
+            <BitOffs>1300668304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -78138,7 +78543,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668192</BitOffs>
+            <BitOffs>1300668320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -78151,7 +78556,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668224</BitOffs>
+            <BitOffs>1300668352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -78164,7 +78569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668288</BitOffs>
+            <BitOffs>1300668416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -78177,7 +78582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668304</BitOffs>
+            <BitOffs>1300668432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78189,7 +78594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300686976</BitOffs>
+            <BitOffs>1300687104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -78201,7 +78606,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301012864</BitOffs>
+            <BitOffs>1301012992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -78214,7 +78619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020800</BitOffs>
+            <BitOffs>1301020928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -78227,7 +78632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020808</BitOffs>
+            <BitOffs>1301020936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -78240,7 +78645,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020816</BitOffs>
+            <BitOffs>1301020944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -78263,7 +78668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020832</BitOffs>
+            <BitOffs>1301020960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -78276,7 +78681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020864</BitOffs>
+            <BitOffs>1301020992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -78289,7 +78694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020928</BitOffs>
+            <BitOffs>1301021056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -78302,7 +78707,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020944</BitOffs>
+            <BitOffs>1301021072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78314,7 +78719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301039616</BitOffs>
+            <BitOffs>1301039744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -78326,7 +78731,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301365504</BitOffs>
+            <BitOffs>1301365632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -78339,7 +78744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373440</BitOffs>
+            <BitOffs>1301373568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -78352,7 +78757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373448</BitOffs>
+            <BitOffs>1301373576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -78365,7 +78770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373456</BitOffs>
+            <BitOffs>1301373584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -78388,7 +78793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373472</BitOffs>
+            <BitOffs>1301373600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -78401,7 +78806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373504</BitOffs>
+            <BitOffs>1301373632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -78414,7 +78819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373568</BitOffs>
+            <BitOffs>1301373696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -78427,7 +78832,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373584</BitOffs>
+            <BitOffs>1301373712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78439,7 +78844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301392256</BitOffs>
+            <BitOffs>1301392384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -78451,7 +78856,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301718144</BitOffs>
+            <BitOffs>1301718272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -78464,7 +78869,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726080</BitOffs>
+            <BitOffs>1301726208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -78477,7 +78882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726088</BitOffs>
+            <BitOffs>1301726216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -78490,7 +78895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726096</BitOffs>
+            <BitOffs>1301726224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -78513,7 +78918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726112</BitOffs>
+            <BitOffs>1301726240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -78526,7 +78931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726144</BitOffs>
+            <BitOffs>1301726272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -78539,7 +78944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726208</BitOffs>
+            <BitOffs>1301726336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -78552,7 +78957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726224</BitOffs>
+            <BitOffs>1301726352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78564,7 +78969,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301744896</BitOffs>
+            <BitOffs>1301745024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -78576,7 +78981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302070784</BitOffs>
+            <BitOffs>1302070912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -78589,7 +78994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078720</BitOffs>
+            <BitOffs>1302078848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -78602,7 +79007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078728</BitOffs>
+            <BitOffs>1302078856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -78615,7 +79020,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078736</BitOffs>
+            <BitOffs>1302078864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -78638,7 +79043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078752</BitOffs>
+            <BitOffs>1302078880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -78651,7 +79056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078784</BitOffs>
+            <BitOffs>1302078912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -78664,7 +79069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078848</BitOffs>
+            <BitOffs>1302078976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -78677,7 +79082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078864</BitOffs>
+            <BitOffs>1302078992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78689,7 +79094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302097536</BitOffs>
+            <BitOffs>1302097664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -78701,7 +79106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302423424</BitOffs>
+            <BitOffs>1302423552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -78714,7 +79119,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431360</BitOffs>
+            <BitOffs>1302431488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -78727,7 +79132,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431368</BitOffs>
+            <BitOffs>1302431496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -78740,7 +79145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431376</BitOffs>
+            <BitOffs>1302431504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -78763,7 +79168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431392</BitOffs>
+            <BitOffs>1302431520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -78776,7 +79181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431424</BitOffs>
+            <BitOffs>1302431552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -78789,7 +79194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431488</BitOffs>
+            <BitOffs>1302431616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -78802,7 +79207,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431504</BitOffs>
+            <BitOffs>1302431632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78814,7 +79219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302450176</BitOffs>
+            <BitOffs>1302450304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -78826,7 +79231,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302776064</BitOffs>
+            <BitOffs>1302776192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -78839,7 +79244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784000</BitOffs>
+            <BitOffs>1302784128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -78852,7 +79257,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784008</BitOffs>
+            <BitOffs>1302784136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -78865,7 +79270,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784016</BitOffs>
+            <BitOffs>1302784144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -78888,7 +79293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784032</BitOffs>
+            <BitOffs>1302784160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -78901,7 +79306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784064</BitOffs>
+            <BitOffs>1302784192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -78914,7 +79319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784128</BitOffs>
+            <BitOffs>1302784256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -78927,7 +79332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784144</BitOffs>
+            <BitOffs>1302784272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78939,7 +79344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302802816</BitOffs>
+            <BitOffs>1302802944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -78951,7 +79356,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303128704</BitOffs>
+            <BitOffs>1303128832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -78964,7 +79369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136640</BitOffs>
+            <BitOffs>1303136768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -78977,7 +79382,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136648</BitOffs>
+            <BitOffs>1303136776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -78990,7 +79395,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136656</BitOffs>
+            <BitOffs>1303136784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -79013,7 +79418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136672</BitOffs>
+            <BitOffs>1303136800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -79026,7 +79431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136704</BitOffs>
+            <BitOffs>1303136832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -79039,7 +79444,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136768</BitOffs>
+            <BitOffs>1303136896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -79052,7 +79457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136784</BitOffs>
+            <BitOffs>1303136912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79064,7 +79469,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303155456</BitOffs>
+            <BitOffs>1303155584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -79076,7 +79481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303481344</BitOffs>
+            <BitOffs>1303481472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -79089,7 +79494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489280</BitOffs>
+            <BitOffs>1303489408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -79102,7 +79507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489288</BitOffs>
+            <BitOffs>1303489416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -79115,7 +79520,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489296</BitOffs>
+            <BitOffs>1303489424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -79138,7 +79543,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489312</BitOffs>
+            <BitOffs>1303489440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -79151,7 +79556,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489344</BitOffs>
+            <BitOffs>1303489472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -79164,7 +79569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489408</BitOffs>
+            <BitOffs>1303489536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -79177,7 +79582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489424</BitOffs>
+            <BitOffs>1303489552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79189,7 +79594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303508096</BitOffs>
+            <BitOffs>1303508224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -79201,7 +79606,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303833984</BitOffs>
+            <BitOffs>1303834112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -79214,7 +79619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303841920</BitOffs>
+            <BitOffs>1303842048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -79227,7 +79632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303841928</BitOffs>
+            <BitOffs>1303842056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -79240,7 +79645,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303841936</BitOffs>
+            <BitOffs>1303842064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -79263,7 +79668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303841952</BitOffs>
+            <BitOffs>1303842080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -79276,7 +79681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303841984</BitOffs>
+            <BitOffs>1303842112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -79289,7 +79694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842048</BitOffs>
+            <BitOffs>1303842176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -79302,7 +79707,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842064</BitOffs>
+            <BitOffs>1303842192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79314,7 +79719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303860736</BitOffs>
+            <BitOffs>1303860864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -79326,7 +79731,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304186624</BitOffs>
+            <BitOffs>1304186752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -79339,7 +79744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194560</BitOffs>
+            <BitOffs>1304194688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -79352,7 +79757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194568</BitOffs>
+            <BitOffs>1304194696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -79365,7 +79770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194576</BitOffs>
+            <BitOffs>1304194704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -79388,7 +79793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194592</BitOffs>
+            <BitOffs>1304194720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -79401,7 +79806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194624</BitOffs>
+            <BitOffs>1304194752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -79414,7 +79819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194688</BitOffs>
+            <BitOffs>1304194816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -79427,7 +79832,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194704</BitOffs>
+            <BitOffs>1304194832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79439,7 +79844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304213376</BitOffs>
+            <BitOffs>1304213504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -79451,7 +79856,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304539264</BitOffs>
+            <BitOffs>1304539392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -79464,7 +79869,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547200</BitOffs>
+            <BitOffs>1304547328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -79477,7 +79882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547208</BitOffs>
+            <BitOffs>1304547336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -79490,7 +79895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547216</BitOffs>
+            <BitOffs>1304547344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -79513,7 +79918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547232</BitOffs>
+            <BitOffs>1304547360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -79526,7 +79931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547264</BitOffs>
+            <BitOffs>1304547392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -79539,7 +79944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547328</BitOffs>
+            <BitOffs>1304547456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -79552,7 +79957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547344</BitOffs>
+            <BitOffs>1304547472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79564,7 +79969,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304566016</BitOffs>
+            <BitOffs>1304566144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -79576,7 +79981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304891904</BitOffs>
+            <BitOffs>1304892032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -79589,7 +79994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899840</BitOffs>
+            <BitOffs>1304899968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -79602,7 +80007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899848</BitOffs>
+            <BitOffs>1304899976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -79615,7 +80020,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899856</BitOffs>
+            <BitOffs>1304899984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -79638,7 +80043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899872</BitOffs>
+            <BitOffs>1304900000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -79651,7 +80056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899904</BitOffs>
+            <BitOffs>1304900032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -79664,7 +80069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899968</BitOffs>
+            <BitOffs>1304900096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -79677,7 +80082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899984</BitOffs>
+            <BitOffs>1304900112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79689,420 +80094,26 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304918656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310867584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310867904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310868416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310868992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310869696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310870208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable1</Name>
-            <Comment> STO Button</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310873728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.bSTOEnable2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310873736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYupEnc</Name>
-            <Comment> Encoders</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310873792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stYdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310873920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310874048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310874176</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310874944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310875072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310885696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310885824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312711872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312712384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
-            <Comment> STO Button</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312731136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312731144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
-            <Comment> Encoders</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312731200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312731328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312731456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312731584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312732352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312732480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312743104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312743232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312755904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312782976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314690304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1317025792</BitOffs>
+            <BitOffs>1304918784</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1275470208</BitOffs>
+          </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -80232,6 +80243,18 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1276136480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283989248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80592,7 +80615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295730856</BitOffs>
+            <BitOffs>1295730984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -80612,7 +80635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296255208</BitOffs>
+            <BitOffs>1296255336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -80624,7 +80647,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296779776</BitOffs>
+            <BitOffs>1296779904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -80637,7 +80660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788760</BitOffs>
+            <BitOffs>1296788888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80649,7 +80672,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296806528</BitOffs>
+            <BitOffs>1296806656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -80661,7 +80684,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297132416</BitOffs>
+            <BitOffs>1297132544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -80674,7 +80697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141400</BitOffs>
+            <BitOffs>1297141528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80686,7 +80709,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297159168</BitOffs>
+            <BitOffs>1297159296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -80698,7 +80721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297485056</BitOffs>
+            <BitOffs>1297485184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -80711,7 +80734,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494040</BitOffs>
+            <BitOffs>1297494168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80723,7 +80746,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297511808</BitOffs>
+            <BitOffs>1297511936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -80735,7 +80758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297837696</BitOffs>
+            <BitOffs>1297837824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -80748,7 +80771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846680</BitOffs>
+            <BitOffs>1297846808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80760,7 +80783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297864448</BitOffs>
+            <BitOffs>1297864576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -80772,7 +80795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298190336</BitOffs>
+            <BitOffs>1298190464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -80785,7 +80808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199320</BitOffs>
+            <BitOffs>1298199448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -80797,7 +80820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298215552</BitOffs>
+            <BitOffs>1298215680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -80810,7 +80833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224536</BitOffs>
+            <BitOffs>1298224664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -80822,7 +80845,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298240768</BitOffs>
+            <BitOffs>1298240896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -80835,7 +80858,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249752</BitOffs>
+            <BitOffs>1298249880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -80847,7 +80870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298265984</BitOffs>
+            <BitOffs>1298266112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -80860,7 +80883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298274968</BitOffs>
+            <BitOffs>1298275096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -80872,7 +80895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298291200</BitOffs>
+            <BitOffs>1298291328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -80885,7 +80908,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300184</BitOffs>
+            <BitOffs>1298300312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -80897,7 +80920,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298316416</BitOffs>
+            <BitOffs>1298316544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -80910,7 +80933,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325400</BitOffs>
+            <BitOffs>1298325528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -80922,7 +80945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298341632</BitOffs>
+            <BitOffs>1298341760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -80935,7 +80958,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350616</BitOffs>
+            <BitOffs>1298350744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -80947,7 +80970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298366848</BitOffs>
+            <BitOffs>1298366976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -80960,7 +80983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375832</BitOffs>
+            <BitOffs>1298375960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80972,7 +80995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298393600</BitOffs>
+            <BitOffs>1298393728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -80984,7 +81007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298719488</BitOffs>
+            <BitOffs>1298719616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -80997,7 +81020,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728472</BitOffs>
+            <BitOffs>1298728600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81009,7 +81032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298746240</BitOffs>
+            <BitOffs>1298746368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -81021,7 +81044,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299072128</BitOffs>
+            <BitOffs>1299072256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -81034,7 +81057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081112</BitOffs>
+            <BitOffs>1299081240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81046,7 +81069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299098880</BitOffs>
+            <BitOffs>1299099008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -81058,7 +81081,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299424768</BitOffs>
+            <BitOffs>1299424896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -81071,7 +81094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433752</BitOffs>
+            <BitOffs>1299433880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81083,7 +81106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299451520</BitOffs>
+            <BitOffs>1299451648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -81095,7 +81118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299777408</BitOffs>
+            <BitOffs>1299777536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -81108,7 +81131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786392</BitOffs>
+            <BitOffs>1299786520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -81120,7 +81143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299802624</BitOffs>
+            <BitOffs>1299802752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -81133,7 +81156,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811608</BitOffs>
+            <BitOffs>1299811736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81145,7 +81168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299829376</BitOffs>
+            <BitOffs>1299829504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -81157,7 +81180,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300155264</BitOffs>
+            <BitOffs>1300155392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -81170,7 +81193,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164248</BitOffs>
+            <BitOffs>1300164376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81182,7 +81205,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300182016</BitOffs>
+            <BitOffs>1300182144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -81194,7 +81217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300507904</BitOffs>
+            <BitOffs>1300508032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -81207,7 +81230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516888</BitOffs>
+            <BitOffs>1300517016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -81219,7 +81242,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300533120</BitOffs>
+            <BitOffs>1300533248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -81232,7 +81255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542104</BitOffs>
+            <BitOffs>1300542232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -81244,7 +81267,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300558336</BitOffs>
+            <BitOffs>1300558464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -81257,7 +81280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567320</BitOffs>
+            <BitOffs>1300567448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -81269,7 +81292,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300583552</BitOffs>
+            <BitOffs>1300583680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -81282,7 +81305,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592536</BitOffs>
+            <BitOffs>1300592664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -81294,7 +81317,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608768</BitOffs>
+            <BitOffs>1300608896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -81307,7 +81330,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617752</BitOffs>
+            <BitOffs>1300617880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -81319,7 +81342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300633984</BitOffs>
+            <BitOffs>1300634112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -81332,7 +81355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300642968</BitOffs>
+            <BitOffs>1300643096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -81344,7 +81367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300659200</BitOffs>
+            <BitOffs>1300659328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -81357,7 +81380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668184</BitOffs>
+            <BitOffs>1300668312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81369,7 +81392,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300685952</BitOffs>
+            <BitOffs>1300686080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -81381,7 +81404,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301011840</BitOffs>
+            <BitOffs>1301011968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -81394,7 +81417,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020824</BitOffs>
+            <BitOffs>1301020952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81406,7 +81429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301038592</BitOffs>
+            <BitOffs>1301038720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -81418,7 +81441,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301364480</BitOffs>
+            <BitOffs>1301364608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -81431,7 +81454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373464</BitOffs>
+            <BitOffs>1301373592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81443,7 +81466,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301391232</BitOffs>
+            <BitOffs>1301391360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -81455,7 +81478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301717120</BitOffs>
+            <BitOffs>1301717248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -81468,7 +81491,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726104</BitOffs>
+            <BitOffs>1301726232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81480,7 +81503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301743872</BitOffs>
+            <BitOffs>1301744000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -81492,7 +81515,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302069760</BitOffs>
+            <BitOffs>1302069888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -81505,7 +81528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078744</BitOffs>
+            <BitOffs>1302078872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81517,7 +81540,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302096512</BitOffs>
+            <BitOffs>1302096640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -81529,7 +81552,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302422400</BitOffs>
+            <BitOffs>1302422528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -81542,7 +81565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431384</BitOffs>
+            <BitOffs>1302431512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81554,7 +81577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449152</BitOffs>
+            <BitOffs>1302449280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -81566,7 +81589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302775040</BitOffs>
+            <BitOffs>1302775168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -81579,7 +81602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784024</BitOffs>
+            <BitOffs>1302784152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81591,7 +81614,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302801792</BitOffs>
+            <BitOffs>1302801920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -81603,7 +81626,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303127680</BitOffs>
+            <BitOffs>1303127808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -81616,7 +81639,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136664</BitOffs>
+            <BitOffs>1303136792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81628,7 +81651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303154432</BitOffs>
+            <BitOffs>1303154560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -81640,7 +81663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303480320</BitOffs>
+            <BitOffs>1303480448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -81653,7 +81676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489304</BitOffs>
+            <BitOffs>1303489432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81665,7 +81688,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303507072</BitOffs>
+            <BitOffs>1303507200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -81677,7 +81700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303832960</BitOffs>
+            <BitOffs>1303833088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -81690,7 +81713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303841944</BitOffs>
+            <BitOffs>1303842072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81702,7 +81725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303859712</BitOffs>
+            <BitOffs>1303859840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -81714,7 +81737,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304185600</BitOffs>
+            <BitOffs>1304185728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -81727,7 +81750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194584</BitOffs>
+            <BitOffs>1304194712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81739,7 +81762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304212352</BitOffs>
+            <BitOffs>1304212480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -81751,7 +81774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304538240</BitOffs>
+            <BitOffs>1304538368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -81764,7 +81787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547224</BitOffs>
+            <BitOffs>1304547352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81776,7 +81799,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304564992</BitOffs>
+            <BitOffs>1304565120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -81788,7 +81811,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304890880</BitOffs>
+            <BitOffs>1304891008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -81801,7 +81824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899864</BitOffs>
+            <BitOffs>1304899992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81813,38 +81836,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304917632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314689280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1317024768</BitOffs>
+            <BitOffs>1304917760</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -81995,7 +81994,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#1ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82010,7 +82009,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#100ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82025,7 +82024,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10s</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82040,7 +82039,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10m</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -88628,7 +88627,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#0MS</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -88701,6 +88700,21 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1256411920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoRange</Name>
+            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>60</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1256411936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -88782,6 +88796,120 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1264813120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
+            <Comment> default gantry tolerance in encoder counts = nm</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Default>
+              <Value>50000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1264813440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoMaxVoltage</Name>
+            <Comment> in Volts</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>120</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1264813504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoMinVoltage</Name>
+            <Comment> in Volts</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>-10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1264813568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
+            <BitSize>2496</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.ReqPosLimHi</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.ReqPosLimLo</Name>
+                <Value>-2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimHi</Name>
+                <Value>10768330</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimLo</Name>
+                <Value>8141680</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1264813632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>7</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>0.7.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1264816128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ControllerToolbox</Name>
@@ -88879,7 +89007,7 @@ Emergency Stop for MR1K1</Comment>
             <Default>
               <SubItem>
                 <Name>.PT</Name>
-                <DateTime>T#2S</DateTime>
+                <DateTime>T</DateTime>
               </SubItem>
             </Default>
             <BitOffs>1265827328</BitOffs>
@@ -88938,6 +89066,44 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1274210368</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K1_BEND.M1K1</Name>
+            <BitSize>23552</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
+                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
+                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274219200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbYRMSErrorM1K1</Name>
+            <Comment> Encoder Arrays/RMS Watch:</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:Y
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274242752</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxYRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -88948,6 +89114,20 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1274630336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbXRMSErrorM1K1</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:X
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1274630400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxXRMSErrorM1K1</Name>
@@ -88962,6 +89142,20 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1275017984</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K1_BEND.fbPitchRMSErrorM1K1</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:PITCH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1275018048</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K1_BEND.fMaxPitchRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -88972,6 +89166,13 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1275405632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl</Name>
+            <Comment> Pitch Control</Comment>
+            <BitSize>397888</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
+            <BitOffs>1275405696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbMotionStage_m16</Name>
@@ -89271,6 +89472,22 @@ MR1K1 BEND US ENC REF</Comment>
             <BitOffs>1276138240</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR1K1 US BENDER ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:US
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1276138304</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89281,6 +89498,21 @@ MR1K1 BEND US ENC REF</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1276525888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
+            <Comment>MR1K1 DS BENDER ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:ENC:DS
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1276525952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendDSRMSErrorM1K1</Name>
@@ -89502,6 +89734,44 @@ M1K1 BEND US ENC CNT</Comment>
             <BitOffs>1282712320</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K2_SWITCH.M1K2</Name>
+            <BitSize>23552</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K2_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K2_STO]^Channel 2^Input;
+                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position;
+                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282738240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:ENC:Y
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1282761792</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89512,6 +89782,20 @@ M1K1 BEND US ENC CNT</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1283149376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:ENC:X
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283149440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
@@ -89526,6 +89810,20 @@ M1K1 BEND US ENC CNT</Comment>
             <BitOffs>1283537024</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:ENC:PITCH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283537088</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89536,6 +89834,13 @@ M1K1 BEND US ENC CNT</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1283924672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
+            <Comment> Pitch Control</Comment>
+            <BitSize>397888</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
+            <BitOffs>1283924736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -91001,6 +91306,20 @@ MR2K2 X ENC REF</Comment>
             <BitOffs>1289680704</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR2K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR2K2:FLAT:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1289681408</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91013,6 +91332,19 @@ MR2K2 X ENC REF</Comment>
             <BitOffs>1290068992</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
+            <Comment>MR2K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290069056</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91023,6 +91355,19 @@ MR2K2 X ENC REF</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1290456640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
+            <Comment>MR2K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1290456704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
@@ -91141,104 +91486,39 @@ MR3K2 X ENC REF</Comment>
             <BitOffs>1290844512</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
-            <Comment> default gantry tolerance in encoder counts = nm</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Default>
-              <Value>50000</Value>
-            </Default>
+            <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
+            <BitSize>1792</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</BaseType>
             <Properties>
               <Property>
-                <Name>TcVarGlobal</Name>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
+                                 .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2K2:FLAT
+    </Value>
               </Property>
             </Properties>
             <BitOffs>1290844544</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Constants.cPiezoMaxVoltage</Name>
-            <Comment> in Volts</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>120</Value>
-            </Default>
+            <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR3K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
-                <Name>TcVarGlobal</Name>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1290844608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoMinVoltage</Name>
-            <Comment> in Volts</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>-10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1290844672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoRange</Name>
-            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>60</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1290844736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>7</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.7.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1290844768</BitOffs>
+            <BitOffs>1290846336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
@@ -91253,6 +91533,19 @@ MR3K2 X ENC REF</Comment>
             <BitOffs>1291233920</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
+            <Comment>MR3K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1291233984</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91263,6 +91556,19 @@ MR3K2 X ENC REF</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1291621568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
+            <Comment>MR3K2 rY ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1291621632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
@@ -91277,6 +91583,19 @@ MR3K2 X ENC REF</Comment>
             <BitOffs>1292009216</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
+            <Comment>MR3K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292009280</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -91287,6 +91606,19 @@ MR3K2 X ENC REF</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1292396864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
+            <Comment>MR3K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292396928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
@@ -91578,64 +91910,151 @@ MR4K2 X ENC REF</Comment>
             <BitOffs>1292785120</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1293173824</BitOffs>
+            <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
+            <Comment> MR3K2 Flow Sensors</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBH
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292785152</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR4K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1292786368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1293173888</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293561472</BitOffs>
+            <BitOffs>1293173952</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
+            <Comment>MR4K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1293174016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1293561536</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293949120</BitOffs>
+            <BitOffs>1293561600</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
+            <Comment>MR4K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1293561664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1293949184</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294336768</BitOffs>
+            <BitOffs>1293949248</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
+            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
+            <Comment>MR4K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1293949312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>1294336832</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1294336896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
+            <Comment>MR4K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294336960</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294724416</BitOffs>
+            <BitOffs>1294724480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294724480</BitOffs>
+            <BitOffs>1294724544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -91652,7 +92071,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724544</BitOffs>
+            <BitOffs>1294724608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -91669,7 +92088,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724576</BitOffs>
+            <BitOffs>1294724640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -91686,7 +92105,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724608</BitOffs>
+            <BitOffs>1294724672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -91703,7 +92122,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724640</BitOffs>
+            <BitOffs>1294724704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -91721,7 +92140,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724672</BitOffs>
+            <BitOffs>1294724736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -91738,7 +92157,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724704</BitOffs>
+            <BitOffs>1294724768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -91755,7 +92174,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724736</BitOffs>
+            <BitOffs>1294724800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -91772,7 +92191,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724768</BitOffs>
+            <BitOffs>1294724832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -91789,7 +92208,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724800</BitOffs>
+            <BitOffs>1294724864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -91808,7 +92227,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724832</BitOffs>
+            <BitOffs>1294724896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -91825,7 +92244,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724864</BitOffs>
+            <BitOffs>1294724928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -91842,7 +92261,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724896</BitOffs>
+            <BitOffs>1294724960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -91860,7 +92279,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724928</BitOffs>
+            <BitOffs>1294724992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -91877,7 +92296,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724960</BitOffs>
+            <BitOffs>1294725024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -91894,7 +92313,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724992</BitOffs>
+            <BitOffs>1294725056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -91917,7 +92336,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725056</BitOffs>
+            <BitOffs>1294725120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -91940,7 +92359,63 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725312</BitOffs>
+            <BitOffs>1294725376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
+            <Comment> MR4K2 Flow Sensors</Comment>
+            <BitSize>1216</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
+                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR4K2:KBV
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1294725696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch</Name>
+            <Comment> Pitch Mechanism:\
+ Currently unused</Comment>
+            <BitSize>2496</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.ReqPosLimHi</Name>
+                <Value>24681</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.ReqPosLimLo</Name>
+                <Value>24321</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimHi</Name>
+                <Value>10139808</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimLo</Name>
+                <Value>9950984</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.diEncCnt:=TIIB[EL5042_M1K2_Pitch]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1294731968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -91955,7 +92430,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734336</BitOffs>
+            <BitOffs>1294734464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -91969,7 +92444,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734400</BitOffs>
+            <BitOffs>1294734528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -91984,7 +92459,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734464</BitOffs>
+            <BitOffs>1294734592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -91999,7 +92474,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734528</BitOffs>
+            <BitOffs>1294734656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -92014,7 +92489,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734592</BitOffs>
+            <BitOffs>1294734720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -92029,7 +92504,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734656</BitOffs>
+            <BitOffs>1294734784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -92045,7 +92520,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734784</BitOffs>
+            <BitOffs>1294734912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -92059,7 +92534,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734848</BitOffs>
+            <BitOffs>1294734976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -92073,7 +92548,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734912</BitOffs>
+            <BitOffs>1294735040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -92087,7 +92562,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734976</BitOffs>
+            <BitOffs>1294735104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -92102,7 +92577,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737536</BitOffs>
+            <BitOffs>1294737664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -92117,7 +92592,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737600</BitOffs>
+            <BitOffs>1294737728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -92132,7 +92607,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737664</BitOffs>
+            <BitOffs>1294737792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -92148,7 +92623,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737728</BitOffs>
+            <BitOffs>1294737856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -92162,7 +92637,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737792</BitOffs>
+            <BitOffs>1294737920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -92176,7 +92651,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737856</BitOffs>
+            <BitOffs>1294737984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -92191,7 +92666,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737920</BitOffs>
+            <BitOffs>1294738048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -92206,7 +92681,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737984</BitOffs>
+            <BitOffs>1294738112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -92222,7 +92697,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738112</BitOffs>
+            <BitOffs>1294738240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -92236,7 +92711,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738176</BitOffs>
+            <BitOffs>1294738304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -92250,7 +92725,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738240</BitOffs>
+            <BitOffs>1294738368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -92265,7 +92740,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738304</BitOffs>
+            <BitOffs>1294738432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -92280,7 +92755,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738368</BitOffs>
+            <BitOffs>1294738496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -92295,7 +92770,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738432</BitOffs>
+            <BitOffs>1294738560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -92310,7 +92785,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738496</BitOffs>
+            <BitOffs>1294738624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -92325,7 +92800,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738560</BitOffs>
+            <BitOffs>1294738688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -92340,7 +92815,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738624</BitOffs>
+            <BitOffs>1294738752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -92355,7 +92830,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738784</BitOffs>
+            <BitOffs>1294738912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -92371,7 +92846,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738816</BitOffs>
+            <BitOffs>1294738944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -92385,7 +92860,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738880</BitOffs>
+            <BitOffs>1294739008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -92399,7 +92874,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738944</BitOffs>
+            <BitOffs>1294739072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -92413,7 +92888,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739008</BitOffs>
+            <BitOffs>1294739136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -92431,7 +92906,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739072</BitOffs>
+            <BitOffs>1294739200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -92449,7 +92924,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295234816</BitOffs>
+            <BitOffs>1295234944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -92478,7 +92953,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295730560</BitOffs>
+            <BitOffs>1295730688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -92507,7 +92982,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296254912</BitOffs>
+            <BitOffs>1296255040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -92518,7 +92993,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779264</BitOffs>
+            <BitOffs>1296779392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -92555,7 +93030,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779712</BitOffs>
+            <BitOffs>1296779840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -92566,7 +93041,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296804928</BitOffs>
+            <BitOffs>1296805056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -92603,7 +93078,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297132352</BitOffs>
+            <BitOffs>1297132480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -92614,7 +93089,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297157568</BitOffs>
+            <BitOffs>1297157696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -92651,7 +93126,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297484992</BitOffs>
+            <BitOffs>1297485120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -92662,7 +93137,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297510208</BitOffs>
+            <BitOffs>1297510336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -92699,7 +93174,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297837632</BitOffs>
+            <BitOffs>1297837760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -92710,7 +93185,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297862848</BitOffs>
+            <BitOffs>1297862976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -92747,7 +93222,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298190272</BitOffs>
+            <BitOffs>1298190400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -92785,7 +93260,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298215488</BitOffs>
+            <BitOffs>1298215616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -92823,7 +93298,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298265920</BitOffs>
+            <BitOffs>1298266048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -92861,7 +93336,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298291136</BitOffs>
+            <BitOffs>1298291264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -92898,7 +93373,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298316352</BitOffs>
+            <BitOffs>1298316480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -92930,7 +93405,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298341568</BitOffs>
+            <BitOffs>1298341696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -92968,7 +93443,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298366784</BitOffs>
+            <BitOffs>1298366912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -92979,7 +93454,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298392000</BitOffs>
+            <BitOffs>1298392128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -93016,7 +93491,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298719424</BitOffs>
+            <BitOffs>1298719552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -93027,7 +93502,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298744640</BitOffs>
+            <BitOffs>1298744768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -93064,7 +93539,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299072064</BitOffs>
+            <BitOffs>1299072192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -93075,7 +93550,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299097280</BitOffs>
+            <BitOffs>1299097408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -93112,7 +93587,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299424704</BitOffs>
+            <BitOffs>1299424832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -93123,7 +93598,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299449920</BitOffs>
+            <BitOffs>1299450048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -93161,7 +93636,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299777344</BitOffs>
+            <BitOffs>1299777472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -93194,7 +93669,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299802560</BitOffs>
+            <BitOffs>1299802688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -93205,7 +93680,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299827776</BitOffs>
+            <BitOffs>1299827904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -93239,7 +93714,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300155200</BitOffs>
+            <BitOffs>1300155328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -93250,7 +93725,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300180416</BitOffs>
+            <BitOffs>1300180544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -93284,7 +93759,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300507840</BitOffs>
+            <BitOffs>1300507968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -93318,7 +93793,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300533056</BitOffs>
+            <BitOffs>1300533184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -93352,7 +93827,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300558272</BitOffs>
+            <BitOffs>1300558400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -93386,7 +93861,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300583488</BitOffs>
+            <BitOffs>1300583616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -93420,7 +93895,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300608704</BitOffs>
+            <BitOffs>1300608832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -93449,7 +93924,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300633920</BitOffs>
+            <BitOffs>1300634048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -93481,7 +93956,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300659136</BitOffs>
+            <BitOffs>1300659264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -93492,7 +93967,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300684352</BitOffs>
+            <BitOffs>1300684480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -93524,7 +93999,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301011776</BitOffs>
+            <BitOffs>1301011904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -93535,7 +94010,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301036992</BitOffs>
+            <BitOffs>1301037120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -93567,7 +94042,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301364416</BitOffs>
+            <BitOffs>1301364544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -93578,7 +94053,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301389632</BitOffs>
+            <BitOffs>1301389760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -93610,7 +94085,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301717056</BitOffs>
+            <BitOffs>1301717184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -93621,7 +94096,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301742272</BitOffs>
+            <BitOffs>1301742400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -93653,7 +94128,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302069696</BitOffs>
+            <BitOffs>1302069824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -93664,7 +94139,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302094912</BitOffs>
+            <BitOffs>1302095040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -93696,7 +94171,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302422336</BitOffs>
+            <BitOffs>1302422464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -93707,7 +94182,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302447552</BitOffs>
+            <BitOffs>1302447680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -93739,7 +94214,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302774976</BitOffs>
+            <BitOffs>1302775104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -93750,7 +94225,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302800192</BitOffs>
+            <BitOffs>1302800320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -93782,7 +94257,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303127616</BitOffs>
+            <BitOffs>1303127744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -93793,7 +94268,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303152832</BitOffs>
+            <BitOffs>1303152960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -93825,7 +94300,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303480256</BitOffs>
+            <BitOffs>1303480384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -93836,7 +94311,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303505472</BitOffs>
+            <BitOffs>1303505600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -93868,7 +94343,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303832896</BitOffs>
+            <BitOffs>1303833024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -93879,7 +94354,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303858112</BitOffs>
+            <BitOffs>1303858240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -93911,7 +94386,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304185536</BitOffs>
+            <BitOffs>1304185664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -93922,7 +94397,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304210752</BitOffs>
+            <BitOffs>1304210880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -93954,7 +94429,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304538176</BitOffs>
+            <BitOffs>1304538304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -93965,7 +94440,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304563392</BitOffs>
+            <BitOffs>1304563520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -93997,7 +94472,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304890816</BitOffs>
+            <BitOffs>1304890944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -94008,7 +94483,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304916032</BitOffs>
+            <BitOffs>1304916160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -94019,7 +94494,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243456</BitOffs>
+            <BitOffs>1305243584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -94034,7 +94509,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243472</BitOffs>
+            <BitOffs>1305243600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -94049,7 +94524,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243480</BitOffs>
+            <BitOffs>1305243608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -94079,7 +94554,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243488</BitOffs>
+            <BitOffs>1305243616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -94109,7 +94584,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243552</BitOffs>
+            <BitOffs>1305243680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -94124,7 +94599,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243616</BitOffs>
+            <BitOffs>1305243744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -94139,7 +94614,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243632</BitOffs>
+            <BitOffs>1305243760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -94154,7 +94629,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243648</BitOffs>
+            <BitOffs>1305243776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -94168,7 +94643,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243656</BitOffs>
+            <BitOffs>1305243784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -94183,7 +94658,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243680</BitOffs>
+            <BitOffs>1305243808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -94198,7 +94673,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243712</BitOffs>
+            <BitOffs>1305243840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -94319,7 +94794,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243744</BitOffs>
+            <BitOffs>1305243872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -94333,7 +94808,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253216</BitOffs>
+            <BitOffs>1305253344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -94347,7 +94822,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253248</BitOffs>
+            <BitOffs>1305253376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -94368,7 +94843,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305256896</BitOffs>
+            <BitOffs>1305257024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -94440,7 +94915,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305274816</BitOffs>
+            <BitOffs>1305274944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -94512,7 +94987,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305274944</BitOffs>
+            <BitOffs>1305275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -94584,7 +95059,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275072</BitOffs>
+            <BitOffs>1305275200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -94656,7 +95131,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275200</BitOffs>
+            <BitOffs>1305275328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -94728,7 +95203,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275328</BitOffs>
+            <BitOffs>1305275456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -94800,7 +95275,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275456</BitOffs>
+            <BitOffs>1305275584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -94826,490 +95301,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305308480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
-            <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.ReqPosLimHi</Name>
-                <Value>2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.ReqPosLimLo</Name>
-                <Value>-2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimHi</Name>
-                <Value>10768330</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimLo</Name>
-                <Value>8141680</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310865152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
-            <BitSize>1792</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 1^Value;
-                                 .fbFlow_2.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 3^Value;
-                              .fbPress_1.iRaw := TIIB[EL3054_MR2K2_FWM_PRSM]^AI Standard Channel 2^Value
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR2K2:FLAT
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310867648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
-            <Comment> MR3K2 Flow Sensors</Comment>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 1^Value;
-                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR3K2:KBH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310869440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.M1K1</Name>
-            <BitSize>23552</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
-                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
-                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310872512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
-            <Comment> MR4K2 Flow Sensors</Comment>
-            <BitSize>1216</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbFlow_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 3^Value;
-                              .fbPress_1.iRaw := TIIB[EL3054_MR3_4K2_FWM_PRSM]^AI Standard Channel 2^Value
-    </Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR4K2:KBV
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312711616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.M1K2</Name>
-            <BitSize>23552</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K2_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K2_STO]^Channel 2^Input;
-                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position;
-                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312729920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch</Name>
-            <Comment> Pitch Mechanism:\
- Currently unused</Comment>
-            <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.ReqPosLimHi</Name>
-                <Value>24681</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.ReqPosLimLo</Name>
-                <Value>24321</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimHi</Name>
-                <Value>10139808</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimLo</Name>
-                <Value>9950984</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.diEncCnt:=TIIB[EL5042_M1K2_Pitch]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312753472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbYRMSErrorM1K1</Name>
-            <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:Y
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313462208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbXRMSErrorM1K1</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:X
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313849728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbPitchRMSErrorM1K1</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:PITCH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314237248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbM1K1PitchControl</Name>
-            <Comment> Pitch Control</Comment>
-            <BitSize>397888</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1314624768</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR1K1 US BENDER ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:US
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1315022656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
-            <Comment>MR1K1 DS BENDER ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:ENC:DS
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1315410176</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:ENC:Y
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1315797696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:ENC:X
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1316185216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:ENC:PITCH
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1316572736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
-            <Comment> Pitch Control</Comment>
-            <BitSize>397888</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1316960256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR2K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR2K2:FLAT:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1317358144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
-            <Comment>MR2K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1317745664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
-            <Comment>MR2K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1318133184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR3K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1318520704</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
-            <Comment>MR3K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1318908224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
-            <Comment>MR3K2 rY ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1319295744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
-            <Comment>MR3K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1319683264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
-            <Comment>MR3K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1320070784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR4K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1320458304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
-            <Comment>MR4K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1320845824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
-            <Comment>MR4K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1321233344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
-            <Comment>MR4K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1321620864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
-            <Comment>MR4K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1322008384</BitOffs>
+            <BitOffs>1305308608</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165412864</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95389,11 +95388,11 @@ MR4K2 X ENC RMS</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-09T14:19:05</Value>
+          <Value>2024-02-26T14:27:10</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>925696</Value>
+          <Value>917504</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{64BADEED-7A46-6999-26C7-6F1A919E5DB8}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{99BC765F-962C-CB1C-018B-126FBB19E481}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10194,31 +10194,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163192152</GetCodeOffs>
+        <GetCodeOffs>163192280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163192224</GetCodeOffs>
+        <GetCodeOffs>163192352</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192240</GetCodeOffs>
+        <GetCodeOffs>163192368</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192200</GetCodeOffs>
+        <GetCodeOffs>163192328</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192232</GetCodeOffs>
+        <GetCodeOffs>163192360</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11470,15 +11470,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192024</GetCodeOffs>
-        <SetCodeOffs>163192072</SetCodeOffs>
+        <GetCodeOffs>163192152</GetCodeOffs>
+        <SetCodeOffs>163192200</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192104</GetCodeOffs>
-        <SetCodeOffs>163192128</SetCodeOffs>
+        <GetCodeOffs>163192232</GetCodeOffs>
+        <SetCodeOffs>163192256</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11719,31 +11719,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>163192336</GetCodeOffs>
+        <GetCodeOffs>163192464</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163192296</GetCodeOffs>
+        <GetCodeOffs>163192424</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192472</GetCodeOffs>
+        <GetCodeOffs>163192600</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163192480</GetCodeOffs>
+        <GetCodeOffs>163192608</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192392</GetCodeOffs>
+        <GetCodeOffs>163192520</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11755,7 +11755,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163192488</GetCodeOffs>
+        <GetCodeOffs>163192616</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12348,7 +12348,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163192544</GetCodeOffs>
+        <GetCodeOffs>163192672</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -36760,7 +36760,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163204176</GetCodeOffs>
+        <GetCodeOffs>163204304</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -38688,31 +38688,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163203576</GetCodeOffs>
+        <GetCodeOffs>163203704</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163203664</GetCodeOffs>
+        <GetCodeOffs>163203792</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163203592</GetCodeOffs>
+        <GetCodeOffs>163203720</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163203640</GetCodeOffs>
+        <GetCodeOffs>163203768</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163203680</GetCodeOffs>
+        <GetCodeOffs>163203808</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -72250,7 +72250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72266,14 +72266,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779424</BitOffs>
+            <BitOffs>1296780448</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72287,14 +72287,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779616</BitOffs>
+            <BitOffs>1296780640</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72311,7 +72311,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294726912</BitOffs>
+            <BitOffs>1294727936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -72322,7 +72322,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294729424</BitOffs>
+            <BitOffs>1294730448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -72336,7 +72336,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305245920</BitOffs>
+            <BitOffs>1305246944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -72350,7 +72350,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305245952</BitOffs>
+            <BitOffs>1305246976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -72364,7 +72364,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253120</BitOffs>
+            <BitOffs>1305254144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -72385,14 +72385,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253440</BitOffs>
+            <BitOffs>1305254464</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72403,14 +72403,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298241920</BitOffs>
+            <BitOffs>1298242944</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72512,7 +72512,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298240832</BitOffs>
+            <BitOffs>1298241856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -72526,7 +72526,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253152</BitOffs>
+            <BitOffs>1305254176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -72540,7 +72540,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253184</BitOffs>
+            <BitOffs>1305254208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -72561,14 +72561,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305254336</BitOffs>
+            <BitOffs>1305255360</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -72609,7 +72609,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294735168</BitOffs>
+            <BitOffs>1294736192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -72623,7 +72623,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253216</BitOffs>
+            <BitOffs>1305254240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -72637,7 +72637,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253248</BitOffs>
+            <BitOffs>1305254272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -72658,14 +72658,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305255232</BitOffs>
+            <BitOffs>1305256256</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72720,7 +72720,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -73141,7 +73141,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305248000</BitOffs>
+            <BitOffs>1305249024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -73155,7 +73155,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253280</BitOffs>
+            <BitOffs>1305254304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -73169,7 +73169,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253312</BitOffs>
+            <BitOffs>1305254336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -73190,14 +73190,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305256128</BitOffs>
+            <BitOffs>1305257152</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -74358,6 +74358,246 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1286624544</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD9.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD9.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD9.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD9.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD10.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD10.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD10.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD10.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD11.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD11.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD11.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD11.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD12.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD12.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD12.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD12.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625568</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw</Name>
             <Comment> Connect this input to the terminal</Comment>
             <BitSize>16</BitSize>
@@ -74368,7 +74608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286650816</BitOffs>
+            <BitOffs>1286651840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2.iRaw</Name>
@@ -74381,7 +74621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286651392</BitOffs>
+            <BitOffs>1286652416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
@@ -74394,7 +74634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286651968</BitOffs>
+            <BitOffs>1286652992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74406,7 +74646,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286688832</BitOffs>
+            <BitOffs>1286689856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74418,7 +74658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287016256</BitOffs>
+            <BitOffs>1287017280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74430,7 +74670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287343680</BitOffs>
+            <BitOffs>1287344704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74442,7 +74682,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287671104</BitOffs>
+            <BitOffs>1287672128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74454,7 +74694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287998528</BitOffs>
+            <BitOffs>1287999552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bError</Name>
@@ -74478,7 +74718,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018248</BitOffs>
+            <BitOffs>1289019272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bUnderrange</Name>
@@ -74490,7 +74730,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018256</BitOffs>
+            <BitOffs>1289019280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bOverrange</Name>
@@ -74502,7 +74742,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018264</BitOffs>
+            <BitOffs>1289019288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.iRaw</Name>
@@ -74514,7 +74754,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018272</BitOffs>
+            <BitOffs>1289019296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bError</Name>
@@ -74538,7 +74778,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018504</BitOffs>
+            <BitOffs>1289019528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bUnderrange</Name>
@@ -74550,7 +74790,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018512</BitOffs>
+            <BitOffs>1289019536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bOverrange</Name>
@@ -74562,7 +74802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018520</BitOffs>
+            <BitOffs>1289019544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.iRaw</Name>
@@ -74574,7 +74814,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018528</BitOffs>
+            <BitOffs>1289019552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bError</Name>
@@ -74598,7 +74838,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018760</BitOffs>
+            <BitOffs>1289019784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bUnderrange</Name>
@@ -74610,7 +74850,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018768</BitOffs>
+            <BitOffs>1289019792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bOverrange</Name>
@@ -74622,7 +74862,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018776</BitOffs>
+            <BitOffs>1289019800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.iRaw</Name>
@@ -74634,7 +74874,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018784</BitOffs>
+            <BitOffs>1289019808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bError</Name>
@@ -74658,7 +74898,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019016</BitOffs>
+            <BitOffs>1289020040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bUnderrange</Name>
@@ -74670,7 +74910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019024</BitOffs>
+            <BitOffs>1289020048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bOverrange</Name>
@@ -74682,7 +74922,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019032</BitOffs>
+            <BitOffs>1289020056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.iRaw</Name>
@@ -74694,7 +74934,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019040</BitOffs>
+            <BitOffs>1289020064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbGetIllPercent.iRaw</Name>
@@ -74707,7 +74947,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019328</BitOffs>
+            <BitOffs>1289020352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter.iRaw</Name>
@@ -74720,7 +74960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289020480</BitOffs>
+            <BitOffs>1289021504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74732,7 +74972,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289023872</BitOffs>
+            <BitOffs>1289024896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -74748,7 +74988,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289350848</BitOffs>
+            <BitOffs>1289351872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -74769,7 +75009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289354368</BitOffs>
+            <BitOffs>1289355392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -74790,7 +75030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289354369</BitOffs>
+            <BitOffs>1289355393</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable1</Name>
@@ -74807,7 +75047,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289652944</BitOffs>
+            <BitOffs>1289653968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2</Name>
@@ -74823,7 +75063,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289652952</BitOffs>
+            <BitOffs>1289653976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -74836,7 +75076,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290844800</BitOffs>
+            <BitOffs>1290845824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -74849,7 +75089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290845312</BitOffs>
+            <BitOffs>1290846336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
@@ -74862,7 +75102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290845888</BitOffs>
+            <BitOffs>1290846912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
@@ -74875,7 +75115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785056</BitOffs>
+            <BitOffs>1292786080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
@@ -74887,7 +75127,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785064</BitOffs>
+            <BitOffs>1292786088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
@@ -74899,7 +75139,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785072</BitOffs>
+            <BitOffs>1292786096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
@@ -74911,7 +75151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785080</BitOffs>
+            <BitOffs>1292786104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
@@ -74923,7 +75163,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785088</BitOffs>
+            <BitOffs>1292786112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -74935,7 +75175,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785096</BitOffs>
+            <BitOffs>1292786120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -74952,7 +75192,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785104</BitOffs>
+            <BitOffs>1292786128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -74968,7 +75208,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785112</BitOffs>
+            <BitOffs>1292786136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -74981,7 +75221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785408</BitOffs>
+            <BitOffs>1292786432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -74994,7 +75234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292785920</BitOffs>
+            <BitOffs>1292786944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -75007,7 +75247,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725088</BitOffs>
+            <BitOffs>1294726112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -75019,7 +75259,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725096</BitOffs>
+            <BitOffs>1294726120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -75031,7 +75271,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725104</BitOffs>
+            <BitOffs>1294726128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -75043,7 +75283,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725112</BitOffs>
+            <BitOffs>1294726136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -75067,7 +75307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725320</BitOffs>
+            <BitOffs>1294726344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -75079,7 +75319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725328</BitOffs>
+            <BitOffs>1294726352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -75091,7 +75331,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725336</BitOffs>
+            <BitOffs>1294726360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -75103,7 +75343,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725344</BitOffs>
+            <BitOffs>1294726368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -75127,7 +75367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725576</BitOffs>
+            <BitOffs>1294726600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -75139,7 +75379,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725584</BitOffs>
+            <BitOffs>1294726608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -75151,7 +75391,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725592</BitOffs>
+            <BitOffs>1294726616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -75163,7 +75403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725600</BitOffs>
+            <BitOffs>1294726624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -75175,7 +75415,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725632</BitOffs>
+            <BitOffs>1294726656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -75187,7 +75427,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725640</BitOffs>
+            <BitOffs>1294726664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -75204,7 +75444,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725648</BitOffs>
+            <BitOffs>1294726672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -75220,7 +75460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725656</BitOffs>
+            <BitOffs>1294726680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -75240,7 +75480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294725664</BitOffs>
+            <BitOffs>1294726688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -75259,7 +75499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294725680</BitOffs>
+            <BitOffs>1294726704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -75272,7 +75512,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294725952</BitOffs>
+            <BitOffs>1294726976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -75285,7 +75525,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294726464</BitOffs>
+            <BitOffs>1294727488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -75304,7 +75544,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731936</BitOffs>
+            <BitOffs>1294732960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -75324,7 +75564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731952</BitOffs>
+            <BitOffs>1294732976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
@@ -75337,7 +75577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294734400</BitOffs>
+            <BitOffs>1294735424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -75356,7 +75596,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734848</BitOffs>
+            <BitOffs>1294735872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -75375,7 +75615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734864</BitOffs>
+            <BitOffs>1294735888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -75395,7 +75635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734880</BitOffs>
+            <BitOffs>1294735904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -75414,7 +75654,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734896</BitOffs>
+            <BitOffs>1294735920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
@@ -75427,7 +75667,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1294737600</BitOffs>
+            <BitOffs>1294738624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -75446,7 +75686,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738176</BitOffs>
+            <BitOffs>1294739200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -75466,7 +75706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738192</BitOffs>
+            <BitOffs>1294739216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -75485,7 +75725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738208</BitOffs>
+            <BitOffs>1294739232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -75504,7 +75744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738224</BitOffs>
+            <BitOffs>1294739248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -75524,7 +75764,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738816</BitOffs>
+            <BitOffs>1294739840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -75543,7 +75783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738832</BitOffs>
+            <BitOffs>1294739856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -75562,7 +75802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738848</BitOffs>
+            <BitOffs>1294739872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -75582,7 +75822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738864</BitOffs>
+            <BitOffs>1294739888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -75601,7 +75841,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738880</BitOffs>
+            <BitOffs>1294739904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -75620,7 +75860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738896</BitOffs>
+            <BitOffs>1294739920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -75635,7 +75875,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779808</BitOffs>
+            <BitOffs>1296780832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -75650,7 +75890,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779824</BitOffs>
+            <BitOffs>1296780848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -75662,7 +75902,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296780928</BitOffs>
+            <BitOffs>1296781952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -75675,7 +75915,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788864</BitOffs>
+            <BitOffs>1296789888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -75688,7 +75928,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788872</BitOffs>
+            <BitOffs>1296789896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -75701,7 +75941,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788880</BitOffs>
+            <BitOffs>1296789904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -75724,7 +75964,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788896</BitOffs>
+            <BitOffs>1296789920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -75737,7 +75977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788928</BitOffs>
+            <BitOffs>1296789952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -75750,7 +75990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788992</BitOffs>
+            <BitOffs>1296790016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -75763,7 +76003,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296789008</BitOffs>
+            <BitOffs>1296790032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75775,7 +76015,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296807680</BitOffs>
+            <BitOffs>1296808704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -75787,7 +76027,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297133568</BitOffs>
+            <BitOffs>1297134592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -75800,7 +76040,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141504</BitOffs>
+            <BitOffs>1297142528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -75813,7 +76053,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141512</BitOffs>
+            <BitOffs>1297142536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -75826,7 +76066,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141520</BitOffs>
+            <BitOffs>1297142544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -75849,7 +76089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141536</BitOffs>
+            <BitOffs>1297142560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -75862,7 +76102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141568</BitOffs>
+            <BitOffs>1297142592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -75875,7 +76115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141632</BitOffs>
+            <BitOffs>1297142656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -75888,7 +76128,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141648</BitOffs>
+            <BitOffs>1297142672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75900,7 +76140,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297160320</BitOffs>
+            <BitOffs>1297161344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -75912,7 +76152,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297486208</BitOffs>
+            <BitOffs>1297487232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -75925,7 +76165,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494144</BitOffs>
+            <BitOffs>1297495168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -75938,7 +76178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494152</BitOffs>
+            <BitOffs>1297495176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -75951,7 +76191,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494160</BitOffs>
+            <BitOffs>1297495184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -75974,7 +76214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494176</BitOffs>
+            <BitOffs>1297495200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -75987,7 +76227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494208</BitOffs>
+            <BitOffs>1297495232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -76000,7 +76240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494272</BitOffs>
+            <BitOffs>1297495296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -76013,7 +76253,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494288</BitOffs>
+            <BitOffs>1297495312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76025,7 +76265,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297512960</BitOffs>
+            <BitOffs>1297513984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -76037,7 +76277,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297838848</BitOffs>
+            <BitOffs>1297839872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -76050,7 +76290,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846784</BitOffs>
+            <BitOffs>1297847808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -76063,7 +76303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846792</BitOffs>
+            <BitOffs>1297847816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -76076,7 +76316,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846800</BitOffs>
+            <BitOffs>1297847824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -76099,7 +76339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846816</BitOffs>
+            <BitOffs>1297847840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -76112,7 +76352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846848</BitOffs>
+            <BitOffs>1297847872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -76125,7 +76365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846912</BitOffs>
+            <BitOffs>1297847936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -76138,7 +76378,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846928</BitOffs>
+            <BitOffs>1297847952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76150,7 +76390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297865600</BitOffs>
+            <BitOffs>1297866624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -76162,7 +76402,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298191488</BitOffs>
+            <BitOffs>1298192512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -76175,7 +76415,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199424</BitOffs>
+            <BitOffs>1298200448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -76188,7 +76428,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199432</BitOffs>
+            <BitOffs>1298200456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -76201,7 +76441,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199440</BitOffs>
+            <BitOffs>1298200464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -76224,7 +76464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199456</BitOffs>
+            <BitOffs>1298200480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -76237,7 +76477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199488</BitOffs>
+            <BitOffs>1298200512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -76250,7 +76490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199552</BitOffs>
+            <BitOffs>1298200576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -76263,7 +76503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199568</BitOffs>
+            <BitOffs>1298200592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -76275,7 +76515,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298216704</BitOffs>
+            <BitOffs>1298217728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -76288,7 +76528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224640</BitOffs>
+            <BitOffs>1298225664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -76301,7 +76541,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224648</BitOffs>
+            <BitOffs>1298225672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -76314,7 +76554,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224656</BitOffs>
+            <BitOffs>1298225680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -76337,7 +76577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224672</BitOffs>
+            <BitOffs>1298225696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -76350,7 +76590,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224704</BitOffs>
+            <BitOffs>1298225728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -76363,7 +76603,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224768</BitOffs>
+            <BitOffs>1298225792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -76376,7 +76616,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224784</BitOffs>
+            <BitOffs>1298225808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -76389,7 +76629,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249856</BitOffs>
+            <BitOffs>1298250880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -76402,7 +76642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249864</BitOffs>
+            <BitOffs>1298250888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -76415,7 +76655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249872</BitOffs>
+            <BitOffs>1298250896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -76438,7 +76678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249888</BitOffs>
+            <BitOffs>1298250912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -76451,7 +76691,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249920</BitOffs>
+            <BitOffs>1298250944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -76464,7 +76704,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249984</BitOffs>
+            <BitOffs>1298251008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -76477,7 +76717,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298250000</BitOffs>
+            <BitOffs>1298251024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -76489,7 +76729,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298267136</BitOffs>
+            <BitOffs>1298268160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -76502,7 +76742,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275072</BitOffs>
+            <BitOffs>1298276096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -76515,7 +76755,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275080</BitOffs>
+            <BitOffs>1298276104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -76528,7 +76768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275088</BitOffs>
+            <BitOffs>1298276112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -76551,7 +76791,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275104</BitOffs>
+            <BitOffs>1298276128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -76564,7 +76804,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275136</BitOffs>
+            <BitOffs>1298276160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -76577,7 +76817,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275200</BitOffs>
+            <BitOffs>1298276224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -76590,7 +76830,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275216</BitOffs>
+            <BitOffs>1298276240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -76602,7 +76842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298292352</BitOffs>
+            <BitOffs>1298293376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -76615,7 +76855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300288</BitOffs>
+            <BitOffs>1298301312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -76628,7 +76868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300296</BitOffs>
+            <BitOffs>1298301320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -76641,7 +76881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300304</BitOffs>
+            <BitOffs>1298301328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -76664,7 +76904,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300320</BitOffs>
+            <BitOffs>1298301344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -76677,7 +76917,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300352</BitOffs>
+            <BitOffs>1298301376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -76690,7 +76930,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300416</BitOffs>
+            <BitOffs>1298301440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -76703,7 +76943,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300432</BitOffs>
+            <BitOffs>1298301456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -76715,7 +76955,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298317568</BitOffs>
+            <BitOffs>1298318592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -76728,7 +76968,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325504</BitOffs>
+            <BitOffs>1298326528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -76741,7 +76981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325512</BitOffs>
+            <BitOffs>1298326536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -76754,7 +76994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325520</BitOffs>
+            <BitOffs>1298326544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -76777,7 +77017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325536</BitOffs>
+            <BitOffs>1298326560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -76790,7 +77030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325568</BitOffs>
+            <BitOffs>1298326592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -76803,7 +77043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325632</BitOffs>
+            <BitOffs>1298326656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -76816,7 +77056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325648</BitOffs>
+            <BitOffs>1298326672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -76828,7 +77068,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298342784</BitOffs>
+            <BitOffs>1298343808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -76841,7 +77081,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350720</BitOffs>
+            <BitOffs>1298351744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -76854,7 +77094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350728</BitOffs>
+            <BitOffs>1298351752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -76867,7 +77107,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350736</BitOffs>
+            <BitOffs>1298351760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -76890,7 +77130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350752</BitOffs>
+            <BitOffs>1298351776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -76903,7 +77143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350784</BitOffs>
+            <BitOffs>1298351808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -76916,7 +77156,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350848</BitOffs>
+            <BitOffs>1298351872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -76929,7 +77169,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350864</BitOffs>
+            <BitOffs>1298351888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -76941,7 +77181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298368000</BitOffs>
+            <BitOffs>1298369024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -76954,7 +77194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375936</BitOffs>
+            <BitOffs>1298376960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -76967,7 +77207,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375944</BitOffs>
+            <BitOffs>1298376968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -76980,7 +77220,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375952</BitOffs>
+            <BitOffs>1298376976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -77003,7 +77243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375968</BitOffs>
+            <BitOffs>1298376992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -77016,7 +77256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298376000</BitOffs>
+            <BitOffs>1298377024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -77029,7 +77269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298376064</BitOffs>
+            <BitOffs>1298377088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -77042,7 +77282,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298376080</BitOffs>
+            <BitOffs>1298377104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77054,7 +77294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298394752</BitOffs>
+            <BitOffs>1298395776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -77066,7 +77306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298720640</BitOffs>
+            <BitOffs>1298721664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -77079,7 +77319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728576</BitOffs>
+            <BitOffs>1298729600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -77092,7 +77332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728584</BitOffs>
+            <BitOffs>1298729608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -77105,7 +77345,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728592</BitOffs>
+            <BitOffs>1298729616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -77128,7 +77368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728608</BitOffs>
+            <BitOffs>1298729632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -77141,7 +77381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728640</BitOffs>
+            <BitOffs>1298729664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -77154,7 +77394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728704</BitOffs>
+            <BitOffs>1298729728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -77167,7 +77407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728720</BitOffs>
+            <BitOffs>1298729744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77179,7 +77419,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298747392</BitOffs>
+            <BitOffs>1298748416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -77191,7 +77431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299073280</BitOffs>
+            <BitOffs>1299074304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -77204,7 +77444,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081216</BitOffs>
+            <BitOffs>1299082240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -77217,7 +77457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081224</BitOffs>
+            <BitOffs>1299082248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -77230,7 +77470,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081232</BitOffs>
+            <BitOffs>1299082256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -77253,7 +77493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081248</BitOffs>
+            <BitOffs>1299082272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -77266,7 +77506,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081280</BitOffs>
+            <BitOffs>1299082304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -77279,7 +77519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081344</BitOffs>
+            <BitOffs>1299082368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -77292,7 +77532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081360</BitOffs>
+            <BitOffs>1299082384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77304,7 +77544,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299100032</BitOffs>
+            <BitOffs>1299101056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -77316,7 +77556,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299425920</BitOffs>
+            <BitOffs>1299426944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -77329,7 +77569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433856</BitOffs>
+            <BitOffs>1299434880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -77342,7 +77582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433864</BitOffs>
+            <BitOffs>1299434888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -77355,7 +77595,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433872</BitOffs>
+            <BitOffs>1299434896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -77378,7 +77618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433888</BitOffs>
+            <BitOffs>1299434912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -77391,7 +77631,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433920</BitOffs>
+            <BitOffs>1299434944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -77404,7 +77644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433984</BitOffs>
+            <BitOffs>1299435008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -77417,7 +77657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299434000</BitOffs>
+            <BitOffs>1299435024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77429,7 +77669,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299452672</BitOffs>
+            <BitOffs>1299453696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -77441,7 +77681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299778560</BitOffs>
+            <BitOffs>1299779584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -77454,7 +77694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786496</BitOffs>
+            <BitOffs>1299787520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -77467,7 +77707,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786504</BitOffs>
+            <BitOffs>1299787528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -77480,7 +77720,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786512</BitOffs>
+            <BitOffs>1299787536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -77503,7 +77743,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786528</BitOffs>
+            <BitOffs>1299787552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -77516,7 +77756,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786560</BitOffs>
+            <BitOffs>1299787584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -77529,7 +77769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786624</BitOffs>
+            <BitOffs>1299787648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -77542,7 +77782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786640</BitOffs>
+            <BitOffs>1299787664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -77554,7 +77794,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299803776</BitOffs>
+            <BitOffs>1299804800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -77567,7 +77807,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811712</BitOffs>
+            <BitOffs>1299812736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -77580,7 +77820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811720</BitOffs>
+            <BitOffs>1299812744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -77593,7 +77833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811728</BitOffs>
+            <BitOffs>1299812752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -77616,7 +77856,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811744</BitOffs>
+            <BitOffs>1299812768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -77629,7 +77869,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811776</BitOffs>
+            <BitOffs>1299812800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -77642,7 +77882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811840</BitOffs>
+            <BitOffs>1299812864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -77655,7 +77895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811856</BitOffs>
+            <BitOffs>1299812880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77667,7 +77907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299830528</BitOffs>
+            <BitOffs>1299831552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -77679,7 +77919,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300156416</BitOffs>
+            <BitOffs>1300157440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -77692,7 +77932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164352</BitOffs>
+            <BitOffs>1300165376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -77705,7 +77945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164360</BitOffs>
+            <BitOffs>1300165384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -77718,7 +77958,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164368</BitOffs>
+            <BitOffs>1300165392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -77741,7 +77981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164384</BitOffs>
+            <BitOffs>1300165408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -77754,7 +77994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164416</BitOffs>
+            <BitOffs>1300165440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -77767,7 +78007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164480</BitOffs>
+            <BitOffs>1300165504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -77780,7 +78020,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164496</BitOffs>
+            <BitOffs>1300165520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77792,7 +78032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300183168</BitOffs>
+            <BitOffs>1300184192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -77804,7 +78044,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300509056</BitOffs>
+            <BitOffs>1300510080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -77817,7 +78057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300516992</BitOffs>
+            <BitOffs>1300518016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -77830,7 +78070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517000</BitOffs>
+            <BitOffs>1300518024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -77843,7 +78083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517008</BitOffs>
+            <BitOffs>1300518032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -77866,7 +78106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517024</BitOffs>
+            <BitOffs>1300518048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -77879,7 +78119,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517056</BitOffs>
+            <BitOffs>1300518080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -77892,7 +78132,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517120</BitOffs>
+            <BitOffs>1300518144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -77905,7 +78145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517136</BitOffs>
+            <BitOffs>1300518160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -77917,7 +78157,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300534272</BitOffs>
+            <BitOffs>1300535296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -77930,7 +78170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542208</BitOffs>
+            <BitOffs>1300543232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -77943,7 +78183,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542216</BitOffs>
+            <BitOffs>1300543240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -77956,7 +78196,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542224</BitOffs>
+            <BitOffs>1300543248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -77979,7 +78219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542240</BitOffs>
+            <BitOffs>1300543264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -77992,7 +78232,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542272</BitOffs>
+            <BitOffs>1300543296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -78005,7 +78245,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542336</BitOffs>
+            <BitOffs>1300543360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -78018,7 +78258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542352</BitOffs>
+            <BitOffs>1300543376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -78030,7 +78270,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300559488</BitOffs>
+            <BitOffs>1300560512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -78043,7 +78283,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567424</BitOffs>
+            <BitOffs>1300568448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -78056,7 +78296,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567432</BitOffs>
+            <BitOffs>1300568456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -78069,7 +78309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567440</BitOffs>
+            <BitOffs>1300568464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -78092,7 +78332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567456</BitOffs>
+            <BitOffs>1300568480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -78105,7 +78345,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567488</BitOffs>
+            <BitOffs>1300568512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -78118,7 +78358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567552</BitOffs>
+            <BitOffs>1300568576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -78131,7 +78371,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567568</BitOffs>
+            <BitOffs>1300568592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -78143,7 +78383,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300584704</BitOffs>
+            <BitOffs>1300585728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -78156,7 +78396,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592640</BitOffs>
+            <BitOffs>1300593664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -78169,7 +78409,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592648</BitOffs>
+            <BitOffs>1300593672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -78182,7 +78422,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592656</BitOffs>
+            <BitOffs>1300593680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -78205,7 +78445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592672</BitOffs>
+            <BitOffs>1300593696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -78218,7 +78458,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592704</BitOffs>
+            <BitOffs>1300593728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -78231,7 +78471,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592768</BitOffs>
+            <BitOffs>1300593792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -78244,7 +78484,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592784</BitOffs>
+            <BitOffs>1300593808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -78256,7 +78496,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300609920</BitOffs>
+            <BitOffs>1300610944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -78269,7 +78509,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617856</BitOffs>
+            <BitOffs>1300618880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -78282,7 +78522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617864</BitOffs>
+            <BitOffs>1300618888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -78295,7 +78535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617872</BitOffs>
+            <BitOffs>1300618896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -78318,7 +78558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617888</BitOffs>
+            <BitOffs>1300618912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -78331,7 +78571,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617920</BitOffs>
+            <BitOffs>1300618944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -78344,7 +78584,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617984</BitOffs>
+            <BitOffs>1300619008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -78357,7 +78597,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300618000</BitOffs>
+            <BitOffs>1300619024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -78369,7 +78609,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300635136</BitOffs>
+            <BitOffs>1300636160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -78382,7 +78622,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643072</BitOffs>
+            <BitOffs>1300644096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -78395,7 +78635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643080</BitOffs>
+            <BitOffs>1300644104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -78408,7 +78648,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643088</BitOffs>
+            <BitOffs>1300644112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -78431,7 +78671,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643104</BitOffs>
+            <BitOffs>1300644128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -78444,7 +78684,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643136</BitOffs>
+            <BitOffs>1300644160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -78457,7 +78697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643200</BitOffs>
+            <BitOffs>1300644224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -78470,7 +78710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643216</BitOffs>
+            <BitOffs>1300644240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -78482,7 +78722,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300660352</BitOffs>
+            <BitOffs>1300661376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -78495,7 +78735,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668288</BitOffs>
+            <BitOffs>1300669312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -78508,7 +78748,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668296</BitOffs>
+            <BitOffs>1300669320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -78521,7 +78761,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668304</BitOffs>
+            <BitOffs>1300669328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -78544,7 +78784,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668320</BitOffs>
+            <BitOffs>1300669344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -78557,7 +78797,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668352</BitOffs>
+            <BitOffs>1300669376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -78570,7 +78810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668416</BitOffs>
+            <BitOffs>1300669440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -78583,7 +78823,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668432</BitOffs>
+            <BitOffs>1300669456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78595,7 +78835,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300687104</BitOffs>
+            <BitOffs>1300688128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -78607,7 +78847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301012992</BitOffs>
+            <BitOffs>1301014016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -78620,7 +78860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020928</BitOffs>
+            <BitOffs>1301021952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -78633,7 +78873,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020936</BitOffs>
+            <BitOffs>1301021960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -78646,7 +78886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020944</BitOffs>
+            <BitOffs>1301021968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -78669,7 +78909,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020960</BitOffs>
+            <BitOffs>1301021984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -78682,7 +78922,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020992</BitOffs>
+            <BitOffs>1301022016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -78695,7 +78935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301021056</BitOffs>
+            <BitOffs>1301022080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -78708,7 +78948,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301021072</BitOffs>
+            <BitOffs>1301022096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78720,7 +78960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301039744</BitOffs>
+            <BitOffs>1301040768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -78732,7 +78972,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301365632</BitOffs>
+            <BitOffs>1301366656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -78745,7 +78985,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373568</BitOffs>
+            <BitOffs>1301374592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -78758,7 +78998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373576</BitOffs>
+            <BitOffs>1301374600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -78771,7 +79011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373584</BitOffs>
+            <BitOffs>1301374608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -78794,7 +79034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373600</BitOffs>
+            <BitOffs>1301374624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -78807,7 +79047,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373632</BitOffs>
+            <BitOffs>1301374656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -78820,7 +79060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373696</BitOffs>
+            <BitOffs>1301374720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -78833,7 +79073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373712</BitOffs>
+            <BitOffs>1301374736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78845,7 +79085,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301392384</BitOffs>
+            <BitOffs>1301393408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -78857,7 +79097,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301718272</BitOffs>
+            <BitOffs>1301719296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -78870,7 +79110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726208</BitOffs>
+            <BitOffs>1301727232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -78883,7 +79123,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726216</BitOffs>
+            <BitOffs>1301727240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -78896,7 +79136,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726224</BitOffs>
+            <BitOffs>1301727248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -78919,7 +79159,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726240</BitOffs>
+            <BitOffs>1301727264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -78932,7 +79172,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726272</BitOffs>
+            <BitOffs>1301727296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -78945,7 +79185,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726336</BitOffs>
+            <BitOffs>1301727360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -78958,7 +79198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726352</BitOffs>
+            <BitOffs>1301727376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78970,7 +79210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301745024</BitOffs>
+            <BitOffs>1301746048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -78982,7 +79222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302070912</BitOffs>
+            <BitOffs>1302071936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -78995,7 +79235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078848</BitOffs>
+            <BitOffs>1302079872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -79008,7 +79248,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078856</BitOffs>
+            <BitOffs>1302079880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -79021,7 +79261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078864</BitOffs>
+            <BitOffs>1302079888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -79044,7 +79284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078880</BitOffs>
+            <BitOffs>1302079904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -79057,7 +79297,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078912</BitOffs>
+            <BitOffs>1302079936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -79070,7 +79310,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078976</BitOffs>
+            <BitOffs>1302080000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -79083,7 +79323,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078992</BitOffs>
+            <BitOffs>1302080016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79095,7 +79335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302097664</BitOffs>
+            <BitOffs>1302098688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -79107,7 +79347,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302423552</BitOffs>
+            <BitOffs>1302424576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -79120,7 +79360,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431488</BitOffs>
+            <BitOffs>1302432512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -79133,7 +79373,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431496</BitOffs>
+            <BitOffs>1302432520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -79146,7 +79386,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431504</BitOffs>
+            <BitOffs>1302432528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -79169,7 +79409,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431520</BitOffs>
+            <BitOffs>1302432544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -79182,7 +79422,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431552</BitOffs>
+            <BitOffs>1302432576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -79195,7 +79435,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431616</BitOffs>
+            <BitOffs>1302432640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -79208,7 +79448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431632</BitOffs>
+            <BitOffs>1302432656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79220,7 +79460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302450304</BitOffs>
+            <BitOffs>1302451328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -79232,7 +79472,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302776192</BitOffs>
+            <BitOffs>1302777216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -79245,7 +79485,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784128</BitOffs>
+            <BitOffs>1302785152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -79258,7 +79498,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784136</BitOffs>
+            <BitOffs>1302785160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -79271,7 +79511,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784144</BitOffs>
+            <BitOffs>1302785168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -79294,7 +79534,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784160</BitOffs>
+            <BitOffs>1302785184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -79307,7 +79547,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784192</BitOffs>
+            <BitOffs>1302785216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -79320,7 +79560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784256</BitOffs>
+            <BitOffs>1302785280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -79333,7 +79573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784272</BitOffs>
+            <BitOffs>1302785296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79345,7 +79585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302802944</BitOffs>
+            <BitOffs>1302803968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -79357,7 +79597,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303128832</BitOffs>
+            <BitOffs>1303129856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -79370,7 +79610,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136768</BitOffs>
+            <BitOffs>1303137792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -79383,7 +79623,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136776</BitOffs>
+            <BitOffs>1303137800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -79396,7 +79636,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136784</BitOffs>
+            <BitOffs>1303137808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -79419,7 +79659,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136800</BitOffs>
+            <BitOffs>1303137824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -79432,7 +79672,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136832</BitOffs>
+            <BitOffs>1303137856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -79445,7 +79685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136896</BitOffs>
+            <BitOffs>1303137920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -79458,7 +79698,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136912</BitOffs>
+            <BitOffs>1303137936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79470,7 +79710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303155584</BitOffs>
+            <BitOffs>1303156608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -79482,7 +79722,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303481472</BitOffs>
+            <BitOffs>1303482496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -79495,7 +79735,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489408</BitOffs>
+            <BitOffs>1303490432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -79508,7 +79748,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489416</BitOffs>
+            <BitOffs>1303490440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -79521,7 +79761,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489424</BitOffs>
+            <BitOffs>1303490448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -79544,7 +79784,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489440</BitOffs>
+            <BitOffs>1303490464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -79557,7 +79797,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489472</BitOffs>
+            <BitOffs>1303490496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -79570,7 +79810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489536</BitOffs>
+            <BitOffs>1303490560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -79583,7 +79823,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489552</BitOffs>
+            <BitOffs>1303490576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79595,7 +79835,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303508224</BitOffs>
+            <BitOffs>1303509248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -79607,7 +79847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303834112</BitOffs>
+            <BitOffs>1303835136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -79620,7 +79860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842048</BitOffs>
+            <BitOffs>1303843072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -79633,7 +79873,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842056</BitOffs>
+            <BitOffs>1303843080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -79646,7 +79886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842064</BitOffs>
+            <BitOffs>1303843088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -79669,7 +79909,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842080</BitOffs>
+            <BitOffs>1303843104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -79682,7 +79922,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842112</BitOffs>
+            <BitOffs>1303843136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -79695,7 +79935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842176</BitOffs>
+            <BitOffs>1303843200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -79708,7 +79948,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842192</BitOffs>
+            <BitOffs>1303843216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79720,7 +79960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303860864</BitOffs>
+            <BitOffs>1303861888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -79732,7 +79972,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304186752</BitOffs>
+            <BitOffs>1304187776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -79745,7 +79985,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194688</BitOffs>
+            <BitOffs>1304195712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -79758,7 +79998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194696</BitOffs>
+            <BitOffs>1304195720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -79771,7 +80011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194704</BitOffs>
+            <BitOffs>1304195728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -79794,7 +80034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194720</BitOffs>
+            <BitOffs>1304195744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -79807,7 +80047,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194752</BitOffs>
+            <BitOffs>1304195776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -79820,7 +80060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194816</BitOffs>
+            <BitOffs>1304195840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -79833,7 +80073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194832</BitOffs>
+            <BitOffs>1304195856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79845,7 +80085,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304213504</BitOffs>
+            <BitOffs>1304214528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -79857,7 +80097,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304539392</BitOffs>
+            <BitOffs>1304540416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -79870,7 +80110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547328</BitOffs>
+            <BitOffs>1304548352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -79883,7 +80123,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547336</BitOffs>
+            <BitOffs>1304548360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -79896,7 +80136,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547344</BitOffs>
+            <BitOffs>1304548368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -79919,7 +80159,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547360</BitOffs>
+            <BitOffs>1304548384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -79932,7 +80172,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547392</BitOffs>
+            <BitOffs>1304548416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -79945,7 +80185,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547456</BitOffs>
+            <BitOffs>1304548480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -79958,7 +80198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547472</BitOffs>
+            <BitOffs>1304548496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79970,7 +80210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304566144</BitOffs>
+            <BitOffs>1304567168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -79982,7 +80222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304892032</BitOffs>
+            <BitOffs>1304893056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -79995,7 +80235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899968</BitOffs>
+            <BitOffs>1304900992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -80008,7 +80248,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899976</BitOffs>
+            <BitOffs>1304901000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -80021,7 +80261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899984</BitOffs>
+            <BitOffs>1304901008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -80044,7 +80284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900000</BitOffs>
+            <BitOffs>1304901024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -80057,7 +80297,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900032</BitOffs>
+            <BitOffs>1304901056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -80070,7 +80310,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900096</BitOffs>
+            <BitOffs>1304901120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -80083,7 +80323,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304900112</BitOffs>
+            <BitOffs>1304901136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80095,14 +80335,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304918784</BitOffs>
+            <BitOffs>1304919808</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -80364,7 +80604,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286624704</BitOffs>
+            <BitOffs>1286625728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower02</Name>
@@ -80389,7 +80629,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286624712</BitOffs>
+            <BitOffs>1286625736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower03</Name>
@@ -80414,7 +80654,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286624720</BitOffs>
+            <BitOffs>1286625744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bFanOn</Name>
@@ -80438,7 +80678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286624728</BitOffs>
+            <BitOffs>1286625752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bLEDPower</Name>
@@ -80463,7 +80703,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286624736</BitOffs>
+            <BitOffs>1286625760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80475,7 +80715,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286687808</BitOffs>
+            <BitOffs>1286688832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80487,7 +80727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287015232</BitOffs>
+            <BitOffs>1287016256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80499,7 +80739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287342656</BitOffs>
+            <BitOffs>1287343680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80511,7 +80751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287670080</BitOffs>
+            <BitOffs>1287671104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80523,7 +80763,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287997504</BitOffs>
+            <BitOffs>1287998528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.iIlluminatorINT</Name>
@@ -80535,7 +80775,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019136</BitOffs>
+            <BitOffs>1289020160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.bGigePower</Name>
@@ -80555,7 +80795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019152</BitOffs>
+            <BitOffs>1289020176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbSetIllPercent.iRaw</Name>
@@ -80568,7 +80808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289020224</BitOffs>
+            <BitOffs>1289021248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80580,7 +80820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289022848</BitOffs>
+            <BitOffs>1289023872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -80596,7 +80836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289352608</BitOffs>
+            <BitOffs>1289353632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -80616,7 +80856,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295730984</BitOffs>
+            <BitOffs>1295732008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -80636,7 +80876,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296255336</BitOffs>
+            <BitOffs>1296256360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -80648,7 +80888,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296779904</BitOffs>
+            <BitOffs>1296780928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -80661,7 +80901,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296788888</BitOffs>
+            <BitOffs>1296789912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80673,7 +80913,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296806656</BitOffs>
+            <BitOffs>1296807680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -80685,7 +80925,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297132544</BitOffs>
+            <BitOffs>1297133568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -80698,7 +80938,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297141528</BitOffs>
+            <BitOffs>1297142552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80710,7 +80950,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297159296</BitOffs>
+            <BitOffs>1297160320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -80722,7 +80962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297485184</BitOffs>
+            <BitOffs>1297486208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -80735,7 +80975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297494168</BitOffs>
+            <BitOffs>1297495192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80747,7 +80987,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297511936</BitOffs>
+            <BitOffs>1297512960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -80759,7 +80999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297837824</BitOffs>
+            <BitOffs>1297838848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -80772,7 +81012,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297846808</BitOffs>
+            <BitOffs>1297847832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80784,7 +81024,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297864576</BitOffs>
+            <BitOffs>1297865600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -80796,7 +81036,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298190464</BitOffs>
+            <BitOffs>1298191488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -80809,7 +81049,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298199448</BitOffs>
+            <BitOffs>1298200472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -80821,7 +81061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298215680</BitOffs>
+            <BitOffs>1298216704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -80834,7 +81074,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298224664</BitOffs>
+            <BitOffs>1298225688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -80846,7 +81086,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298240896</BitOffs>
+            <BitOffs>1298241920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -80859,7 +81099,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298249880</BitOffs>
+            <BitOffs>1298250904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -80871,7 +81111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298266112</BitOffs>
+            <BitOffs>1298267136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -80884,7 +81124,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298275096</BitOffs>
+            <BitOffs>1298276120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -80896,7 +81136,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298291328</BitOffs>
+            <BitOffs>1298292352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -80909,7 +81149,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298300312</BitOffs>
+            <BitOffs>1298301336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -80921,7 +81161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298316544</BitOffs>
+            <BitOffs>1298317568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -80934,7 +81174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298325528</BitOffs>
+            <BitOffs>1298326552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -80946,7 +81186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298341760</BitOffs>
+            <BitOffs>1298342784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -80959,7 +81199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298350744</BitOffs>
+            <BitOffs>1298351768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -80971,7 +81211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298366976</BitOffs>
+            <BitOffs>1298368000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -80984,7 +81224,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298375960</BitOffs>
+            <BitOffs>1298376984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80996,7 +81236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298393728</BitOffs>
+            <BitOffs>1298394752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -81008,7 +81248,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298719616</BitOffs>
+            <BitOffs>1298720640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -81021,7 +81261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298728600</BitOffs>
+            <BitOffs>1298729624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81033,7 +81273,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298746368</BitOffs>
+            <BitOffs>1298747392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -81045,7 +81285,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299072256</BitOffs>
+            <BitOffs>1299073280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -81058,7 +81298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299081240</BitOffs>
+            <BitOffs>1299082264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81070,7 +81310,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299099008</BitOffs>
+            <BitOffs>1299100032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -81082,7 +81322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299424896</BitOffs>
+            <BitOffs>1299425920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -81095,7 +81335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299433880</BitOffs>
+            <BitOffs>1299434904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81107,7 +81347,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299451648</BitOffs>
+            <BitOffs>1299452672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -81119,7 +81359,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299777536</BitOffs>
+            <BitOffs>1299778560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -81132,7 +81372,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299786520</BitOffs>
+            <BitOffs>1299787544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -81144,7 +81384,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299802752</BitOffs>
+            <BitOffs>1299803776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -81157,7 +81397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299811736</BitOffs>
+            <BitOffs>1299812760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81169,7 +81409,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299829504</BitOffs>
+            <BitOffs>1299830528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -81181,7 +81421,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300155392</BitOffs>
+            <BitOffs>1300156416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -81194,7 +81434,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300164376</BitOffs>
+            <BitOffs>1300165400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81206,7 +81446,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300182144</BitOffs>
+            <BitOffs>1300183168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -81218,7 +81458,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300508032</BitOffs>
+            <BitOffs>1300509056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -81231,7 +81471,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300517016</BitOffs>
+            <BitOffs>1300518040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -81243,7 +81483,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300533248</BitOffs>
+            <BitOffs>1300534272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -81256,7 +81496,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300542232</BitOffs>
+            <BitOffs>1300543256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -81268,7 +81508,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300558464</BitOffs>
+            <BitOffs>1300559488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -81281,7 +81521,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300567448</BitOffs>
+            <BitOffs>1300568472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -81293,7 +81533,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300583680</BitOffs>
+            <BitOffs>1300584704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -81306,7 +81546,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300592664</BitOffs>
+            <BitOffs>1300593688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -81318,7 +81558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608896</BitOffs>
+            <BitOffs>1300609920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -81331,7 +81571,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300617880</BitOffs>
+            <BitOffs>1300618904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -81343,7 +81583,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634112</BitOffs>
+            <BitOffs>1300635136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -81356,7 +81596,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300643096</BitOffs>
+            <BitOffs>1300644120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -81368,7 +81608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300659328</BitOffs>
+            <BitOffs>1300660352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -81381,7 +81621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300668312</BitOffs>
+            <BitOffs>1300669336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81393,7 +81633,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300686080</BitOffs>
+            <BitOffs>1300687104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -81405,7 +81645,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301011968</BitOffs>
+            <BitOffs>1301012992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -81418,7 +81658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301020952</BitOffs>
+            <BitOffs>1301021976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81430,7 +81670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301038720</BitOffs>
+            <BitOffs>1301039744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -81442,7 +81682,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301364608</BitOffs>
+            <BitOffs>1301365632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -81455,7 +81695,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301373592</BitOffs>
+            <BitOffs>1301374616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81467,7 +81707,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301391360</BitOffs>
+            <BitOffs>1301392384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -81479,7 +81719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301717248</BitOffs>
+            <BitOffs>1301718272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -81492,7 +81732,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301726232</BitOffs>
+            <BitOffs>1301727256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81504,7 +81744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301744000</BitOffs>
+            <BitOffs>1301745024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -81516,7 +81756,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302069888</BitOffs>
+            <BitOffs>1302070912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -81529,7 +81769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302078872</BitOffs>
+            <BitOffs>1302079896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81541,7 +81781,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302096640</BitOffs>
+            <BitOffs>1302097664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -81553,7 +81793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302422528</BitOffs>
+            <BitOffs>1302423552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -81566,7 +81806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302431512</BitOffs>
+            <BitOffs>1302432536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81578,7 +81818,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302449280</BitOffs>
+            <BitOffs>1302450304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -81590,7 +81830,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302775168</BitOffs>
+            <BitOffs>1302776192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -81603,7 +81843,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302784152</BitOffs>
+            <BitOffs>1302785176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81615,7 +81855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302801920</BitOffs>
+            <BitOffs>1302802944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -81627,7 +81867,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303127808</BitOffs>
+            <BitOffs>1303128832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -81640,7 +81880,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303136792</BitOffs>
+            <BitOffs>1303137816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81652,7 +81892,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303154560</BitOffs>
+            <BitOffs>1303155584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -81664,7 +81904,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303480448</BitOffs>
+            <BitOffs>1303481472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -81677,7 +81917,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303489432</BitOffs>
+            <BitOffs>1303490456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81689,7 +81929,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303507200</BitOffs>
+            <BitOffs>1303508224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -81701,7 +81941,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303833088</BitOffs>
+            <BitOffs>1303834112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -81714,7 +81954,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303842072</BitOffs>
+            <BitOffs>1303843096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81726,7 +81966,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303859840</BitOffs>
+            <BitOffs>1303860864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -81738,7 +81978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304185728</BitOffs>
+            <BitOffs>1304186752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -81751,7 +81991,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304194712</BitOffs>
+            <BitOffs>1304195736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81763,7 +82003,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304212480</BitOffs>
+            <BitOffs>1304213504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -81775,7 +82015,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304538368</BitOffs>
+            <BitOffs>1304539392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -81788,7 +82028,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304547352</BitOffs>
+            <BitOffs>1304548376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81800,7 +82040,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304565120</BitOffs>
+            <BitOffs>1304566144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -81812,7 +82052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304891008</BitOffs>
+            <BitOffs>1304892032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -81825,7 +82065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304899992</BitOffs>
+            <BitOffs>1304901016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81837,14 +82077,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304917760</BitOffs>
+            <BitOffs>1304918784</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -90350,10 +90590,10 @@ M1K1 BEND US ENC CNT</Comment>
               </Property>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Value;
-                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Error;
-                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Underrange;
-                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
+                <Value>.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Value;
+                              .bError := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
             <BitOffs>1286624064</BitOffs>
@@ -90372,13 +90612,101 @@ M1K1 BEND US ENC CNT</Comment>
               </Property>
               <Property>
                 <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Value;
+                              .bError := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Overrange</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD9</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:RTD:09
+        io: o
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Value;
+                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286624576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD10</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:RTD:10
+        io: o
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
                 <Value>.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Value;
                               .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Error;
                               .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1286624320</BitOffs>
+            <BitOffs>1286624832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD11</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:RTD:11
+        io: o
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Value;
+                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Overrange</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.RTD12</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:RTD:12
+        io: o
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Value;
+                              .bError := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Error;
+                              .bUnderrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Underrange;
+                              .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Overrange</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286625344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_read</Name>
@@ -90394,7 +90722,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286624576</BitOffs>
+            <BitOffs>1286625600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_set</Name>
@@ -90409,7 +90737,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286624640</BitOffs>
+            <BitOffs>1286625664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bInit</Name>
@@ -90418,7 +90746,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1286624744</BitOffs>
+            <BitOffs>1286625768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
@@ -90434,7 +90762,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286624752</BitOffs>
+            <BitOffs>1286625776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
@@ -90450,7 +90778,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286624760</BitOffs>
+            <BitOffs>1286625784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_FFO</Name>
@@ -90470,7 +90798,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>4368</Value>
               </SubItem>
             </Default>
-            <BitOffs>1286624768</BitOffs>
+            <BitOffs>1286625792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_e_pmps</Name>
@@ -90479,7 +90807,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>74000.29</Value>
             </Default>
-            <BitOffs>1286650688</BitOffs>
+            <BitOffs>1286651712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1</Name>
@@ -90492,7 +90820,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1286650752</BitOffs>
+            <BitOffs>1286651776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1_val</Name>
@@ -90508,7 +90836,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286651264</BitOffs>
+            <BitOffs>1286652288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2</Name>
@@ -90520,7 +90848,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1286651328</BitOffs>
+            <BitOffs>1286652352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2_val</Name>
@@ -90536,7 +90864,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286651840</BitOffs>
+            <BitOffs>1286652864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1</Name>
@@ -90548,7 +90876,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1286651904</BitOffs>
+            <BitOffs>1286652928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1_val</Name>
@@ -90564,7 +90892,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1286652416</BitOffs>
+            <BitOffs>1286653440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -90584,37 +90912,37 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>3664</Value>
               </SubItem>
             </Default>
-            <BitOffs>1286660288</BitOffs>
+            <BitOffs>1286661312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286686208</BitOffs>
+            <BitOffs>1286687232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287013632</BitOffs>
+            <BitOffs>1287014656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287341056</BitOffs>
+            <BitOffs>1287342080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287668480</BitOffs>
+            <BitOffs>1287669504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287995904</BitOffs>
+            <BitOffs>1287996928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbStates</Name>
@@ -90629,7 +90957,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288323328</BitOffs>
+            <BitOffs>1288324352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP</Name>
@@ -90650,7 +90978,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_1]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018048</BitOffs>
+            <BitOffs>1289019072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM</Name>
@@ -90671,7 +90999,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_2]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018304</BitOffs>
+            <BitOffs>1289019328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG</Name>
@@ -90692,7 +91020,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_4]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018560</BitOffs>
+            <BitOffs>1289019584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync</Name>
@@ -90713,7 +91041,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_3]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289018816</BitOffs>
+            <BitOffs>1289019840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige</Name>
@@ -90732,7 +91060,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bGigePower := TIIB[EL2004_SL1K2]^Channel 3^Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289019072</BitOffs>
+            <BitOffs>1289020096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter</Name>
@@ -90762,7 +91090,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3052_SL1K2_FWM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1289020416</BitOffs>
+            <BitOffs>1289021440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fSmallDelta</Name>
@@ -90772,7 +91100,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.01</Value>
             </Default>
-            <BitOffs>1289020928</BitOffs>
+            <BitOffs>1289021952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fBigDelta</Name>
@@ -90781,7 +91109,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>10</Value>
             </Default>
-            <BitOffs>1289020992</BitOffs>
+            <BitOffs>1289022016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fMaxVelocity</Name>
@@ -90790,7 +91118,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.5</Value>
             </Default>
-            <BitOffs>1289021056</BitOffs>
+            <BitOffs>1289022080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fHighAccel</Name>
@@ -90799,7 +91127,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.8</Value>
             </Default>
-            <BitOffs>1289021120</BitOffs>
+            <BitOffs>1289022144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fLowAccel</Name>
@@ -90808,25 +91136,25 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1289021184</BitOffs>
+            <BitOffs>1289022208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1289021248</BitOffs>
+            <BitOffs>1289022272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO</Name>
             <BitSize>145024</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>1289349888</BitOffs>
+            <BitOffs>1289350912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>1289494912</BitOffs>
+            <BitOffs>1289495936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ff2_ff1_link_optics</Name>
@@ -90850,7 +91178,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>65535</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289523264</BitOffs>
+            <BitOffs>1289524288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX01</Name>
@@ -90875,7 +91203,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62729</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289549184</BitOffs>
+            <BitOffs>1289550208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX02</Name>
@@ -90899,7 +91227,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62736</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289575104</BitOffs>
+            <BitOffs>1289576128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX05</Name>
@@ -90923,7 +91251,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62737</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289601024</BitOffs>
+            <BitOffs>1289602048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.delta</Name>
@@ -90932,7 +91260,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1289626944</BitOffs>
+            <BitOffs>1289627968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOS_IN</Name>
@@ -90948,7 +91276,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289626976</BitOffs>
+            <BitOffs>1289628000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOB_on_Lower_Stopper</Name>
@@ -90964,7 +91292,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289626984</BitOffs>
+            <BitOffs>1289628008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
@@ -90980,7 +91308,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289626992</BitOffs>
+            <BitOffs>1289628016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
@@ -90996,7 +91324,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289627000</BitOffs>
+            <BitOffs>1289628024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeam</Name>
@@ -91021,7 +91349,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289627008</BitOffs>
+            <BitOffs>1289628032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.nMachineMode</Name>
@@ -91039,7 +91367,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289652928</BitOffs>
+            <BitOffs>1289653952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefXM2K2</Name>
@@ -91057,110 +91385,110 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289652960</BitOffs>
+            <BitOffs>1289653984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289652992</BitOffs>
+            <BitOffs>1289654016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653056</BitOffs>
+            <BitOffs>1289654080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653120</BitOffs>
+            <BitOffs>1289654144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653184</BitOffs>
+            <BitOffs>1289654208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.HZos</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653248</BitOffs>
+            <BitOffs>1289654272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653312</BitOffs>
+            <BitOffs>1289654336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653376</BitOffs>
+            <BitOffs>1289654400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653440</BitOffs>
+            <BitOffs>1289654464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653504</BitOffs>
+            <BitOffs>1289654528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653568</BitOffs>
+            <BitOffs>1289654592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653632</BitOffs>
+            <BitOffs>1289654656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hb0m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653696</BitOffs>
+            <BitOffs>1289654720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm3</Name>
             <Comment>fixed calc</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653760</BitOffs>
+            <BitOffs>1289654784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hpiv</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653824</BitOffs>
+            <BitOffs>1289654848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653888</BitOffs>
+            <BitOffs>1289654912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289653952</BitOffs>
+            <BitOffs>1289654976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289654016</BitOffs>
+            <BitOffs>1289655040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Delta</Name>
@@ -91176,13 +91504,13 @@ MR2K2 X ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289654080</BitOffs>
+            <BitOffs>1289655104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Ans</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289654144</BitOffs>
+            <BitOffs>1289655168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeamExitSlits</Name>
@@ -91206,7 +91534,7 @@ MR2K2 X ENC REF</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289654208</BitOffs>
+            <BitOffs>1289655232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hi2</Name>
@@ -91216,7 +91544,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>1.4</Value>
             </Default>
-            <BitOffs>1289680128</BitOffs>
+            <BitOffs>1289681152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zi2</Name>
@@ -91226,7 +91554,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>731.613</Value>
             </Default>
-            <BitOffs>1289680192</BitOffs>
+            <BitOffs>1289681216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta0</Name>
@@ -91235,7 +91563,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>1289680256</BitOffs>
+            <BitOffs>1289681280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zm1</Name>
@@ -91245,7 +91573,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>733.772</Value>
             </Default>
-            <BitOffs>1289680320</BitOffs>
+            <BitOffs>1289681344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zmon</Name>
@@ -91255,7 +91583,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>739.622</Value>
             </Default>
-            <BitOffs>1289680384</BitOffs>
+            <BitOffs>1289681408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zpiv</Name>
@@ -91265,7 +91593,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>739.762</Value>
             </Default>
-            <BitOffs>1289680448</BitOffs>
+            <BitOffs>1289681472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zzos</Name>
@@ -91275,7 +91603,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>741.422</Value>
             </Default>
-            <BitOffs>1289680512</BitOffs>
+            <BitOffs>1289681536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1Offset</Name>
@@ -91284,7 +91612,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>18081.1</Value>
             </Default>
-            <BitOffs>1289680576</BitOffs>
+            <BitOffs>1289681600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2Offset</Name>
@@ -91293,7 +91621,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>-90603</Value>
             </Default>
-            <BitOffs>1289680640</BitOffs>
+            <BitOffs>1289681664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3Offset</Name>
@@ -91303,7 +91631,7 @@ MR2K2 X ENC REF</Comment>
             <Default>
               <Value>-63300</Value>
             </Default>
-            <BitOffs>1289680704</BitOffs>
+            <BitOffs>1289681728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
@@ -91317,19 +91645,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1289681408</BitOffs>
+            <BitOffs>1289682432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290068928</BitOffs>
+            <BitOffs>1290069952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290068992</BitOffs>
+            <BitOffs>1290070016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
@@ -91342,19 +91670,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1290069056</BitOffs>
+            <BitOffs>1290070080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290456576</BitOffs>
+            <BitOffs>1290457600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290456640</BitOffs>
+            <BitOffs>1290457664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
@@ -91367,19 +91695,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1290456704</BitOffs>
+            <BitOffs>1290457728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290844224</BitOffs>
+            <BitOffs>1290845248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290844288</BitOffs>
+            <BitOffs>1290845312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefYM2K2</Name>
@@ -91396,7 +91724,7 @@ MR2K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844352</BitOffs>
+            <BitOffs>1290845376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefrXM2K2</Name>
@@ -91413,7 +91741,7 @@ MR2K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844384</BitOffs>
+            <BitOffs>1290845408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntXM2K2</Name>
@@ -91431,7 +91759,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844416</BitOffs>
+            <BitOffs>1290845440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntYM2K2</Name>
@@ -91448,7 +91776,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844448</BitOffs>
+            <BitOffs>1290845472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntrXM2K2</Name>
@@ -91465,7 +91793,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844480</BitOffs>
+            <BitOffs>1290845504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefXM3K2</Name>
@@ -91483,7 +91811,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844512</BitOffs>
+            <BitOffs>1290845536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
@@ -91504,7 +91832,7 @@ MR3K2 X ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1290844544</BitOffs>
+            <BitOffs>1290845568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
@@ -91518,19 +91846,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1290846336</BitOffs>
+            <BitOffs>1290847360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291233856</BitOffs>
+            <BitOffs>1291234880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291233920</BitOffs>
+            <BitOffs>1291234944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
@@ -91543,19 +91871,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1291233984</BitOffs>
+            <BitOffs>1291235008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291621504</BitOffs>
+            <BitOffs>1291622528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291621568</BitOffs>
+            <BitOffs>1291622592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
@@ -91568,19 +91896,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1291621632</BitOffs>
+            <BitOffs>1291622656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292009152</BitOffs>
+            <BitOffs>1292010176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292009216</BitOffs>
+            <BitOffs>1292010240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
@@ -91593,19 +91921,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1292009280</BitOffs>
+            <BitOffs>1292010304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292396800</BitOffs>
+            <BitOffs>1292397824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292396864</BitOffs>
+            <BitOffs>1292397888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
@@ -91618,19 +91946,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1292396928</BitOffs>
+            <BitOffs>1292397952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292784448</BitOffs>
+            <BitOffs>1292785472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292784512</BitOffs>
+            <BitOffs>1292785536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefYM3K2</Name>
@@ -91647,7 +91975,7 @@ MR3K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784576</BitOffs>
+            <BitOffs>1292785600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefrYM3K2</Name>
@@ -91664,7 +91992,7 @@ MR3K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784608</BitOffs>
+            <BitOffs>1292785632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefUSM3K2</Name>
@@ -91681,7 +92009,7 @@ MR3K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784640</BitOffs>
+            <BitOffs>1292785664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefDSM3K2</Name>
@@ -91698,7 +92026,7 @@ MR3K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784672</BitOffs>
+            <BitOffs>1292785696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntXM3K2</Name>
@@ -91716,7 +92044,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784704</BitOffs>
+            <BitOffs>1292785728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntYM3K2</Name>
@@ -91733,7 +92061,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784736</BitOffs>
+            <BitOffs>1292785760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntrYM3K2</Name>
@@ -91750,7 +92078,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784768</BitOffs>
+            <BitOffs>1292785792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntUSM3K2</Name>
@@ -91767,7 +92095,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784800</BitOffs>
+            <BitOffs>1292785824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntDSM3K2</Name>
@@ -91784,7 +92112,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784832</BitOffs>
+            <BitOffs>1292785856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_1</Name>
@@ -91803,7 +92131,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784864</BitOffs>
+            <BitOffs>1292785888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_2</Name>
@@ -91820,7 +92148,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784896</BitOffs>
+            <BitOffs>1292785920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
@@ -91837,7 +92165,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784928</BitOffs>
+            <BitOffs>1292785952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
@@ -91855,7 +92183,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784960</BitOffs>
+            <BitOffs>1292785984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
@@ -91872,7 +92200,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292784992</BitOffs>
+            <BitOffs>1292786016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -91889,7 +92217,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292785024</BitOffs>
+            <BitOffs>1292786048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -91907,7 +92235,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1292785120</BitOffs>
+            <BitOffs>1292786144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
@@ -91928,7 +92256,7 @@ MR4K2 X ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292785152</BitOffs>
+            <BitOffs>1292786176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
@@ -91942,19 +92270,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1292786368</BitOffs>
+            <BitOffs>1292787392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293173888</BitOffs>
+            <BitOffs>1293174912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293173952</BitOffs>
+            <BitOffs>1293174976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
@@ -91967,19 +92295,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174016</BitOffs>
+            <BitOffs>1293175040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293561536</BitOffs>
+            <BitOffs>1293562560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293561600</BitOffs>
+            <BitOffs>1293562624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
@@ -91992,19 +92320,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1293561664</BitOffs>
+            <BitOffs>1293562688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293949184</BitOffs>
+            <BitOffs>1293950208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293949248</BitOffs>
+            <BitOffs>1293950272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
@@ -92017,19 +92345,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1293949312</BitOffs>
+            <BitOffs>1293950336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294336832</BitOffs>
+            <BitOffs>1294337856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294336896</BitOffs>
+            <BitOffs>1294337920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
@@ -92042,19 +92370,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1294336960</BitOffs>
+            <BitOffs>1294337984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294724480</BitOffs>
+            <BitOffs>1294725504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294724544</BitOffs>
+            <BitOffs>1294725568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -92071,7 +92399,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724608</BitOffs>
+            <BitOffs>1294725632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -92088,7 +92416,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724640</BitOffs>
+            <BitOffs>1294725664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -92105,7 +92433,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724672</BitOffs>
+            <BitOffs>1294725696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -92122,7 +92450,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724704</BitOffs>
+            <BitOffs>1294725728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -92140,7 +92468,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724736</BitOffs>
+            <BitOffs>1294725760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -92157,7 +92485,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724768</BitOffs>
+            <BitOffs>1294725792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -92174,7 +92502,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724800</BitOffs>
+            <BitOffs>1294725824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -92191,7 +92519,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724832</BitOffs>
+            <BitOffs>1294725856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -92208,7 +92536,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724864</BitOffs>
+            <BitOffs>1294725888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -92227,7 +92555,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724896</BitOffs>
+            <BitOffs>1294725920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -92244,7 +92572,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724928</BitOffs>
+            <BitOffs>1294725952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -92261,7 +92589,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724960</BitOffs>
+            <BitOffs>1294725984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -92279,7 +92607,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294724992</BitOffs>
+            <BitOffs>1294726016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -92296,7 +92624,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725024</BitOffs>
+            <BitOffs>1294726048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -92313,7 +92641,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725056</BitOffs>
+            <BitOffs>1294726080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -92336,7 +92664,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725120</BitOffs>
+            <BitOffs>1294726144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -92359,7 +92687,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725376</BitOffs>
+            <BitOffs>1294726400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
@@ -92380,7 +92708,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1294725696</BitOffs>
+            <BitOffs>1294726720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -92415,7 +92743,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294731968</BitOffs>
+            <BitOffs>1294732992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -92430,7 +92758,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734464</BitOffs>
+            <BitOffs>1294735488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -92444,7 +92772,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734528</BitOffs>
+            <BitOffs>1294735552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -92459,7 +92787,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734592</BitOffs>
+            <BitOffs>1294735616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -92474,7 +92802,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734656</BitOffs>
+            <BitOffs>1294735680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -92489,7 +92817,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734720</BitOffs>
+            <BitOffs>1294735744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -92504,7 +92832,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734784</BitOffs>
+            <BitOffs>1294735808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -92520,7 +92848,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734912</BitOffs>
+            <BitOffs>1294735936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -92534,7 +92862,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294734976</BitOffs>
+            <BitOffs>1294736000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -92548,7 +92876,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294735040</BitOffs>
+            <BitOffs>1294736064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -92562,7 +92890,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294735104</BitOffs>
+            <BitOffs>1294736128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -92577,7 +92905,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737664</BitOffs>
+            <BitOffs>1294738688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -92592,7 +92920,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737728</BitOffs>
+            <BitOffs>1294738752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -92607,7 +92935,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737792</BitOffs>
+            <BitOffs>1294738816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -92623,7 +92951,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737856</BitOffs>
+            <BitOffs>1294738880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -92637,7 +92965,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737920</BitOffs>
+            <BitOffs>1294738944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -92651,7 +92979,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294737984</BitOffs>
+            <BitOffs>1294739008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -92666,7 +92994,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738048</BitOffs>
+            <BitOffs>1294739072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -92681,7 +93009,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738112</BitOffs>
+            <BitOffs>1294739136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -92697,7 +93025,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738240</BitOffs>
+            <BitOffs>1294739264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -92711,7 +93039,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738304</BitOffs>
+            <BitOffs>1294739328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -92725,7 +93053,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738368</BitOffs>
+            <BitOffs>1294739392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -92740,7 +93068,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738432</BitOffs>
+            <BitOffs>1294739456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -92755,7 +93083,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738496</BitOffs>
+            <BitOffs>1294739520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -92770,7 +93098,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738560</BitOffs>
+            <BitOffs>1294739584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -92785,7 +93113,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738624</BitOffs>
+            <BitOffs>1294739648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -92800,7 +93128,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738688</BitOffs>
+            <BitOffs>1294739712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -92815,7 +93143,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738752</BitOffs>
+            <BitOffs>1294739776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -92830,7 +93158,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738912</BitOffs>
+            <BitOffs>1294739936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -92846,7 +93174,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294738944</BitOffs>
+            <BitOffs>1294739968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -92860,7 +93188,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739008</BitOffs>
+            <BitOffs>1294740032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -92874,7 +93202,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739072</BitOffs>
+            <BitOffs>1294740096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -92888,7 +93216,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739136</BitOffs>
+            <BitOffs>1294740160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -92906,7 +93234,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294739200</BitOffs>
+            <BitOffs>1294740224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -92924,7 +93252,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295234944</BitOffs>
+            <BitOffs>1295235968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -92953,7 +93281,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295730688</BitOffs>
+            <BitOffs>1295731712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -92982,7 +93310,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296255040</BitOffs>
+            <BitOffs>1296256064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -92993,7 +93321,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779392</BitOffs>
+            <BitOffs>1296780416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -93030,7 +93358,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296779840</BitOffs>
+            <BitOffs>1296780864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -93041,7 +93369,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296805056</BitOffs>
+            <BitOffs>1296806080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -93078,7 +93406,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297132480</BitOffs>
+            <BitOffs>1297133504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -93089,7 +93417,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297157696</BitOffs>
+            <BitOffs>1297158720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -93127,7 +93455,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297485120</BitOffs>
+            <BitOffs>1297486144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -93138,7 +93466,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297510336</BitOffs>
+            <BitOffs>1297511360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -93176,7 +93504,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297837760</BitOffs>
+            <BitOffs>1297838784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -93187,7 +93515,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297862976</BitOffs>
+            <BitOffs>1297864000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -93219,7 +93547,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298190400</BitOffs>
+            <BitOffs>1298191424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -93257,7 +93585,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298215616</BitOffs>
+            <BitOffs>1298216640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -93295,7 +93623,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298266048</BitOffs>
+            <BitOffs>1298267072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -93333,7 +93661,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298291264</BitOffs>
+            <BitOffs>1298292288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -93370,7 +93698,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298316480</BitOffs>
+            <BitOffs>1298317504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -93402,7 +93730,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298341696</BitOffs>
+            <BitOffs>1298342720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -93440,7 +93768,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298366912</BitOffs>
+            <BitOffs>1298367936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -93451,7 +93779,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298392128</BitOffs>
+            <BitOffs>1298393152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -93488,7 +93816,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298719552</BitOffs>
+            <BitOffs>1298720576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -93499,7 +93827,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298744768</BitOffs>
+            <BitOffs>1298745792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -93536,7 +93864,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299072192</BitOffs>
+            <BitOffs>1299073216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -93547,7 +93875,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299097408</BitOffs>
+            <BitOffs>1299098432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -93584,7 +93912,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299424832</BitOffs>
+            <BitOffs>1299425856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -93595,7 +93923,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299450048</BitOffs>
+            <BitOffs>1299451072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -93633,7 +93961,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299777472</BitOffs>
+            <BitOffs>1299778496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -93666,7 +93994,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299802688</BitOffs>
+            <BitOffs>1299803712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -93677,7 +94005,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299827904</BitOffs>
+            <BitOffs>1299828928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -93711,7 +94039,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300155328</BitOffs>
+            <BitOffs>1300156352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -93722,7 +94050,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300180544</BitOffs>
+            <BitOffs>1300181568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -93756,7 +94084,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300507968</BitOffs>
+            <BitOffs>1300508992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -93790,7 +94118,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300533184</BitOffs>
+            <BitOffs>1300534208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -93824,7 +94152,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300558400</BitOffs>
+            <BitOffs>1300559424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -93858,7 +94186,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300583616</BitOffs>
+            <BitOffs>1300584640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -93878,8 +94206,8 @@ M4K2 KBV X ENC CNT</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
@@ -93892,7 +94220,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300608832</BitOffs>
+            <BitOffs>1300609856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -93921,7 +94249,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300634048</BitOffs>
+            <BitOffs>1300635072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -93953,7 +94281,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300659264</BitOffs>
+            <BitOffs>1300660288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -93964,7 +94292,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300684480</BitOffs>
+            <BitOffs>1300685504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -93996,7 +94324,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301011904</BitOffs>
+            <BitOffs>1301012928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -94007,7 +94335,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301037120</BitOffs>
+            <BitOffs>1301038144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -94039,7 +94367,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301364544</BitOffs>
+            <BitOffs>1301365568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -94050,7 +94378,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301389760</BitOffs>
+            <BitOffs>1301390784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -94082,7 +94410,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301717184</BitOffs>
+            <BitOffs>1301718208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -94093,7 +94421,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301742400</BitOffs>
+            <BitOffs>1301743424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -94125,7 +94453,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302069824</BitOffs>
+            <BitOffs>1302070848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -94136,7 +94464,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302095040</BitOffs>
+            <BitOffs>1302096064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -94168,7 +94496,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302422464</BitOffs>
+            <BitOffs>1302423488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -94179,7 +94507,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302447680</BitOffs>
+            <BitOffs>1302448704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -94211,7 +94539,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302775104</BitOffs>
+            <BitOffs>1302776128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -94222,7 +94550,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302800320</BitOffs>
+            <BitOffs>1302801344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -94254,7 +94582,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303127744</BitOffs>
+            <BitOffs>1303128768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -94265,7 +94593,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303152960</BitOffs>
+            <BitOffs>1303153984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -94297,7 +94625,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303480384</BitOffs>
+            <BitOffs>1303481408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -94308,7 +94636,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303505600</BitOffs>
+            <BitOffs>1303506624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -94340,7 +94668,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303833024</BitOffs>
+            <BitOffs>1303834048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -94351,7 +94679,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303858240</BitOffs>
+            <BitOffs>1303859264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -94383,7 +94711,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304185664</BitOffs>
+            <BitOffs>1304186688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -94394,7 +94722,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304210880</BitOffs>
+            <BitOffs>1304211904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -94426,7 +94754,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304538304</BitOffs>
+            <BitOffs>1304539328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -94437,7 +94765,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304563520</BitOffs>
+            <BitOffs>1304564544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -94469,7 +94797,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304890944</BitOffs>
+            <BitOffs>1304891968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -94480,7 +94808,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304916160</BitOffs>
+            <BitOffs>1304917184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -94491,7 +94819,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243584</BitOffs>
+            <BitOffs>1305244608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -94506,7 +94834,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243600</BitOffs>
+            <BitOffs>1305244624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -94521,7 +94849,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243608</BitOffs>
+            <BitOffs>1305244632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -94551,7 +94879,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243616</BitOffs>
+            <BitOffs>1305244640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -94581,7 +94909,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243680</BitOffs>
+            <BitOffs>1305244704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -94596,7 +94924,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243744</BitOffs>
+            <BitOffs>1305244768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -94611,7 +94939,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243760</BitOffs>
+            <BitOffs>1305244784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -94626,7 +94954,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243776</BitOffs>
+            <BitOffs>1305244800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -94640,7 +94968,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243784</BitOffs>
+            <BitOffs>1305244808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -94655,7 +94983,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243808</BitOffs>
+            <BitOffs>1305244832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -94670,7 +94998,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243840</BitOffs>
+            <BitOffs>1305244864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -94791,7 +95119,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305243872</BitOffs>
+            <BitOffs>1305244896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -94805,7 +95133,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253344</BitOffs>
+            <BitOffs>1305254368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -94819,7 +95147,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305253376</BitOffs>
+            <BitOffs>1305254400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -94840,7 +95168,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305257024</BitOffs>
+            <BitOffs>1305258048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -94912,7 +95240,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305274944</BitOffs>
+            <BitOffs>1305275968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -94984,7 +95312,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275072</BitOffs>
+            <BitOffs>1305276096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -95056,7 +95384,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275200</BitOffs>
+            <BitOffs>1305276224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -95128,7 +95456,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275328</BitOffs>
+            <BitOffs>1305276352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -95200,7 +95528,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275456</BitOffs>
+            <BitOffs>1305276480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -95272,7 +95600,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305275584</BitOffs>
+            <BitOffs>1305276608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -95298,14 +95626,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305308608</BitOffs>
+            <BitOffs>1305309632</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164364288</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95385,7 +95713,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-04-01T10:07:17</Value>
+          <Value>2024-04-04T12:12:18</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{260DC897-92CC-1B18-6E76-E3ED3545641D}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{28463369-1E78-9975-DB5E-D0683DE89341}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -5349,15 +5349,15 @@ External Setpoint Generation:
         <Default>
           <SubItem>
             <Name>.tCtrlCycleTime</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#0MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTaskCycleTime</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#0MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTn</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#200MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.fKp</Name>
@@ -6819,7 +6819,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME</DateTime>
+          <DateTime>TIME#1s0ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -7113,7 +7113,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME</DateTime>
+          <DateTime>TIME#1S0MS</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -9120,7 +9120,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>128</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1h</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -11822,7 +11822,7 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -12021,6 +12021,9 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -12181,9 +12184,6 @@ External Setpoint Generation:
             </Property>
           </Properties>
         </Local>
-      </Method>
-      <Method>
-        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -12670,7 +12670,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12686,7 +12686,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#100ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12702,7 +12702,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10m</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13968,22 +13968,21 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14002,21 +14001,22 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14212,6 +14212,85 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -14270,85 +14349,6 @@ External Setpoint Generation:
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14552,13 +14552,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -14589,6 +14582,36 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Comment>
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14604,29 +14627,9 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-        <Comment>
-    Clears the contents of the entire buffer.
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -14647,20 +14650,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
+        <Name>ClearBuffer</Name>
         <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+    Clears the contents of the entire buffer.
 </Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
       </Method>
       <Properties>
         <Property>
@@ -15154,17 +15154,15 @@ External Setpoint Generation:
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsSkipped</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IsFailed</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
@@ -15206,12 +15204,14 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -15661,52 +15661,35 @@ External Setpoint Generation:
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15754,27 +15737,9 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
+        <Name>GetDetectionCountThisCycle</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15998,12 +15963,47 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -16143,7 +16143,37 @@ External Setpoint Generation:
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16151,7 +16181,9 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -16368,39 +16400,7 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16977,21 +16977,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_UINT</Name>
+        <Name>AssertEquals_STRING</Name>
         <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -17334,6 +17334,24 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_ULINT</Name>
         <Comment>
     Asserts that two ULINT arrays are equal. If they are not, an assertion error is created.
@@ -17428,6 +17446,21 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -17841,21 +17874,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_DINT</Name>
         <Comment>
     Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
@@ -17953,21 +17971,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_WSTRING</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> WSTRING expected value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> WSTRING actual value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18032,45 +18050,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
+        <Name>AssertEquals_WSTRING</Name>
         <Comment>
-    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> WSTRING expected value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> WSTRING actual value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18079,22 +18073,7 @@ External Setpoint Generation:
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -18102,127 +18081,6 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -18420,20 +18278,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertTrue</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that a condition is true. If it is not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -18442,16 +18294,6 @@ External Setpoint Generation:
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -18681,6 +18523,40 @@ External Setpoint Generation:
           <Name>Actual</Name>
           <Comment> DATE actual value</Comment>
           <Type>DATE</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
@@ -18974,6 +18850,331 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AssertArray3dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_UDINT</Name>
+        <Comment>
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -19071,211 +19272,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_STRING</Name>
-        <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -19309,14 +19305,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
+        <Name>AssertArrayEquals_LINT</Name>
         <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19330,8 +19326,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19555,21 +19551,6 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfSkippedTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>SkippedTestsCount</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -19849,22 +19830,19 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -20027,6 +20005,100 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_UINT</Name>
+        <Comment>
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSkippedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>SkippedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -20124,58 +20196,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_LREAL</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20189,8 +20217,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20201,6 +20229,12 @@ External Setpoint Generation:
               <Value>1</Value>
             </Property>
           </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -20262,40 +20296,6 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -20648,33 +20648,6 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>WriteLog</Name>
         <Comment> Writes a new data set into the ring buffer </Comment>
         <Parameter>
@@ -20709,6 +20682,33 @@ External Setpoint Generation:
           <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -22961,14 +22961,6 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -23021,20 +23013,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddKeyNull</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23048,17 +23026,25 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>StartObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -23083,6 +23069,12 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -23102,36 +23094,36 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddFileTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>StartObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
           <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -23158,6 +23150,20 @@ External Setpoint Generation:
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -23203,6 +23209,33 @@ External Setpoint Generation:
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -23254,153 +23287,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddBool</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddBase64</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddDcTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EndArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>EndObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>StartArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>CopyDocument</Name>
         <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
@@ -23433,6 +23319,120 @@ External Setpoint Generation:
               <Value>Output</Value>
             </Property>
           </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBase64</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EndArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>EndObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>StartArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -23750,11 +23750,22 @@ External Setpoint Generation:
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>Execute</Name>
-      </Action>
-      <Action>
         <Name>EvaluateOutput</Name>
       </Action>
+      <Action>
+        <Name>Execute</Name>
+      </Action>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
+      </Method>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -23813,51 +23824,6 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
-        <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IdxCheckIn</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>OK</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Reset</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stFF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
-        </Local>
-        <Local>
-          <Name>BeamPermitted</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Register</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23895,15 +23861,49 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>EvaluateVetos</Name>
+        <Name>IdxCheckIn</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>OK</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Reset</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stFF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
+        </Local>
+        <Local>
+          <Name>BeamPermitted</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
         <Properties>
           <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
+            <Name>no_check</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
+        <Parameter>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -24147,14 +24147,23 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <Method>
-        <Name>PopbackValue</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24241,15 +24250,19 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+        <Name>PushbackFileTimeValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -24293,6 +24306,33 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveMemberByName</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24316,6 +24356,16 @@ External Setpoint Generation:
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24350,23 +24400,34 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>PushbackUintValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ParseDocument</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -24406,17 +24467,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24432,7 +24482,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
+        <Name>PushbackBoolValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24442,8 +24492,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24508,6 +24558,16 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24544,60 +24604,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddJsonMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint</Name>
+        <Name>PushbackUint64Value</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24607,8 +24614,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24628,9 +24635,10 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveAllMembers</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24643,16 +24651,6 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -24663,17 +24661,12 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -24746,6 +24739,36 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>SetDcTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetArray</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24756,20 +24779,25 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -24829,9 +24857,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsBase64</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24839,7 +24867,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
+        <Name>IsTrue</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -24938,7 +24966,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetArray</Name>
+        <Name>AddObjectMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24947,9 +24975,15 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -24969,6 +25003,21 @@ External Setpoint Generation:
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25016,38 +25065,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25084,34 +25101,8 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsHexBinary</Name>
+        <Name>Swap</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -25119,11 +25110,31 @@ External Setpoint Generation:
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsHexBinary</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25157,9 +25168,34 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -25222,9 +25258,10 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25232,17 +25269,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackFileTimeValue</Name>
+        <Name>AddJsonMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25251,9 +25278,26 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -25294,9 +25338,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25398,6 +25442,14 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>SetMaxDecimalPlaces</Name>
+        <Parameter>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25480,17 +25532,59 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
+        <Name>SetUint</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>dp</Name>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25544,42 +25638,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackBoolValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25606,23 +25664,13 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -25711,10 +25759,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25732,22 +25779,7 @@ External Setpoint Generation:
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
+          <Name>value</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -25779,28 +25811,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArrayValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25815,136 +25836,11 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackDoubleValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -25982,7 +25878,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
+        <Name>PushbackDoubleValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25992,8 +25888,112 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -30169,22 +30169,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30203,21 +30202,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30416,6 +30416,100 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -30474,100 +30568,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -30771,13 +30771,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -30808,6 +30801,36 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>WriteDocumentHeader</Name>
+        <Comment>
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -30823,29 +30846,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
-        <Comment>
-    Clears the contents of the entire buffer.
-</Comment>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -30866,20 +30869,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
+        <Name>ClearBuffer</Name>
         <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+    Clears the contents of the entire buffer.
 </Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+      </Method>
+      <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
       </Method>
       <Properties>
         <Property>
@@ -31253,12 +31253,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -31270,6 +31264,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -31286,9 +31288,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -31328,17 +31330,15 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Properties>
         <Property>
@@ -31608,52 +31608,35 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31701,27 +31684,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
+        <Name>GetDetectionCountThisCycle</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31945,12 +31910,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
+        <Name>AddAssertResult</Name>
+        <Parameter>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
           <BitSize>16</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -32096,7 +32096,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>CreateAssertResultInstance</Name>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32104,7 +32134,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -32321,39 +32353,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32921,21 +32921,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -33672,688 +33672,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
-        <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -34663,6 +33981,533 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -35207,21 +35052,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>CompleteTestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -35713,24 +35543,56 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestName</Name>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
         <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -35801,21 +35663,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertArray2dEquals_REAL</Name>
         <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -35824,7 +35710,22 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -35832,6 +35733,124 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36105,37 +36124,18 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
           <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
-        </Local>
+        </Parameter>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36482,7 +36482,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#10MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -36501,40 +36501,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10MS</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -36571,6 +36544,33 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -36788,44 +36788,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Init2</Name>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nTimestamp</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipMessage</Name>
-          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarm</Name>
-          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Release</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -36875,6 +36837,44 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>property</Name>
           </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Init2</Name>
+        <Parameter>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nTimestamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipMessage</Name>
+          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarm</Name>
+          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
@@ -37051,6 +37051,47 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>TcQueryInterface</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -37098,21 +37139,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>Execute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -37215,45 +37241,19 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
+        <Name>Execute</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38741,6 +38741,26 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>RequestRemote</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38846,45 +38866,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sEventText</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>Request</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38914,6 +38895,25 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
           <BitSize>64</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventText</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38984,11 +38984,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> | generates a JSON string from a given symbol (via address/size).
+ | Method returns TRUE if succeeded.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -39002,16 +39002,28 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39024,16 +39036,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -39179,6 +39181,58 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39349,60 +39403,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> | generates a JSON string from a given symbol (via address/size).
- | Method returns TRUE if succeeded.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
-          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
@@ -39948,7 +39948,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>865952</BitOffs>
         <Default>
-          <Bool>udint</Bool>
+          <Bool>nt :=</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -39986,12 +39986,46 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -40121,40 +40155,6 @@ contributing fast faults, unless the FFO is currently vetoed.
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -40365,7 +40365,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40465,7 +40465,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#10s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40793,7 +40793,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#1h</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40805,7 +40805,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#1s</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40817,7 +40817,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#10s</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -50329,7 +50329,7 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1s</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -52114,6 +52114,9 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_Error</Name>
       </Action>
       <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
         <Name>M_Manual</Name>
       </Action>
       <Action>
@@ -52123,13 +52126,10 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Init</Name>
       </Action>
       <Properties>
         <Property>
@@ -52404,6 +52404,9 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_Error</Name>
       </Action>
       <Action>
+        <Name>M_Reset</Name>
+      </Action>
+      <Action>
         <Name>M_Manual</Name>
       </Action>
       <Action>
@@ -52413,13 +52416,10 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
-      </Action>
-      <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Init</Name>
       </Action>
       <Properties>
         <Property>
@@ -52573,19 +52573,19 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>704</BitOffs>
       </SubItem>
       <Action>
-        <Name>M_Active</Name>
+        <Name>M_Reset</Name>
       </Action>
       <Action>
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
+        <Name>M_Active</Name>
       </Action>
       <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Init</Name>
       </Action>
       <Properties>
         <Property>
@@ -52841,7 +52841,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#2S</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -52853,7 +52853,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#500MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -53159,7 +53159,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#100MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -53204,7 +53204,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T</DateTime>
+            <DateTime>T#2S</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -55657,10 +55657,10 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>256448</BitOffs>
       </SubItem>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Properties>
         <Property>
@@ -55749,6 +55749,37 @@ Use this thing to have a simple indexer with rollover.
       </Method>
     </DataType>
     <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -55793,37 +55824,6 @@ Use this thing to have a simple indexer with rollover.
 	</Value>
           </Property>
         </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -56439,28 +56439,28 @@ Use this thing to have a simple indexer with rollover.
         </Default>
       </SubItem>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Properties>
         <Property>
@@ -56687,7 +56687,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>237128</BitOffs>
         <Default>
-          <Bool>true</Bool>
+          <Bool> : u</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -56721,30 +56721,42 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>409664</BitOffs>
       </SubItem>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqId</Name>
+          <Name>nReqID</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>86080</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
         </Local>
       </Method>
       <Method>
@@ -56875,42 +56887,6 @@ These features efficiently address the addition, removal, and verification of be
         </Properties>
       </Method>
       <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -56952,20 +56928,44 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqId</Name>
+          <Type>DWORD</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>86080</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
         </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -57116,7 +57116,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -57369,13 +57369,13 @@ ELSE:
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -58263,13 +58263,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
-      </Action>
-      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
+      </Action>
+      <Action>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -58290,7 +58290,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>AssertFinalBP</Name>
+        <Name>DeauthorizeTransition</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -58539,10 +58539,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -58893,7 +58893,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>257952</BitOffs>
         <Default>
-          <DateTime>T</DateTime>
+          <DateTime>T#1s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -59932,7 +59932,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>144960</BitOffs>
         <Default>
-          <Bool>,</Bool>
+          <Bool>,
+  </Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -72249,7 +72250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72272,7 +72273,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72293,7 +72294,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72391,7 +72392,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72409,7 +72410,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72567,7 +72568,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -72664,7 +72665,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72719,7 +72720,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72910,7 +72911,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>8</DateTime>
+              <DateTime>T#8ms</DateTime>
             </Default>
             <BitOffs>1264935328</BitOffs>
           </Symbol>
@@ -73196,7 +73197,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -80101,7 +80102,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -81843,7 +81844,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -81994,7 +81995,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#1ms</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82009,7 +82010,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#100ms</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82024,7 +82025,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#10s</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82039,7 +82040,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#10m</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -88627,7 +88628,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T</DateTime>
+              <DateTime>T#0MS</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -89007,7 +89008,7 @@ Emergency Stop for MR1K1</Comment>
             <Default>
               <SubItem>
                 <Name>.PT</Name>
-                <DateTime>T</DateTime>
+                <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
             <BitOffs>1265827328</BitOffs>
@@ -93113,8 +93114,7 @@ M4K2 KBV X ENC CNT</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2</Value>
+                <Value>.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -93161,8 +93161,7 @@ M4K2 KBV X ENC CNT</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2</Value>
+                <Value>.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -95308,7 +95307,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164233216</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95388,11 +95387,11 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-26T14:27:10</Value>
+          <Value>2024-02-27T16:51:26</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>917504</Value>
+          <Value>978944</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{82D15D0F-784A-EDEC-0951-8604808142FF}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{64BADEED-7A46-6999-26C7-6F1A919E5DB8}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -72250,7 +72250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72273,7 +72273,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72294,7 +72294,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72392,7 +72392,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72410,7 +72410,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72568,13 +72568,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1264933760</BitOffs>
+            <BitOffs>1265714560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -72665,7 +72665,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72681,7 +72681,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265050560</BitOffs>
+            <BitOffs>1264934464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -72697,7 +72697,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265050624</BitOffs>
+            <BitOffs>1264934528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -72713,14 +72713,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265050688</BitOffs>
+            <BitOffs>1264934592</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72882,14 +72882,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265050752</BitOffs>
+            <BitOffs>1264934656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265051400</BitOffs>
+            <BitOffs>1264935304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -72904,7 +72904,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265051408</BitOffs>
+            <BitOffs>1264935312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -72913,20 +72913,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265051424</BitOffs>
+            <BitOffs>1264935328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265051456</BitOffs>
+            <BitOffs>1264935360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265051520</BitOffs>
+            <BitOffs>1264935424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -72935,19 +72935,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265051584</BitOffs>
+            <BitOffs>1264935488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265051648</BitOffs>
+            <BitOffs>1264935552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265051712</BitOffs>
+            <BitOffs>1264935616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -72962,25 +72962,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265051776</BitOffs>
+            <BitOffs>1264935680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265051840</BitOffs>
+            <BitOffs>1264935744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052096</BitOffs>
+            <BitOffs>1264936000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265052160</BitOffs>
+            <BitOffs>1264936064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -72989,79 +72989,79 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265052224</BitOffs>
+            <BitOffs>1264936128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052288</BitOffs>
+            <BitOffs>1264936192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052352</BitOffs>
+            <BitOffs>1264936256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265052416</BitOffs>
+            <BitOffs>1264936320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265053440</BitOffs>
+            <BitOffs>1264937344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265053504</BitOffs>
+            <BitOffs>1264937408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265053568</BitOffs>
+            <BitOffs>1264937472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265053632</BitOffs>
+            <BitOffs>1264937536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265053696</BitOffs>
+            <BitOffs>1264937600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265164288</BitOffs>
+            <BitOffs>1265048192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265439488</BitOffs>
+            <BitOffs>1265323392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265550080</BitOffs>
+            <BitOffs>1265433984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265825280</BitOffs>
+            <BitOffs>1265709184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -73073,7 +73073,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265825792</BitOffs>
+            <BitOffs>1265709696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -73085,14 +73085,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265826368</BitOffs>
+            <BitOffs>1265710272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265827200</BitOffs>
+            <BitOffs>1265711104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -73108,7 +73108,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265827520</BitOffs>
+            <BitOffs>1265711424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -73123,7 +73123,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265827552</BitOffs>
+            <BitOffs>1265711456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -73197,7 +73197,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -80102,7 +80102,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -81844,7 +81844,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -88964,10 +88964,41 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264816704</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265711360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265711376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265711392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>1265711408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <BitOffs>1265711416</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265046400</BitOffs>
+            <BitOffs>1265827200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -88980,38 +89011,7 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265046528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265827456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265827472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265827488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>1265827504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <BitOffs>1265827512</BitOffs>
+            <BitOffs>1265827328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -93427,8 +93427,8 @@ M4K2 KBV X ENC CNT</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
-							  .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-							  .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
+                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -93476,7 +93476,7 @@ M4K2 KBV X ENC CNT</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-						.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
+                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -95305,7 +95305,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164233216</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95385,7 +95385,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-03-27T14:34:04</Value>
+          <Value>2024-04-01T10:07:17</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C85B3384-5678-5727-ADC1-FE3E8545C97D}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{ED4D5D9F-FC60-174F-F845-FEC39D417C4D}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -5349,15 +5349,15 @@ External Setpoint Generation:
         <Default>
           <SubItem>
             <Name>.tCtrlCycleTime</Name>
-            <DateTime>T#0MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTaskCycleTime</Name>
-            <DateTime>T#0MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTn</Name>
-            <DateTime>T#200MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
           <SubItem>
             <Name>.fKp</Name>
@@ -6819,7 +6819,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME#1s0ms</DateTime>
+          <DateTime>TIME</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -7113,7 +7113,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>TIME#1S0MS</DateTime>
+          <DateTime>TIME</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -9120,7 +9120,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>128</BitOffs>
         <Default>
-          <DateTime>T#1h</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -11822,7 +11822,7 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>UpdateLangId</Name>
+        <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
@@ -12021,9 +12021,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -12184,6 +12181,9 @@ External Setpoint Generation:
             </Property>
           </Properties>
         </Local>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
@@ -12670,7 +12670,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <DateTime>T#1ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12686,7 +12686,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <DateTime>T#100ms</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -12702,7 +12702,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <DateTime>T#10m</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13968,21 +13968,22 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14001,22 +14002,21 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -14212,85 +14212,6 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Parameter>
-          <Name>Append</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Parameter>
-          <Name>Length</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -14349,6 +14270,85 @@ External Setpoint Generation:
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Parameter>
+          <Name>Length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Parameter>
+          <Name>Append</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -14552,6 +14552,13 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -14582,36 +14589,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -14627,9 +14604,29 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -14650,17 +14647,20 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -15154,15 +15154,17 @@ External Setpoint Generation:
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
+        <Name>IsSkipped</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsSkipped</Name>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsFailed</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
@@ -15204,14 +15206,12 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -15661,35 +15661,52 @@ External Setpoint Generation:
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15737,9 +15754,27 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -15963,47 +15998,12 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -16143,37 +16143,7 @@ External Setpoint Generation:
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16181,9 +16151,7 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -16400,7 +16368,39 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -16977,21 +16977,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_STRING</Name>
+        <Name>AssertEquals_UINT</Name>
         <Comment>
-    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> STRING expected value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT expected value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> STRING actual value</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Comment> UINT actual value</Comment>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -17334,24 +17334,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>SetTestFinished</Name>
-        <Comment> Marks the test as finished in this testsuite.
-   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
-</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_ULINT</Name>
         <Comment>
     Asserts that two ULINT arrays are equal. If they are not, an assertion error is created.
@@ -17446,21 +17428,6 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsTestFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -17874,6 +17841,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AreAllTestsFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>GetCurTaskIndex</Name>
+          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
+          <BitSize>256</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertArrayEquals_DINT</Name>
         <Comment>
     Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
@@ -17971,21 +17953,21 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_SINT</Name>
+        <Name>AssertEquals_WSTRING</Name>
         <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Comment> WSTRING expected value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
+          <Comment> WSTRING actual value</Comment>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18050,21 +18032,45 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_WSTRING</Name>
+        <Name>AssertArray3dEquals_REAL</Name>
         <Comment>
-    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
+    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> WSTRING expected value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Name>Expecteds</Name>
+          <Comment> REAL 3d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
-          <Name>Actual</Name>
-          <Comment> WSTRING actual value</Comment>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
+          <Name>Actuals</Name>
+          <Comment> REAL 3d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>3</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -18073,7 +18079,22 @@ External Setpoint Generation:
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -18081,6 +18102,127 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>3</Elements>
+          </ArrayInfo>
+          <BitSize>96</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualValueString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>FormatString</Name>
+          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
+          <BitSize>8576</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -18278,14 +18420,20 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertTrue</Name>
+        <Name>AssertEquals_BYTE</Name>
         <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
           <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
@@ -18294,6 +18442,16 @@ External Setpoint Generation:
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
@@ -18523,40 +18681,6 @@ External Setpoint Generation:
           <Name>Actual</Name>
           <Comment> DATE actual value</Comment>
           <Type>DATE</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
@@ -18850,331 +18974,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray3dEquals_REAL</Name>
-        <Comment>
-    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 3d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 3d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="3">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>3</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>3</Elements>
-          </ArrayInfo>
-          <BitSize>96</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualValueString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>FormatString</Name>
-          <Type Namespace="Tc2_Utilities">FB_FormatString</Type>
-          <BitSize>8576</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_DINT</Name>
-        <Comment>
-    Asserts that two DINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> DINT expected value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DINT actual value</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_UDINT</Name>
-        <Comment>
-    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> UDINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> UDINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_INT</Name>
         <Comment>
     Asserts that two INT arrays are equal. If they are not, an assertion error is created.
@@ -19272,6 +19071,211 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AssertArrayEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> DINT expected value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> DINT actual value</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> STRING expected value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> STRING actual value</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AssertFalse</Name>
         <Comment>
     Asserts that a condition is false. If it is not, an assertion error is created.
@@ -19305,14 +19309,14 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LINT</Name>
+        <Name>AssertArrayEquals_UDINT</Name>
         <Comment>
-    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19326,8 +19330,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
+          <Comment> UDINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">UDINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -19551,6 +19555,21 @@ External Setpoint Generation:
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetNumberOfSkippedTests</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>SkippedTestsCount</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
       </Method>
       <Method>
@@ -19830,19 +19849,22 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AreAllTestsFinished</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>GetCurTaskIndex</Name>
-          <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-          <BitSize>256</BitSize>
-        </Local>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddTest</Name>
@@ -20005,100 +20027,6 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>FindTestSuiteInstancePath</Name>
-        <Comment> Searches for the instance path of the calling function block </Comment>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BYTE</Name>
-        <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_UINT</Name>
-        <Comment>
-    Asserts that two UINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> UINT expected value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> UINT actual value</Comment>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetNumberOfSkippedTests</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>SkippedTestsCount</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
         <Name>AssertArrayEquals_UINT</Name>
         <Comment>
     Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
@@ -20196,14 +20124,58 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>AssertArrayEquals_LREAL</Name>
+        <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsTestFinished</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>TestName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_LINT</Name>
         <Comment>
-    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expecteds</Name>
-          <Comment> LREAL array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20217,8 +20189,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>Actuals</Name>
-          <Comment> LREAL array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">LREAL</Type>
+          <Comment> LINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">LINT</Type>
           <BitSize>64</BitSize>
           <Properties>
             <Property>
@@ -20229,12 +20201,6 @@ External Setpoint Generation:
               <Value>1</Value>
             </Property>
           </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -20296,6 +20262,40 @@ External Setpoint Generation:
           <Name>ActualsIndex</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -20648,6 +20648,33 @@ External Setpoint Generation:
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>WriteLog</Name>
         <Comment> Writes a new data set into the ring buffer </Comment>
         <Parameter>
@@ -20682,33 +20709,6 @@ External Setpoint Generation:
           <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="LCLS_General.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -22961,6 +22961,14 @@ External Setpoint Generation:
         </Default>
       </SubItem>
       <Method>
+        <Name>AddUlint</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddKeyNumber</Name>
         <Parameter>
           <Name>key</Name>
@@ -23013,6 +23021,20 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>AddKeyNull</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsComplete</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -23026,25 +23048,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddHexBinary</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddLint</Name>
         <Parameter>
           <Name>value</Name>
           <Type>LINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
+      </Method>
+      <Method>
+        <Name>StartObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>AddLreal</Name>
@@ -23069,12 +23083,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>ResetDocument</Name>
-        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
         <Name>AddKeyLreal</Name>
         <Parameter>
           <Name>key</Name>
@@ -23094,36 +23102,36 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>StartObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>AddFileTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>AddNull</Name>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
         <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <Name>value</Name>
+          <Type>REAL</Type>
           <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
         </Parameter>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
+      </Method>
+      <Method>
+        <Name>AddHexBinary</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Local>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>AddKeyDcTime</Name>
@@ -23150,20 +23158,6 @@ External Setpoint Generation:
           <Name>value</Name>
           <Type>DATE_AND_TIME</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddRawObject</Name>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -23209,33 +23203,6 @@ External Setpoint Generation:
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">SINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>n</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AddDint</Name>
@@ -23287,6 +23254,153 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>dp</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddRawObject</Name>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">SINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>n</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddBase64</Name>
+        <Parameter>
+          <Name>pBytes</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBytes</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDcTime</Name>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddKeyDateTime</Name>
+        <Parameter>
+          <Name>key</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DATE_AND_TIME</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EndArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>EndObject</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>StartArray</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>CopyDocument</Name>
         <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
@@ -23319,120 +23433,6 @@ External Setpoint Generation:
               <Value>Output</Value>
             </Property>
           </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUlint</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AddFileTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddNull</Name>
-      </Method>
-      <Method>
-        <Name>AddKeyDateTime</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DATE_AND_TIME</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddBool</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddBase64</Name>
-        <Parameter>
-          <Name>pBytes</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nBytes</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddDcTime</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddKeyNull</Name>
-        <Parameter>
-          <Name>key</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EndArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>EndObject</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>StartArray</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
-        <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -23750,22 +23750,11 @@ External Setpoint Generation:
         <Name>ExecuteNoLog</Name>
       </Action>
       <Action>
-        <Name>EvaluateOutput</Name>
-      </Action>
-      <Action>
         <Name>Execute</Name>
       </Action>
-      <Method>
-        <Name>EvaluateVetos</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>obsolete</Name>
-            <Value>Use EvaluateOverrides instead.</Value>
-          </Property>
-        </Properties>
-      </Method>
+      <Action>
+        <Name>EvaluateOutput</Name>
+      </Action>
       <Method>
         <Name>EvaluateOverrides</Name>
         <ReturnType>BOOL</ReturnType>
@@ -23824,41 +23813,14 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>Register</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>FormulateLogJson</Name>
+        <ReturnType>STRING(80)</ReturnType>
+        <ReturnBitSize>648</ReturnBitSize>
         <Parameter>
-          <Name>stFFInfo</Name>
-          <Type Namespace="PMPS">ST_FFInfo</Type>
-          <BitSize>6832</BitSize>
+          <Name>FF</Name>
+          <Type Namespace="PMPS">ST_FF</Type>
+          <BitSize>8128</BitSize>
         </Parameter>
-        <Parameter>
-          <Name>FFOName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Idx</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>no_check</Name>
-          </Property>
-        </Properties>
       </Method>
       <Method>
         <Name>IdxCheckIn</Name>
@@ -23896,14 +23858,52 @@ External Setpoint Generation:
         </Properties>
       </Method>
       <Method>
-        <Name>FormulateLogJson</Name>
-        <ReturnType>STRING(80)</ReturnType>
-        <ReturnBitSize>648</ReturnBitSize>
+        <Name>Register</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>FF</Name>
-          <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8128</BitSize>
+          <Name>stFFInfo</Name>
+          <Type Namespace="PMPS">ST_FFInfo</Type>
+          <BitSize>6832</BitSize>
         </Parameter>
+        <Parameter>
+          <Name>FFOName</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Idx</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>no_check</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EvaluateVetos</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>obsolete</Name>
+            <Value>Use EvaluateOverrides instead.</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -24147,23 +24147,14 @@ External Setpoint Generation:
         </Properties>
       </SubItem>
       <Method>
-        <Name>GetHexBinary</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PopbackValue</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24250,19 +24241,15 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackFileTimeValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Method>
         <Name>PushbackIntValue</Name>
@@ -24306,33 +24293,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveMemberByName</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>keepOrder</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddArrayMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24356,16 +24316,6 @@ External Setpoint Generation:
           <Name>reserve</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetNull</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24400,34 +24350,23 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUintValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetAdsProvider</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
+          <Name>oid</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>ParseDocument</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>IsDouble</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>sJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -24467,6 +24406,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>RemoveAllMembers</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetDouble</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24482,7 +24432,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackBoolValue</Name>
+        <Name>SetDcTime</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24492,8 +24442,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24558,16 +24508,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetObject</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AddDateTimeMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24604,7 +24544,60 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackUint64Value</Name>
+        <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>l</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AddJsonMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24614,8 +24607,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -24635,10 +24628,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>RemoveAllMembers</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetObject</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24651,6 +24643,16 @@ External Setpoint Generation:
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
+        <Name>GetArraySize</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>IsISO8601TimeFormat</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -24661,12 +24663,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArraySize</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>PushbackUint64Value</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -24739,36 +24746,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetDcTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetArray</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>reserve</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetFileTime</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -24779,25 +24756,20 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetStringLength</Name>
-        <Comment>| Returns the size in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>Swap</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
+        <Parameter>
+          <Name>w</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>l</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
+        </Parameter>
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
@@ -24857,9 +24829,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsBase64</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetUint64</Name>
+        <ReturnType>ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -24867,7 +24839,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsTrue</Name>
+        <Name>IsBase64</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -24966,7 +24938,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddObjectMember</Name>
+        <Name>SetArray</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -24975,15 +24947,9 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
+          <Name>reserve</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -25003,21 +24969,6 @@ External Setpoint Generation:
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetFileTime</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25065,6 +25016,38 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
+        <Name>AddStringMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetBase64</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25101,40 +25084,46 @@ External Setpoint Generation:
         </Local>
       </Method>
       <Method>
-        <Name>Swap</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>p</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>w</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>q</Name>
+          <Type PointerTo="1">BYTE</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetUint64</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        </Local>
+        <Local>
+          <Name>t</Name>
+          <Type PointerTo="1">STRING(255)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        </Local>
+        <Local>
+          <Name>length</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>IsHexBinary</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetUint</Name>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25168,34 +25157,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>IsFalse</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetAdsProvider</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>oid</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>MemberBegin</Name>
-        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
+        <Name>GetMaxDecimalPlaces</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>NewDocument</Name>
@@ -25258,10 +25222,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PopbackValue</Name>
-        <Comment> returns TRUE if succeeded</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNull</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25269,7 +25232,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddJsonMember</Name>
+        <Name>GetDateTime</Name>
+        <ReturnType>DATE_AND_TIME</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackFileTimeValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25278,26 +25251,9 @@ External Setpoint Generation:
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>member</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
           <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
       </Method>
       <Method>
@@ -25338,9 +25294,9 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDateTime</Name>
-        <ReturnType>DATE_AND_TIME</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
+        <Name>IsTrue</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25442,14 +25398,6 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetMaxDecimalPlaces</Name>
-        <Parameter>
-          <Name>dp</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>FindMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25532,59 +25480,17 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>SetUint</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>SetMaxDecimalPlaces</Name>
         <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>SetHexBinary</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>p</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>n</Name>
+          <Name>dp</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name>GetArrayValueByIdx</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>idx</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackHexBinaryValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>GetHexBinary</Name>
+        <ReturnType>DINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25638,6 +25544,42 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
+        <Name>AddObjectMember</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>member</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackBoolValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AddBoolMember</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
@@ -25664,13 +25606,23 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDcTime</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <Name>SetHexBinary</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -25759,9 +25711,10 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>AddStringMember</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
+        <Name>RemoveMemberByName</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>v</Name>
           <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
@@ -25779,7 +25732,22 @@ External Setpoint Generation:
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>value</Name>
+          <Name>keepOrder</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackJsonValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>rawJson</Name>
           <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
           <Properties>
@@ -25811,17 +25779,28 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetMaxDecimalPlaces</Name>
-        <ReturnType>DINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArrayValue</Name>
+        <Name>ParseDocument</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
-          <Name>i</Name>
-          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <Name>sJson</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsFalse</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -25836,11 +25815,136 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>GetDocument</Name>
-        <Comment> | Returns the full DOM document. 
- | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
+        <Name>GetArrayValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>i</Name>
+          <Type GUID="{1CDBE9A4-A0EC-4898-8CEC-1550896CC52E}">SJsonAIterator</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetFileTime</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000046}">FILETIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackDoubleValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PushbackHexBinaryValue</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>n</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>MemberBegin</Name>
+        <ReturnType GUID="{1CDBE9A4-A0EC-4898-8CED-1550896CC52E}">SJsonIterator</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArrayValueByIdx</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>idx</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>SetUint64</Name>
+        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDcTime</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>IsArray</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>v</Name>
+          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
         <Local>
           <Name>p</Name>
           <Type PointerTo="1">BYTE</Type>
@@ -25878,7 +25982,7 @@ External Setpoint Generation:
         </Parameter>
       </Method>
       <Method>
-        <Name>PushbackDoubleValue</Name>
+        <Name>PushbackUintValue</Name>
         <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Parameter>
@@ -25888,112 +25992,8 @@ External Setpoint Generation:
         </Parameter>
         <Parameter>
           <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint</Name>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetUint64</Name>
-        <ReturnType>ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDocumentLength</Name>
-        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJson</Name>
-        <Comment>| Returns the JSON document. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>p</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>q</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>t</Name>
-          <Type PointerTo="1">STRING(255)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>length</Name>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>IsArray</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PushbackJsonValue</Name>
-        <ReturnType GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>rawJson</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>IsDouble</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>v</Name>
-          <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -30169,21 +30169,22 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
-        <Name>Open</Name>
+        <Name>Write</Name>
         <Comment>
-    Opens a file
+    Writes the contents of the buffer into a file.
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>FileName</Name>
-          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>BufferPointer</Name>
+          <Comment> Call with ADR();</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
-          <Name>FileAccessMode</Name>
-          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
+          <Name>Size</Name>
+          <Comment> Call with SIZEOF();</Comment>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30202,22 +30203,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>Write</Name>
+        <Name>Open</Name>
         <Comment>
-    Writes the contents of the buffer into a file.
+    Opens a file
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>BufferPointer</Name>
-          <Comment> Call with ADR();</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
+          <Name>FileName</Name>
+          <Comment> File name can contain an absolute or relative path to the file. Path entries must be separated with a Slash (/)</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Size</Name>
-          <Comment> Call with SIZEOF();</Comment>
-          <Type>UDINT</Type>
+          <Name>FileAccessMode</Name>
+          <Type Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Type>
           <BitSize>32</BitSize>
         </Parameter>
       </Method>
@@ -30416,100 +30416,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Clear</Name>
-        <Comment>
-    Clears the buffer and sets the length to 0
-</Comment>
-        <Local>
-          <Name>Count</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>__setAppend</Name>
-        <Comment>
-    Appends a string to the buffer
-</Comment>
-        <Parameter>
-          <Name>Append</Name>
-          <Comment>
-    Appends a string to the buffer
-</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ByteIn</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ByteBuffer</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__getBufferSize</Name>
-        <Comment>
-    Read current Buffersize
-</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>BufferSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>__setLength</Name>
-        <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-        <Parameter>
-          <Name>Length</Name>
-          <Comment>
-    Gets/Sets the current length (in bytes) of the streambuffer
-</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>SetBuffer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>PointerToBufferAddress</Name>
-          <Comment> Set buffer address (ADR ...)</Comment>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>SizeOfBuffer</Name>
-          <Comment> Set buffer size (SIZEOF ...)</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Copy</Name>
         <Comment>
     Copies a string from the character buffer
@@ -30568,6 +30474,100 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
+        <Local>
+          <Name>Count</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <Parameter>
+          <Name>Length</Name>
+          <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>BufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SetBuffer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>PointerToBufferAddress</Name>
+          <Comment> Set buffer address (ADR ...)</Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>SizeOfBuffer</Name>
+          <Comment> Set buffer size (SIZEOF ...)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
+        <Parameter>
+          <Name>Append</Name>
+          <Comment>
+    Appends a string to the buffer
+</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ByteIn</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ByteBuffer</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -30771,6 +30771,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
+        <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -30801,36 +30808,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>WriteDocumentHeader</Name>
-        <Comment>
-    Add your own preffered fileheader like:
-    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-    
-    Start with calling this method before appending any other tags!
-
-    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
-</Comment>
-        <Parameter>
-          <Name>Header</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>NewComment</Name>
-        <Comment>
-    Adds a comment
-    XML: &lt;!-- MyComment --&gt;
-
-    XML.NewComment(Comment: = 'MyComment');
-</Comment>
-        <Parameter>
-          <Name>Comment</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -30846,9 +30823,29 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
+      </Method>
+      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
+        <Parameter>
+          <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
@@ -30869,17 +30866,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>ClearBuffer</Name>
+        <Name>WriteDocumentHeader</Name>
         <Comment>
-    Clears the contents of the entire buffer.
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
 </Comment>
-      </Method>
-      <Method>
-        <Name>ToStartBuffer</Name>
-        <Comment>
-    Jump to the beginning of the XML data
-    XML.ToStartBuffer();
-</Comment>
+        <Parameter>
+          <Name>Header</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -31253,6 +31253,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>SetFailed</Name>
       </Method>
       <Method>
+        <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>SetName</Name>
         <Parameter>
           <Name>Name</Name>
@@ -31264,14 +31270,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>GetName</Name>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>SetNumberOfAssertions</Name>
-        <Parameter>
-          <Name>NoOfAssertions</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>SetTestOrder</Name>
@@ -31288,9 +31286,9 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetNumberOfAssertions</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>IsFailed</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
         <Name>SetFinished</Name>
@@ -31330,15 +31328,17 @@ contributing fast faults, unless the FFO is currently vetoed.
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
       <Method>
-        <Name>GetTestOrder</Name>
-        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <Name>GetNumberOfAssertions</Name>
+        <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
       <Method>
-        <Name>IsFailed</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>SetNumberOfAssertions</Name>
+        <Parameter>
+          <Name>NoOfAssertions</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -31608,35 +31608,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetNumberOfAssertsForTest</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>AddAssertResult</Name>
         <Parameter>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>ExpectedSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualValue</Name>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
-        <Local>
-          <Name>Counter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfAsserts</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
       </Method>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31684,9 +31701,27 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
+        <Name>GetNumberOfAssertsForTest</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Counter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfAsserts</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -31910,47 +31945,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddAssertResult</Name>
-        <Parameter>
-          <Name>ExpectedSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualValue</Name>
-          <Type PointerTo="1">BYTE</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        </Local>
       </Method>
       <Properties>
         <Property>
@@ -32096,37 +32096,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>CreateAssertResultInstance</Name>
-        <Parameter>
-          <Name>ExpectedsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ExpectedsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ActualsTypeClass</Name>
-          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
+        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32134,9 +32104,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>GetDetectionCountThisCycle</Name>
-        <ReturnType>UINT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
+        <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -32353,7 +32321,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
+        <Name>GetDetectionCountThisCycle</Name>
+        <ReturnType>UINT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>ExpectedsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ExpectedsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ActualsTypeClass</Name>
+          <Type Namespace="LCLS_General.TcUnit.IBaseLibrary">TypeClass</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
         <Local>
           <Name>IteratorCounter</Name>
           <Type>UINT</Type>
@@ -32921,21 +32921,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_BYTE</Name>
+        <Name>AssertEquals_DWORD</Name>
         <Comment>
-    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
           <Name>Expected</Name>
-          <Comment> BYTE expected value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD expected value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Actual</Name>
-          <Comment> BYTE actual value</Comment>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
+          <Comment> DWORD actual value</Comment>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -33672,6 +33672,688 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> LREAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> LREAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> ULINT expected value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> ULINT actual value</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BOOL expected value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BOOL actual value</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Condition</Name>
+          <Comment> Condition to be checked</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> USINT expected value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> USINT actual value</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> REAL 2d array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> REAL 2d array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>2</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Delta</Name>
+          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>DimensionIndex</Name>
+          <Comment> Index when looping through Dimensions</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundExpecteds</Name>
+          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundExpecteds</Name>
+          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>LowerBoundActuals</Name>
+          <Comment> Lower bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>UpperBoundActuals</Name>
+          <Comment> Upper bounds of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Comment> Size of Expecteds array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Comment> Size of Actuals array in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Offset</Name>
+          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedArrayIndex</Name>
+          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualArrayIndex</Name>
+          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
+          <Type>DINT</Type>
+          <ArrayInfo>
+            <LBound>1</LBound>
+            <Elements>2</Elements>
+          </ArrayInfo>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>Expected</Name>
+          <Comment> Single expected value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>Actual</Name>
+          <Comment> Single actual value</Comment>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>__Index__0</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expected</Name>
+          <Comment> BYTE expected value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> BYTE actual value</Comment>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
+        <Parameter>
+          <Name>Expecteds</Name>
+          <Comment> USINT array with expected values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Actuals</Name>
+          <Comment> USINT array with actual values</Comment>
+          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>variable_length_array</Name>
+            </Property>
+            <Property>
+              <Name>Dimensions</Name>
+              <Value>1</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>Equals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeEquals</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>Index</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualString</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfExpecteds</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>SizeOfActuals</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ExpectedsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ActualsIndex</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>SetHasStartedRunning</Name>
+      </Method>
+      <Method>
+        <Name>SetTestFailed</Name>
+        <Parameter>
+          <Name>AssertionType</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>AssertionMessage</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+      </Method>
+      <Method>
         <Name>AssertEquals</Name>
         <Comment>
     Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
@@ -33981,533 +34663,6 @@ contributing fast faults, unless the FFO is currently vetoed.
             <Name>hasanytype</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>AssertFalse</Name>
-        <Comment>
-    Asserts that a condition is false. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AssertEquals_SINT</Name>
-        <Comment>
-    Asserts that two SINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> SINT expected value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> SINT actual value</Comment>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArray2dEquals_LREAL</Name>
-        <Comment>
-    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> LREAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> LREAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">LREAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_ULINT</Name>
-        <Comment>
-    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> ULINT expected value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> ULINT actual value</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_BOOL</Name>
-        <Comment>
-    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> BOOL expected value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> BOOL actual value</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINTs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> USINT expected value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> USINT actual value</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertEquals_LWORD</Name>
-        <Comment>
-    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expected</Name>
-          <Comment> LWORD expected value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> LWORD actual value</Comment>
-          <Type>LWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>AssertArrayEquals_USINT</Name>
-        <Comment>
-    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> USINT array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Actuals</Name>
-          <Comment> USINT array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="1">USINT</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>1</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>Index</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>SetHasStartedRunning</Name>
-      </Method>
-      <Method>
-        <Name>SetTestFailed</Name>
-        <Parameter>
-          <Name>AssertionType</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">E_AssertionType</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>AssertionMessage</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
-          <BitSize>16</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetTestOrderNumber</Name>
-        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>TestName</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-        <Local>
-          <Name>IteratorCounter</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>NumberOfTestsToAnalyse</Name>
-          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
-          <BitSize>16</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetNumberOfTests</Name>
@@ -35052,6 +35207,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
+        <Name>AddTestNameToInstancePath</Name>
+        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Parameter>
+          <Name>TestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+        <Local>
+          <Name>CompleteTestInstancePath</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>SetTestFinished</Name>
         <Comment> Marks the test as finished in this testsuite.
    Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
@@ -35543,56 +35713,24 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertEquals_DWORD</Name>
-        <Comment>
-    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
-</Comment>
+        <Name>GetTestOrderNumber</Name>
+        <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
         <Parameter>
-          <Name>Expected</Name>
-          <Comment> DWORD expected value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Actual</Name>
-          <Comment> DWORD actual value</Comment>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
+          <Name>TestName</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
+          <Name>IteratorCounter</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
         </Local>
         <Local>
-          <Name>AlreadyReported</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
+          <Name>NumberOfTestsToAnalyse</Name>
+          <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
+          <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>AssertTrue</Name>
-        <Comment>
-    Asserts that a condition is true. If it is not, an assertion error is created.
-</Comment>
-        <Parameter>
-          <Name>Condition</Name>
-          <Comment> Condition to be checked</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>Message</Name>
-          <Comment> The identifying message for the assertion error</Comment>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
@@ -35663,45 +35801,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AssertArray2dEquals_REAL</Name>
+        <Name>AssertEquals_SINT</Name>
         <Comment>
-    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
 </Comment>
         <Parameter>
-          <Name>Expecteds</Name>
-          <Comment> REAL 2d array with expected values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
+          <Name>Expected</Name>
+          <Comment> SINT expected value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
-          <Name>Actuals</Name>
-          <Comment> REAL 2d array with actual values</Comment>
-          <Type PointerTo="1" RpcArrayDim="2">REAL</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>variable_length_array</Name>
-            </Property>
-            <Property>
-              <Name>Dimensions</Name>
-              <Value>2</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Delta</Name>
-          <Comment> The maximum delta between the value of expected and actual for which both numbers are still considered equal, proportional to the expected value in that array cell</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
+          <Name>Actual</Name>
+          <Comment> SINT actual value</Comment>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
         </Parameter>
         <Parameter>
           <Name>Message</Name>
@@ -35710,22 +35824,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>Equals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeEquals</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedString</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualString</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Local>
@@ -35733,124 +35832,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>AlreadyReported</Name>
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>TestInstancePath</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Local>
-          <Name>DimensionIndex</Name>
-          <Comment> Index when looping through Dimensions</Comment>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundExpecteds</Name>
-          <Comment> Lower bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundExpecteds</Name>
-          <Comment> Upper bounds of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>LowerBoundActuals</Name>
-          <Comment> Lower bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>UpperBoundActuals</Name>
-          <Comment> Upper bounds of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfExpecteds</Name>
-          <Comment> Size of Expecteds array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>SizeOfActuals</Name>
-          <Comment> Size of Actuals array in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Offset</Name>
-          <Comment> Current Array index offsets from Lower Bound in each dimension</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ExpectedArrayIndex</Name>
-          <Comment> Array of current Expected array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ActualArrayIndex</Name>
-          <Comment> Array of current Actual array indexes when looping through arrays</Comment>
-          <Type>DINT</Type>
-          <ArrayInfo>
-            <LBound>1</LBound>
-            <Elements>2</Elements>
-          </ArrayInfo>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>Expected</Name>
-          <Comment> Single expected value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>Actual</Name>
-          <Comment> Single actual value</Comment>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36124,18 +36105,37 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Local>
       </Method>
       <Method>
-        <Name>AddTestNameToInstancePath</Name>
-        <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
+        <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
-          <Name>TestInstancePath</Name>
+          <Name>Expected</Name>
+          <Comment> LWORD expected value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Actual</Name>
+          <Comment> LWORD actual value</Comment>
+          <Type>LWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>Message</Name>
+          <Comment> The identifying message for the assertion error</Comment>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
-          <Name>CompleteTestInstancePath</Name>
+          <Name>TestInstancePath</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
+        </Local>
+        <Local>
+          <Name>AlreadyReported</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
         </Local>
       </Method>
       <Method>
@@ -36482,7 +36482,7 @@ contributing fast faults, unless the FFO is currently vetoed.
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -36501,13 +36501,40 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <DateTime>T#10MS</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
+        <Parameter>
+          <Name>AdsLogStringMessage</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
+          <BitSize>4128</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>Error</Name>
+          <Comment> Buffer empty</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
       </Method>
       <Method>
         <Name>WriteLog</Name>
@@ -36544,33 +36571,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
           <BitSize>4128</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>GetAndRemoveLogFromQueue</Name>
-        <Comment> Reads and removes the oldest message </Comment>
-        <Parameter>
-          <Name>AdsLogStringMessage</Name>
-          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.PMPS.TcUnit">ST_AdsLogStringMessage</Type>
-          <BitSize>4128</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>Error</Name>
-          <Comment> Buffer empty</Comment>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -36788,6 +36788,44 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name>Init2</Name>
+        <Parameter>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nTimestamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipMessage</Name>
+          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipAlarm</Name>
+          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>Release</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -36837,44 +36875,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>Init2</Name>
-        <Parameter>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nTimestamp</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipMessage</Name>
-          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarm</Name>
-          <Type GUID="{EC6D4FF7-5805-4DDB-A316-27894E77D644}">ITcAlarm</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
@@ -37051,47 +37051,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>TcQueryInterface</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>iid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipItf</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipMessageListener</Name>
-          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipAlarmListener</Name>
-          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>c++_compatible</Name>
-          </Property>
-          <Property>
-            <Name>pack_mode</Name>
-            <Value>4</Value>
-          </Property>
-          <Property>
-            <Name>show</Name>
-          </Property>
-          <Property>
-            <Name>minimal_input_size</Name>
-            <Value>4</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnMessageSent</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -37139,6 +37098,21 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Parameter>
           <Name>pipAlarmFilterConfig</Name>
           <Type GUID="{70904B1B-F00E-4FCB-BE59-151086E9B8F6}" PointerTo="1">ITcEventFilterConfig</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Execute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ipListener</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
@@ -37241,19 +37215,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name>Execute</Name>
+        <Name>TcQueryInterface</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
-          <Name>ipListener</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_Listener</Type>
+          <Name>iid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000025}" ReferenceTo="true">IID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipItf</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1">PVOID</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
+          <Name>ipMessageListener</Name>
+          <Type GUID="{47B6BEE8-0ECB-4C92-9D93-FB11D3BA0336}">ITcMessageListener</Type>
+          <BitSize>64</BitSize>
         </Local>
+        <Local>
+          <Name>ipAlarmListener</Name>
+          <Type GUID="{C0CCD9D7-DDCD-4C2D-A24C-B1F3257C9A64}">ITcAlarmListener</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>c++_compatible</Name>
+          </Property>
+          <Property>
+            <Name>pack_mode</Name>
+            <Value>4</Value>
+          </Property>
+          <Property>
+            <Name>show</Name>
+          </Property>
+          <Property>
+            <Name>minimal_input_size</Name>
+            <Value>4</Value>
+          </Property>
+        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38741,26 +38741,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>RequestRemote</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38866,6 +38846,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </Method>
       <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventText</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
         <Name>Request</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
@@ -38895,25 +38914,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
           <BitSize>64</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sEventText</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
       </Method>
       <Properties>
         <Property>
@@ -38984,11 +38984,11 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
-        <Name>GetJsonFromSymbol</Name>
-        <Comment> | generates a JSON string from a given symbol (via address/size).
- | Method returns TRUE if succeeded.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
+        <Name>GetJsonStringFromSymbolProperties</Name>
+        <Comment>| Returns the JSON string. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
+        <ReturnType>STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
           <Name>sDatatype</Name>
           <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
@@ -39002,28 +39002,16 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Properties>
         </Parameter>
         <Parameter>
-          <Name>nData</Name>
-          <Comment> size of symbol</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Comment> address of sxmbol</Comment>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <Name>sProperties</Name>
+          <Comment> multiple Properties separated by '|'</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJson</Name>
-          <Comment> size of json buffer </Comment>
-          <Type ReferenceTo="true">UDINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pJson</Name>
-          <Comment> json buffer</Comment>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39036,6 +39024,16 @@ contributing fast faults, unless the FFO is currently vetoed.
             </Property>
           </Properties>
         </Parameter>
+        <Local>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pTmp</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Local>
       </Method>
       <Method>
         <Name>CopyJsonStringFromSymbolProperties</Name>
@@ -39181,58 +39179,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
           <BitSize>64</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>nSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pTmp</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonStringFromSymbolProperties</Name>
-        <Comment>| Returns the JSON string. 
-| If its size is more than 255 bytes an empty string is returned and the method CopyJsonStringFromSymbolProperties() has to be used.</Comment>
-        <ReturnType>STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Parameter>
-          <Name>sDatatype</Name>
-          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>sProperties</Name>
-          <Comment> multiple Properties separated by '|'</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
         </Parameter>
         <Parameter>
           <Name>hrErrorCode</Name>
@@ -39403,6 +39349,60 @@ contributing fast faults, unless the FFO is currently vetoed.
           <Name>pData</Name>
           <Comment> address of symbol</Comment>
           <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonFromSymbol</Name>
+        <Comment> | generates a JSON string from a given symbol (via address/size).
+ | Method returns TRUE if succeeded.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sDatatype</Name>
+          <Comment> data type name of symbol - if unknown -&gt; retrieve with GetDatatypeByAddreee()</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>nData</Name>
+          <Comment> size of symbol</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Comment> address of sxmbol</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJson</Name>
+          <Comment> size of json buffer </Comment>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pJson</Name>
+          <Comment> json buffer</Comment>
+          <Type PointerTo="1">STRING(80)</Type>
           <BitSize>64</BitSize>
         </Parameter>
         <Parameter>
@@ -39948,7 +39948,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>865952</BitOffs>
         <Default>
-          <Bool>nt :=</Bool>
+          <Bool>udint</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -39986,46 +39986,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Parameter>
       </Method>
       <Method>
-        <Name>__getLogToVisualStudio</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>LogToVisualStudio</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>analysis</Name>
-            <Value>-33</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
         <Name>OnAlarmCleared</Name>
         <Parameter>
           <Name>fbEvent</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcEvent</Type>
           <BitSize>64</BitSize>
         </Parameter>
-      </Method>
-      <Method>
-        <Name>SendMessage</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sMessage</Name>
-          <Type PointerTo="1">STRING(80)</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-        <Local>
-          <Name>sLogStr</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>OnMessageSent</Name>
@@ -40155,6 +40121,40 @@ contributing fast faults, unless the FFO is currently vetoed.
               <Value>__FB_LISTENER__CONFIGURE__BSUBSCRIBED</Value>
             </Property>
           </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>__getLogToVisualStudio</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>LogToVisualStudio</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>analysis</Name>
+            <Value>-33</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>SendMessage</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sMessage</Name>
+          <Type PointerTo="1">STRING(80)</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Local>
+          <Name>sLogStr</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
         </Local>
       </Method>
       <Method>
@@ -40365,7 +40365,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40465,7 +40465,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <DateTime>T#10s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -40793,7 +40793,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1h</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40805,7 +40805,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#1s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -40817,7 +40817,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#10s</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -50329,7 +50329,7 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -52114,9 +52114,6 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_Error</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
         <Name>M_Manual</Name>
       </Action>
       <Action>
@@ -52126,10 +52123,13 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_StateChange</Name>
       </Action>
       <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
+        <Name>M_Reset</Name>
       </Action>
       <Properties>
         <Property>
@@ -52404,9 +52404,6 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_Error</Name>
       </Action>
       <Action>
-        <Name>M_Reset</Name>
-      </Action>
-      <Action>
         <Name>M_Manual</Name>
       </Action>
       <Action>
@@ -52416,10 +52413,13 @@ Use this thing to have a simple indexer with rollover.
         <Name>M_StateChange</Name>
       </Action>
       <Action>
+        <Name>M_Init</Name>
+      </Action>
+      <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
+        <Name>M_Reset</Name>
       </Action>
       <Properties>
         <Property>
@@ -52573,19 +52573,19 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>704</BitOffs>
       </SubItem>
       <Action>
-        <Name>M_Reset</Name>
+        <Name>M_Active</Name>
       </Action>
       <Action>
         <Name>M_StateChange</Name>
       </Action>
       <Action>
-        <Name>M_Active</Name>
+        <Name>M_Init</Name>
       </Action>
       <Action>
         <Name>M_Passive</Name>
       </Action>
       <Action>
-        <Name>M_Init</Name>
+        <Name>M_Reset</Name>
       </Action>
       <Properties>
         <Property>
@@ -52841,7 +52841,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#2S</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -52853,7 +52853,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#500MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -53159,7 +53159,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#100MS</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -53204,7 +53204,7 @@ Use this thing to have a simple indexer with rollover.
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <DateTime>T#2S</DateTime>
+            <DateTime>T</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -55657,10 +55657,10 @@ Use this thing to have a simple indexer with rollover.
         <BitOffs>256448</BitOffs>
       </SubItem>
       <Action>
-        <Name>Exec</Name>
+        <Name>StateHandler</Name>
       </Action>
       <Action>
-        <Name>StateHandler</Name>
+        <Name>Exec</Name>
       </Action>
       <Properties>
         <Property>
@@ -55749,37 +55749,6 @@ Use this thing to have a simple indexer with rollover.
       </Method>
     </DataType>
     <DataType>
-      <Name Namespace="PMPS">T_HashTableEntry</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>key</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: Key
-        io: i
-     </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>value</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
       <Name Namespace="PMPS">ST_BP_ArbInternal</Name>
       <BitSize>2464</BitSize>
       <ExtendsType Namespace="PMPS">ST_BeamParams</ExtendsType>
@@ -55824,6 +55793,37 @@ Use this thing to have a simple indexer with rollover.
 	</Value>
           </Property>
         </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="PMPS">T_HashTableEntry</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>key</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: Key
+        io: i
+     </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
       </SubItem>
     </DataType>
     <DataType>
@@ -56439,28 +56439,28 @@ Use this thing to have a simple indexer with rollover.
         </Default>
       </SubItem>
       <Action>
-        <Name>A_Reset</Name>
-      </Action>
-      <Action>
         <Name>A_Count</Name>
       </Action>
       <Action>
         <Name>DataPoolToEpics</Name>
       </Action>
       <Action>
-        <Name>A_Add</Name>
+        <Name>A_Lookup</Name>
       </Action>
       <Action>
         <Name>A_Remove</Name>
       </Action>
       <Action>
+        <Name>A_Reset</Name>
+      </Action>
+      <Action>
         <Name>A_GetFirst</Name>
       </Action>
       <Action>
-        <Name>A_GetNext</Name>
+        <Name>A_Add</Name>
       </Action>
       <Action>
-        <Name>A_Lookup</Name>
+        <Name>A_GetNext</Name>
       </Action>
       <Properties>
         <Property>
@@ -56687,7 +56687,7 @@ These features efficiently address the addition, removal, and verification of be
         <BitSize>8</BitSize>
         <BitOffs>237128</BitOffs>
         <Default>
-          <Bool> : u</Bool>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -56721,42 +56721,30 @@ These features efficiently address the addition, removal, and verification of be
         <BitOffs>409664</BitOffs>
       </SubItem>
       <Method>
-        <Name>__getnEntryCount</Name>
-        <Comment> How many entries are in the arbiter now</Comment>
-        <ReturnType>UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEntryCount</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>CheckRequest</Name>
-        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
-Use like so:
-IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
-    Request is found and active in arbitration,. Do something.
-ELSE:
-    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
-
-</Comment>
+        <Name>RemoveRequest</Name>
+        <Comment> Removes request from abritration. </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
-          <Name>nReqID</Name>
+          <Name>nReqId</Name>
           <Type>DWORD</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Local>
-          <Name>BP</Name>
-          <Type Namespace="PMPS">ST_BeamParams</Type>
-          <BitSize>1760</BitSize>
+          <Name>fbLog</Name>
+          <Type Namespace="LCLS_General">FB_LogMessage</Type>
+          <BitSize>86080</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>BP_Int</Name>
+          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
+          <BitSize>2464</BitSize>
         </Local>
       </Method>
       <Method>
@@ -56887,6 +56875,42 @@ ELSE:
         </Properties>
       </Method>
       <Method>
+        <Name>CheckRequestInPool</Name>
+        <Comment> Verify request is at least in the local arbiter
+ Does not verify request has been included in arbitration.
+ Use CheckRequest instead.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckRequest</Name>
+        <Comment> Checks request ID is included in arbitration all the way to the accelerator interface
+Use like so:
+IF fbArbiter.CheckRequest(nStateIDAssertionToCheck) AND (other logic) THEN:
+    Request is found and active in arbitration,. Do something.
+ELSE:
+    Request was not found, or is not yet included in arbitration. Don't do something/ wait.
+
+</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nReqID</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>BP</Name>
+          <Type Namespace="PMPS">ST_BeamParams</Type>
+          <BitSize>1760</BitSize>
+        </Local>
+      </Method>
+      <Method>
         <Name>AddRequest</Name>
         <Comment> Adds a request to the arbiter pool.
  Returns true if the request was successfully added, false if not enough space or a request with the same ID is already present.</Comment>
@@ -56928,44 +56952,20 @@ ELSE:
         </Local>
       </Method>
       <Method>
-        <Name>RemoveRequest</Name>
-        <Comment> Removes request from abritration. </Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqId</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
+        <Name>__getnEntryCount</Name>
+        <Comment> How many entries are in the arbiter now</Comment>
+        <ReturnType>UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
         <Local>
-          <Name>fbLog</Name>
-          <Type Namespace="LCLS_General">FB_LogMessage</Type>
-          <BitSize>86080</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__FB_ARBITER__REMOVEREQUEST__FBLOG</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>BP_Int</Name>
-          <Type Namespace="PMPS">ST_BP_ArbInternal</Type>
-          <BitSize>2464</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>CheckRequestInPool</Name>
-        <Comment> Verify request is at least in the local arbiter
- Does not verify request has been included in arbitration.
- Use CheckRequest instead.</Comment>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nReqID</Name>
-          <Type>DWORD</Type>
+          <Name>nEntryCount</Name>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
       </Method>
       <Method>
         <Name>RequestBP</Name>
@@ -57116,7 +57116,7 @@ ELSE:
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -57369,13 +57369,13 @@ ELSE:
         <Name>HandleBPTM</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
         <Name>ClearAsserts</Name>
       </Action>
       <Action>
         <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
         <Name>HandlePmpsDb</Name>
@@ -58263,13 +58263,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_DO</Name>
       </Action>
       <Action>
+        <Name>DeauthorizeTransition</Name>
+      </Action>
+      <Action>
         <Name>NewTarget_ENTRY</Name>
       </Action>
       <Action>
         <Name>AssertTransitionBP</Name>
-      </Action>
-      <Action>
-        <Name>AssertFinalBP</Name>
       </Action>
       <Action>
         <Name>WaitingForTransitionAssertion_DO</Name>
@@ -58290,7 +58290,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>WaitingForFinalAssertion_EXIT</Name>
       </Action>
       <Action>
-        <Name>DeauthorizeTransition</Name>
+        <Name>AssertFinalBP</Name>
       </Action>
       <Method>
         <Name>LogActions</Name>
@@ -58539,10 +58539,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>ClearAsserts</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
+        <Name>AssertHere</Name>
       </Action>
       <Action>
         <Name>HandleBPTM</Name>
@@ -58893,7 +58893,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>32</BitSize>
         <BitOffs>257952</BitOffs>
         <Default>
-          <DateTime>T#1s</DateTime>
+          <DateTime>T</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -59932,8 +59932,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <BitSize>8</BitSize>
         <BitOffs>144960</BitOffs>
         <Default>
-          <Bool>,
-  </Bool>
+          <Bool>,</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -72250,7 +72249,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72273,7 +72272,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72294,7 +72293,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72392,7 +72391,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72410,7 +72409,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72568,7 +72567,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -72665,7 +72664,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72720,7 +72719,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -72734,95 +72733,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               </Property>
             </Properties>
             <BitOffs>3072272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
-            <Comment> TwinCAT System Service </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3160416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>200</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
-            <Comment> Hint icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
-            <Comment> Error icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
-            <Comment> Write message to log file </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3162688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
-            <Comment> Default ADS timeout value </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <DateTime>5000</DateTime>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>3163488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -72911,7 +72821,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#8ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <BitOffs>1264935328</BitOffs>
           </Symbol>
@@ -73197,7 +73107,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -80102,7 +80012,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -81844,7 +81754,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -81995,7 +81905,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#1ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82010,7 +81920,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#100ms</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82025,7 +81935,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10s</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82040,7 +81950,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#10m</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -82498,6 +82408,21 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>3160400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
+            <Comment> TwinCAT System Service </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -83507,6 +83432,20 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>3162240</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>200</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162272</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
@@ -83634,6 +83573,21 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>3162560</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
+            <Comment> Hint icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162592</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
             <Comment> Warning icon </Comment>
             <BitSize>32</BitSize>
@@ -83647,6 +83601,36 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>3162624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
+            <Comment> Error icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
+            <Comment> Write message to log file </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
@@ -84043,6 +84027,21 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>3163472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
+            <Comment> Default ADS timeout value </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <DateTime>5000</DateTime>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3163488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -88628,7 +88627,7 @@ Emergency Stop for MR1K1</Comment>
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <DateTime>T#0MS</DateTime>
+              <DateTime>T</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -89008,7 +89007,7 @@ Emergency Stop for MR1K1</Comment>
             <Default>
               <SubItem>
                 <Name>.PT</Name>
-                <DateTime>T#2S</DateTime>
+                <DateTime>T</DateTime>
               </SubItem>
             </Default>
             <BitOffs>1265827328</BitOffs>
@@ -93115,8 +93114,8 @@ M4K2 KBV X ENC CNT</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
-						      .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
-						 	  .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -93165,7 +93164,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
-							  .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -93210,11 +93209,6 @@ M4K2 KBV X ENC CNT</Comment>
               </SubItem>
             </Default>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
-              </Property>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
@@ -95311,7 +95305,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164298752</ByteSize>
+          <ByteSize>164429824</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95391,7 +95385,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-28T13:23:07</Value>
+          <Value>2024-02-28T16:53:16</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{99BC765F-962C-CB1C-018B-126FBB19E481}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{0B1A3EB5-2374-3214-22E8-09A06099E82B}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -72250,7 +72250,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72273,7 +72273,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72294,7 +72294,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72392,7 +72392,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72410,7 +72410,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72568,7 +72568,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -72665,7 +72665,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72720,7 +72720,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -73197,7 +73197,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -80342,7 +80342,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -82084,7 +82084,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -89313,7 +89313,8 @@ Emergency Stop for MR1K1</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>
+                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K1_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K1_STO]^Channel 2^Input;
                               .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position;
                               .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 2^Position;
                               .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position;
@@ -95633,7 +95634,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164364288</ByteSize>
+          <ByteSize>164298752</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95713,7 +95714,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-04-04T12:12:18</Value>
+          <Value>2024-04-04T21:55:33</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{28463369-1E78-9975-DB5E-D0683DE89341}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C85B3384-5678-5727-ADC1-FE3E8545C97D}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -93114,7 +93114,9 @@ M4K2 KBV X ENC CNT</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
+						      .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
+						 	  .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -93161,7 +93163,9 @@ M4K2 KBV X ENC CNT</Comment>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
+							  .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -95387,7 +95391,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-02-27T16:51:26</Value>
+          <Value>2024-02-28T13:23:07</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Soft Limits updated on SP1K1, MR1K1, MR2/3/4K2.
- Soft Limits swapped on SL1K2 YAG stage.
- RTDs previously unlinked exposed for SP1K1 - RTD order not preserved.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ME exploring and setting hardstops.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was activated on the PLC. All RTDs checked via function blocks on the PLC.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://confluence.slac.stanford.edu/display/L2SI/X-Ray+Optics+Checkout

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
