### PR TITLE
MR1K1, MR1K2, SP1K1 State Movers With PMPS

### DIFF
--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Yleft.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Yleft.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -272,15 +272,13 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Drive Status 4 (automatically linked):
+				<Comment><![CDATA[Drive Status 4 (automatically linked):
 0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
 
 Drive Status 4 (manually linked):
 0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -329,6 +327,8 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>nState8</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+				<Comment><![CDATA[Digital Inputs 1..8
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>248</BitOffs>
 			</SubItem>
@@ -499,7 +499,7 @@ Drive Status 4 (manually linked):
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF_OLD</Name>
 			<BitSize>1024</BitSize>
 			<SubItem>
 				<Name>ControlDWord</Name>
@@ -622,7 +622,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1014,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1031,8 +1031,7 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1046,8 +1045,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1060,8 +1058,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1069,22 +1066,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1310,13 +1304,13 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -1331,9 +1325,9 @@ External Setpoint Generation:
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
-			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-96270.56" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-8870.56"/>
-				<SoftEndMaxControl Enable="true" Range="16239.44"/>
+			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-99172.35" MaxCount="#xffffffff">
+				<SoftEndMinControl Enable="true" Range="-11772.35"/>
+				<SoftEndMaxControl Enable="true" Range="13337.65"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1341,28 +1335,23 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>1024</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
-						<Comment>
-							<![CDATA[Encoder State 1 (automatically linked):
+						<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nComState</Name>
-						<Comment>
-							<![CDATA[Encoder Communication State (automatically linked):
+						<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 				</Var>
 			</Vars>
@@ -1371,7 +1360,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>2048</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1385,24 +1373,11 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>1664</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn2</Name>
-					</SubVar>
-					<SubVar>
-						<Name>nState4</Name>
-						<Comment>
-							<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-						</Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn3</Name>
@@ -1423,7 +1398,6 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>2688</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1432,23 +1406,19 @@ Drive Status 4 (manually linked):
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl2</Name>
-						<Comment>
-							<![CDATA[Digital Outputs Setpoint Generator:
+						<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl3</Name>
-						<Comment>
-							<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+						<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut3</Name>
@@ -1476,59 +1446,14 @@ Drive Status 4 (manually linked):
 			<Name>Inputs</Name>
 			<Var>
 				<Name>FromPlc</Name>
-				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF_OLD</Type>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<SubVar>
-					<Name>AxisState</Name>
-					<Comment>
-						<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>HomingState</Name>
-					<Comment>
-						<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>CoupleState</Name>
-					<Comment>
-						<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-					</Comment>
-				</SubVar>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 			</Var>
 		</Vars>
 	</Axis>
@@ -1536,14 +1461,14 @@ External Setpoint Generation:
 		<OwnerA>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL5042_M1K2_Yleftright">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 1^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 1^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Yleft">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
@@ -1551,7 +1476,7 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -1559,8 +1484,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl2" VarB="STM Control^Control^Digital output 1" Size="1" OffsA="3"/>

--- a/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Yright.xti
+++ b/lcls-plc-rixs-optics/_Config/NC/Axes/M1K2-Yright.xti
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -272,15 +272,13 @@
 			<SubItem>
 				<Name>nState4</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
-				<Comment>
-					<![CDATA[Drive Status 4 (automatically linked):
+				<Comment><![CDATA[Drive Status 4 (automatically linked):
 0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
 
 Drive Status 4 (manually linked):
 0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>88</BitOffs>
 			</SubItem>
@@ -329,6 +327,8 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>nState8</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000002}">USINT</Type>
+				<Comment><![CDATA[Digital Inputs 1..8
+]]></Comment>
 				<BitSize>8</BitSize>
 				<BitOffs>248</BitOffs>
 			</SubItem>
@@ -499,7 +499,7 @@ Drive Status 4 (manually linked):
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF_OLD</Name>
 			<BitSize>1024</BitSize>
 			<SubItem>
 				<Name>ControlDWord</Name>
@@ -622,7 +622,7 @@ Drive Status 4 (manually linked):
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE_OLD</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -1014,11 +1014,11 @@ Drive Status 4 (manually linked):
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF_OLD4</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE_OLD</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -1031,8 +1031,7 @@ Drive Status 4 (manually linked):
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -1046,8 +1045,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -1060,8 +1058,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -1069,22 +1066,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -1310,13 +1304,13 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -1331,9 +1325,9 @@ External Setpoint Generation:
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
-			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-98728.2" MaxCount="#xffffffff">
-				<SoftEndMinControl Enable="true" Range="-8968.2"/>
-				<SoftEndMaxControl Enable="true" Range="16340.8"/>
+			<EncPara ScaleFactorNumerator="1" ScaleFactorDenominator="1000" Offset="-101629.99" MaxCount="#xffffffff">
+				<SoftEndMinControl Enable="true" Range="-11869.99"/>
+				<SoftEndMaxControl Enable="true" Range="13439"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
 			</EncPara>
 			<Vars VarGrpType="1">
@@ -1341,28 +1335,23 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>3008</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
-						<Comment>
-							<![CDATA[Encoder State 1 (automatically linked):
+						<Comment><![CDATA[Encoder State 1 (automatically linked):
 0x0001 (Bit  0)  = Warning
 0x0002 (Bit  1)  = Error
 0x0004 (Bit  2)  = Ready
 0x1000 (Bit 12) = Diagnosis
 0x2000 (Bit 13) = TxPDO State
 0xC000 (Bit 14+15) = Input Cycle Counter
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nComState</Name>
-						<Comment>
-							<![CDATA[Encoder Communication State (automatically linked):
+						<Comment><![CDATA[Encoder Communication State (automatically linked):
 0x01 (Bit 0) = IO data invalid (e.g. EtherCAT 'WcState')
 0x02 (Bit 1) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 				</Var>
 			</Vars>
@@ -1371,7 +1360,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>5056</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1385,24 +1373,11 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>3648</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn2</Name>
-					</SubVar>
-					<SubVar>
-						<Name>nState4</Name>
-						<Comment>
-							<![CDATA[Drive Status 4 (automatically linked):
-0x01 (0000 0001) = IO data invalid (e.g. EtherCAT 'WcState')
-0x02 (0000 0010) = IO data input toggle (e.g. EtherCAT 'InputToggle')
-
-Drive Status 4 (manually linked):
-0x80 (1000 0000) = Fast axis stop (digital IO interrupt)
-]]>
-						</Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn3</Name>
@@ -1423,7 +1398,6 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>5696</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1432,23 +1406,19 @@ Drive Status 4 (manually linked):
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl2</Name>
-						<Comment>
-							<![CDATA[Digital Outputs Setpoint Generator:
+						<Comment><![CDATA[Digital Outputs Setpoint Generator:
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar>
 						<Name>nCtrl3</Name>
-						<Comment>
-							<![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
+						<Comment><![CDATA[Digital Outputs (Setpoint Generator + Position Controller):
 0x41 (0100 0001) = Minus (0x42 for inverse motor polarity)
 0x42 (0100 0010) = Plus (0x41 for inverse motor polarity)
 0x80 (1000 0000) = Stop
-]]>
-						</Comment>
+]]></Comment>
 					</SubVar>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut3</Name>
@@ -1476,61 +1446,14 @@ Drive Status 4 (manually linked):
 			<Name>Inputs</Name>
 			<Var>
 				<Name>FromPlc</Name>
-				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>1984</BitOffs>
+				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF_OLD</Type>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
 			<Name>Outputs</Name>
 			<Var>
 				<Name>ToPlc</Name>
-				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>3008</BitOffs>
-				<SubVar>
-					<Name>AxisState</Name>
-					<Comment>
-						<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>HomingState</Name>
-					<Comment>
-						<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-					</Comment>
-				</SubVar>
-				<SubVar>
-					<Name>CoupleState</Name>
-					<Comment>
-						<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-					</Comment>
-				</SubVar>
+				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF_OLD4</Type>
 			</Var>
 		</Vars>
 	</Axis>
@@ -1538,14 +1461,14 @@ External Setpoint Generation:
 		<OwnerA>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL5042_M1K2_Yleftright">
 				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState"/>
+				<Link VarA="Enc^Inputs^In^nComState" VarB="WcState^WcState" Size="1"/>
 				<Link VarA="Enc^Inputs^In^nDataIn1" VarB="FB Inputs Channel 2^Position"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Diag" Size="1" OffsA="12"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Error" Size="1" OffsA="1"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Input cycle counter" Size="2" OffsA="14"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Ready" Size="1" OffsA="2"/>
 				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^TxPDO State" Size="1" OffsA="13"/>
-				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning"/>
+				<Link VarA="Enc^Inputs^In^nState1" VarB="FB Inputs Channel 2^Status^Warning" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_M1K2^EL7047_M1K2_Yright">
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Error" Size="1" OffsA="3"/>
@@ -1553,7 +1476,7 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving negative" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Moving positive" Size="1" OffsA="4"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable"/>
+				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Ready to enable" Size="1"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Torque reduced" Size="1" OffsA="6"/>
 				<Link VarA="Drive^Inputs^In^nState1" VarB="STM Status^Status^Warning" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Digital input 1" Size="1" OffsA="3"/>
@@ -1561,8 +1484,8 @@ External Setpoint Generation:
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^Sync error" Size="1" OffsA="5"/>
 				<Link VarA="Drive^Inputs^In^nState2" VarB="STM Status^Status^TxPDO Toggle" Size="1" OffsA="7"/>
 				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^InputToggle" Size="1" OffsA="1"/>
-				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState"/>
-				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable"/>
+				<Link VarA="Drive^Inputs^In^nState4" VarB="WcState^WcState" Size="1"/>
+				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Enable" Size="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reduce torque" Size="1" OffsA="2"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl1" VarB="STM Control^Control^Reset" Size="1" OffsA="1"/>
 				<Link VarA="Drive^Outputs^Out^nCtrl2" VarB="STM Control^Control^Digital output 1" Size="1" OffsA="3"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D56FD35A-A82E-BED9-95CE-C5B9B904C156}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{6F7A53A0-C2D9-A16A-9BED-F44FF998AD64}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1561,10 +1561,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
 					<Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
 					<Comment><![CDATA[ Where is the STO]]></Comment>
 					<Type>BOOL</Type>
@@ -1572,6 +1568,10 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
 					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
@@ -1586,123 +1586,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1942,123 +1825,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
-					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
-					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
-					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
-					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
-					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -3942,6 +3708,240 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.sio_load</Name>
 					<Type>UINT</Type>
 				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
 			</Vars>
 			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
@@ -3984,30 +3984,19 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Name>PRG_SP1K1_MONO.bLEDPower01</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Name>PRG_SP1K1_MONO.bLEDPower02</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Name>PRG_SP1K1_MONO.bLEDPower03</Name>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Name>PRG_SL1K2_EXIT.bFanOn</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -4033,49 +4022,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower01</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower02</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower03</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SL1K2_EXIT.bFanOn</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
-					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
-					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
-					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -4554,6 +4500,60 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" ContextId="4" AreaNo="68">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D3536589-6C9E-F8E7-97C3-534B02FC8E7C}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D56FD35A-A82E-BED9-95CE-C5B9B904C156}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1561,6 +1561,10 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
 					<Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
 					<Comment><![CDATA[ Where is the STO]]></Comment>
 					<Type>BOOL</Type>
@@ -1568,10 +1572,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
@@ -1586,6 +1586,123 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -1825,6 +1942,123 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -3750,19 +3984,30 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower01</Name>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower02</Name>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SP1K1_MONO.bLEDPower03</Name>
-					<Type>BOOL</Type>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>PRG_SL1K2_EXIT.bFanOn</Name>
+					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -3788,6 +4033,49 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bLEDPower01</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bLEDPower02</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.bLEDPower03</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SL1K2_EXIT.bFanOn</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -4695,6 +4983,7 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^Main.M16.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^EK1100_MR1K1^EL5042_M1K1_Xupdwn">
+				<Link VarA="PlcTask Inputs^Main.M14.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXdwnEnc^Count" VarB="FB Inputs Channel 2^Position" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^PRG_MR1K1_BEND.M1K1.fbRunHOMS.stXupEnc^Count" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
 			</OwnerB>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{6F7A53A0-C2D9-A16A-9BED-F44FF998AD64}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{C148670C-B896-ACAA-DBAC-169C1BF0BF81}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -3709,6 +3709,123 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bHome</Name>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
@@ -4500,6 +4617,33 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
+					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</TargetSelect>
-					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
+					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/rixs_optics/DUTs/E_B4C_Rh_CoatingStates.TcDUT
+++ b/lcls-plc-rixs-optics/rixs_optics/DUTs/E_B4C_Rh_CoatingStates.TcDUT
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <DUT Name="E_B4C_Rh_CoatingStates" Id="{5c47e943-9d1b-4a02-b245-b8684b0fb105}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_B4C_Rh_CoatingStates :
+(
+    Unknown := 0,
+    B4C := 1,
+    Rh := 2,
+    OUT := 3
+) UINT;
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/DUTs/E_Grating_States.TcDUT
+++ b/lcls-plc-rixs-optics/rixs_optics/DUTs/E_Grating_States.TcDUT
@@ -5,9 +5,9 @@
 {attribute 'strict'}
 TYPE E_Grating_States :
 (
-    unknown := 0,
+    Unknown := 0,
     LRG := 1,
-    UNRULED := 2,
+    Unruled := 2,
     YAG := 3,
     MEG := 4,
     HEG := 5,

--- a/lcls-plc-rixs-optics/rixs_optics/DUTs/E_Grating_States.TcDUT
+++ b/lcls-plc-rixs-optics/rixs_optics/DUTs/E_Grating_States.TcDUT
@@ -12,7 +12,7 @@ TYPE E_Grating_States :
     MEG := 4,
     HEG := 5,
     LEG := 6
-);
+) UINT;
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/lcls-plc-rixs-optics/rixs_optics/DUTs/E_Grating_States.TcDUT
+++ b/lcls-plc-rixs-optics/rixs_optics/DUTs/E_Grating_States.TcDUT
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <DUT Name="E_Grating_States" Id="{9f270b52-cc4a-47bb-a119-bc8968008079}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_Grating_States :
+(
+    unknown := 0,
+    LRG := 1,
+    UNRULED := 2,
+    YAG := 3,
+    MEG := 4,
+    HEG := 5,
+    LEG := 6
+);
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/DUTs/E_MR1K1_States.TcDUT
+++ b/lcls-plc-rixs-optics/rixs_optics/DUTs/E_MR1K1_States.TcDUT
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
-  <DUT Name="E_B4C_Rh_CoatingStates" Id="{5c47e943-9d1b-4a02-b245-b8684b0fb105}">
+  <DUT Name="E_MR1K1_States" Id="{b25f2d1e-112c-4694-92cb-fe3da2835bd9}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}
-TYPE E_B4C_Rh_CoatingStates :
+TYPE E_MR1K1_States :
 (
     Unknown := 0,
     B4C := 1,
-    Rh := 2
+    OUT := 2
 ) UINT;
 END_TYPE
+
 ]]></Declaration>
   </DUT>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_States.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_States.TcGVL
@@ -5,7 +5,7 @@
 VAR_GLOBAL
     stDefaultOffsetY : ST_PositionState := (
         fDelta:=2000,
-        fVelocity:=150,
+        fVelocity:=100,
         fAccel:=5050,
         fDecel:=5050,
         bMoveOk:=TRUE,

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_States.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_States.TcGVL
@@ -21,6 +21,24 @@ VAR_GLOBAL
         bValid:=TRUE,
         bUseRawCounts:=TRUE
     );
+        stDefaultKBX : ST_PositionState := (
+        fDelta:=5,
+        fVelocity:=0.2,
+        fAccel:=100,
+        fDecel:=100,
+        bMoveOk:=TRUE,
+        bValid:=TRUE,
+        bUseRawCounts:=TRUE
+    );
+        stDefaultKBY : ST_PositionState := (
+        fDelta:=5,
+        fVelocity:=0.2,
+        fAccel:=10,
+        fDecel:=10,
+        bMoveOk:=TRUE,
+        bValid:=TRUE,
+        bUseRawCounts:=TRUE
+    );
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_States.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_States.TcGVL
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <GVL Name="GVL_States" Id="{735a8ab0-a2f0-4dc4-b81b-50bee151a84b}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+VAR_GLOBAL
+    stDefaultOffsetY : ST_PositionState := (
+        fDelta:=2000,
+        fVelocity:=150,
+        fAccel:=5050,
+        fDecel:=5050,
+        bMoveOk:=TRUE,
+        bValid:=TRUE,
+        bUseRawCounts:=TRUE
+    );
+        stDefaultOffsetX : ST_PositionState := (
+        fDelta:=10000,
+        fVelocity:=150,
+        fAccel:=1000,
+        fDecel:=1000,
+        bMoveOk:=TRUE,
+        bValid:=TRUE,
+        bUseRawCounts:=TRUE
+    );
+END_VAR]]></Declaration>
+  </GVL>
+</TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -120,7 +120,8 @@
     fbMotionStage_m13 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2'}
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position'}
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:XUP
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -185,6 +185,27 @@ VAR
         io: i
     '}
     fM1K1_Press_1_val : LREAL;
+
+    {attribute 'pytmc' := 'pv: MR1K1:BEND:COATING'}
+    fbCoatingStates: FB_PositionStatePMPS2D;
+    {attribute 'pytmc' := '
+      pv: MR1K1:BEND:COATING:STATE:SET
+      io: io
+    '}
+    eStateSet: E_B4C_Rh_CoatingStates;
+    {attribute 'pytmc' := '
+      pv: MR1K1:BEND:COATING:STATE:GET
+      io: i
+    '}
+    eStateGet: E_B4C_Rh_CoatingStates;
+    fbYSetup: FB_StateSetupHelper;
+    fbXSetup: FB_StateSetupHelper;
+
+    astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
+
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -286,8 +307,44 @@ nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm)
     fM1K1_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
     fM1K1_Press_1_val := fM1K1_Press_1.fReal;
 
+fbYSetup(stPositionState:=GVL_States.stDefaultOffsetY, bSetDefault:=TRUE);
+fbXSetup(stPositionState:=GVL_States.stDefaultOffsetX, bSetDefault:=TRUE);
 
-
+fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.B4C],
+    sName:='B4C',
+    sPmpsState:='MR1K1:BEND-B4C',
+    nEncoderCount:=
+);
+fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.B4C],
+    sName:='B4C',
+    sPmpsState:='MR1K1:BEND-B4C',
+    nEncoderCount:=19829700
+);
+fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.OUT],
+    sName:='OUT',
+    sPmpsState:='MR1K1:BEND-OUT',
+    nEncoderCount:=13412630
+);
+// Out position determined soley by X Axis
+fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.OUT],
+    sName:='OUT',
+    sPmpsState:='MR1K1:BEND-OUT',
+    nEncoderCount:=ULINT_TO_UDINT(M14.nRawEncoderULINT)
+);
+fbCoatingStates(
+    stMotionStage1:=Main.M12,
+    stMotionStage2:=Main.M14,
+    astPositionState1:=astCoatingStatesY,
+    astPositionState2:=astCoatingStatesX,
+    eEnumSet:=eStateSet,
+    eEnumGet:=eStateGet,
+    fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,
+    fbArbiter:=GVL_PMPS.fbArbiter1,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    sDeviceName:='MR1K1:BEND',
+    sTransitionKey:='MR1K1:BEND-TRANSITION',
+);
 ]]></ST>
     </Implementation>
   </POU>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -321,9 +321,10 @@ fbXSetup(stPositionState:=astCoatingStatesX[E_MR1K1_States.B4C],
 fbYSetup(stPositionState:=astCoatingStatesY[E_MR1K1_States.OUT],
     sName:='OUT',
     sPmpsState:='MR1K1:BEND-OUT',
-    nEncoderCount:=13412630
+    nEncoderCount:=13412630,
+    fDelta:=50
 );
-// Out position determined soley by X Axis
+// Out position determined solely by Y Axis
 fbXSetup(stPositionState:=astCoatingStatesX[E_MR1K1_States.OUT],
     sName:='OUT',
     sPmpsState:='MR1K1:BEND-OUT',

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -185,7 +185,7 @@ VAR
         io: i
     '}
     fM1K1_Press_1_val : LREAL;
-
+(*
     {attribute 'pytmc' := 'pv: MR1K1:BEND:COATING'}
     fbCoatingStates: FB_PositionStatePMPS2D;
     {attribute 'pytmc' := '
@@ -204,7 +204,7 @@ VAR
     astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
 
-
+*)
 
 END_VAR
 ]]></Declaration>
@@ -306,7 +306,7 @@ nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm)
 
     fM1K1_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
     fM1K1_Press_1_val := fM1K1_Press_1.fReal;
-
+(*
 fbYSetup(stPositionState:=GVL_States.stDefaultOffsetY, bSetDefault:=TRUE);
 fbXSetup(stPositionState:=GVL_States.stDefaultOffsetX, bSetDefault:=TRUE);
 
@@ -345,7 +345,7 @@ fbCoatingStates(
     sDeviceName:='MR1K1:BEND',
     sTransitionKey:='MR1K1:BEND-TRANSITION',
 );
-]]></ST>
+*)]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -185,26 +185,24 @@ VAR
         io: i
     '}
     fM1K1_Press_1_val : LREAL;
-(*
+
     {attribute 'pytmc' := 'pv: MR1K1:BEND:COATING'}
     fbCoatingStates: FB_PositionStatePMPS2D;
     {attribute 'pytmc' := '
       pv: MR1K1:BEND:COATING:STATE:SET
       io: io
     '}
-    eStateSet: E_B4C_Rh_CoatingStates;
+    eStateSet: E_MR1K1_States;
     {attribute 'pytmc' := '
       pv: MR1K1:BEND:COATING:STATE:GET
       io: i
     '}
-    eStateGet: E_B4C_Rh_CoatingStates;
+    eStateGet: E_MR1K1_States;
     fbYSetup: FB_StateSetupHelper;
     fbXSetup: FB_StateSetupHelper;
 
     astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
     astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
-
-*)
 
 END_VAR
 ]]></Declaration>
@@ -306,27 +304,27 @@ nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm)
 
     fM1K1_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
     fM1K1_Press_1_val := fM1K1_Press_1.fReal;
-(*
+
 fbYSetup(stPositionState:=GVL_States.stDefaultOffsetY, bSetDefault:=TRUE);
 fbXSetup(stPositionState:=GVL_States.stDefaultOffsetX, bSetDefault:=TRUE);
 
-fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.B4C],
+fbYSetup(stPositionState:=astCoatingStatesY[E_MR1K1_States.B4C],
     sName:='B4C',
     sPmpsState:='MR1K1:BEND-B4C',
-    nEncoderCount:=
+    nEncoderCount:=31911452
 );
-fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.B4C],
+fbXSetup(stPositionState:=astCoatingStatesX[E_MR1K1_States.B4C],
     sName:='B4C',
     sPmpsState:='MR1K1:BEND-B4C',
-    nEncoderCount:=19829700
+    nEncoderCount:=19829647
 );
-fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.OUT],
+fbYSetup(stPositionState:=astCoatingStatesY[E_MR1K1_States.OUT],
     sName:='OUT',
     sPmpsState:='MR1K1:BEND-OUT',
     nEncoderCount:=13412630
 );
 // Out position determined soley by X Axis
-fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.OUT],
+fbXSetup(stPositionState:=astCoatingStatesX[E_MR1K1_States.OUT],
     sName:='OUT',
     sPmpsState:='MR1K1:BEND-OUT',
     nEncoderCount:=ULINT_TO_UDINT(M14.nRawEncoderULINT)
@@ -345,7 +343,7 @@ fbCoatingStates(
     sDeviceName:='MR1K1:BEND',
     sTransitionKey:='MR1K1:BEND-TRANSITION',
 );
-*)]]></ST>
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
@@ -148,6 +148,21 @@ VAR
     '}
     fM1K2_Press_1_val : LREAL;
 
+    {attribute 'pytmc' := 'pv: MR1K2:SWITCH:COATING'}
+    fbCoatingStates: FB_PositionStatePMPS1D;
+    {attribute 'pytmc' := '
+      pv: MR1K2:SWITCH:COATING:STATE:SET
+      io: io
+    '}
+    eStateSet: E_B4C_Rh_CoatingStates;
+    {attribute 'pytmc' := '
+      pv: MR1K2:SWITCH:COATING:STATE:GET
+      io: i
+    '}
+    eStateGet: E_B4C_Rh_CoatingStates;
+    fbYSetup: FB_StateSetupHelper;
+
+    astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -245,7 +260,35 @@ fM1K2_Flow_1_val := fM1K2_Flow_1.fReal;
 fM1K2_Flow_2(iTermBits:=15, fTermMax:=5.0427, fTermMin:=0.050472);
 fM1K2_Flow_2_val := fM1K2_Flow_2.fReal;
 fM1K2_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
-fM1K2_Press_1_val := fM1K2_Press_1.fReal;]]></ST>
+fM1K2_Press_1_val := fM1K2_Press_1.fReal;
+
+fbYSetup(stPositionState:=GVL_States.stDefaultOffsetY, bSetDefault:=TRUE);
+
+fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.B4C],
+    sName:='B4C',
+    sPmpsState:='MR1K2:SWITCH-B4C',
+    nEncoderCount:=,
+    fDelta:=5000
+);
+fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.Rh],
+    sName:='Rh',
+    sPmpsState:='MR1K2:SWITCH-RHODIUM',
+    nEncoderCount:=,
+    fDelta:=5000
+);
+fbCoatingStates(
+    stMotionStage:=Main.M1,
+    astPositionState:=astCoatingStatesY,
+    eEnumSet:=eStateSet,
+    eEnumGet:=eStateGet,
+    fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,
+    fbArbiter:=GVL_PMPS.fbArbiter1,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    sDeviceName:='MR1K2:SWITCH',
+    sTransitionKey:='MR1K2:SWITCH-TRANSITION',
+);
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K2_SWITCH.TcPOU
@@ -163,6 +163,7 @@ VAR
     fbYSetup: FB_StateSetupHelper;
 
     astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -267,13 +268,13 @@ fbYSetup(stPositionState:=GVL_States.stDefaultOffsetY, bSetDefault:=TRUE);
 fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.B4C],
     sName:='B4C',
     sPmpsState:='MR1K2:SWITCH-B4C',
-    nEncoderCount:=,
+    nEncoderCount:=91672358,
     fDelta:=5000
 );
 fbYSetup(stPositionState:=astCoatingStatesY[E_B4C_Rh_CoatingStates.Rh],
     sName:='Rh',
     sPmpsState:='MR1K2:SWITCH-RHODIUM',
-    nEncoderCount:=,
+    nEncoderCount:=106672361,
     fDelta:=5000
 );
 fbCoatingStates(
@@ -288,6 +289,7 @@ fbCoatingStates(
     sDeviceName:='MR1K2:SWITCH',
     sTransitionKey:='MR1K2:SWITCH-TRANSITION',
 );
+
 ]]></ST>
     </Implementation>
   </POU>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR2K2_FLAT.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR2K2_FLAT.TcPOU
@@ -80,6 +80,20 @@ VAR
         pv: MR2K2:FLAT
     '}
     fbCoolingPanel : FB_Axilon_Cooling_2f1p;
+    {attribute 'pytmc' := 'pv: MR2K2:FLAT:COATING'}
+    fbCoatingStates: FB_PositionStatePMPS1D;
+    {attribute 'pytmc' := '
+      pv: MR2K2:FLAT:COATING:STATE:SET
+      io: io
+    '}
+    eStateSet: E_B4C_Rh_CoatingStates;
+    {attribute 'pytmc' := '
+      pv: MR2K2:FLAT:COATING:STATE:GET
+      io: i
+    '}
+    eStateGet: E_B4C_Rh_CoatingStates;
+    fbXSetup: FB_StateSetupHelper;
+    astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[//FB_Motion stages for MR2K2 Axes
@@ -118,7 +132,36 @@ nEncCntYM2K2  := ULINT_TO_UDINT(M26.nRawEncoderULINT);
 nEncCntrXM2K2  := ULINT_TO_UDINT(M27.nRawEncoderULINT);
 
 // Axilon Cooling Panel
-fbCoolingPanel();]]></ST>
+fbCoolingPanel();
+
+// States
+fbXSetup(stPositionState:=GVL_States.stDefaultKBX, bSetDefault:=TRUE);
+// B4C
+fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.B4C],
+    sName:='B4C',
+    sPmpsState:='MR2K2:FLAT-B4C',
+    nEncoderCount:=
+);
+
+// Rh
+fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.Rh],
+    sName:='Rh',
+    sPmpsState:='MR2K2:FLAT-RHODIUM',
+    nEncoderCount:=
+);
+
+fbCoatingStates(
+    stMotionStage:=Main.M25,
+    astPositionState:=astCoatingStatesX,
+    eEnumSet:=eStateSet,
+    eEnumGet:=eStateGet,
+    fbFFHWO:=GVL_PMPS.fbFastFaultOutput2,
+    fbArbiter:=GVL_PMPS.fbArbiter2,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    sDeviceName:='MR2K2:FLAT',
+    sTransitionKey:='MR2K2:FLAT-TRANSITION',
+);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR2K2_FLAT.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR2K2_FLAT.TcPOU
@@ -80,20 +80,7 @@ VAR
         pv: MR2K2:FLAT
     '}
     fbCoolingPanel : FB_Axilon_Cooling_2f1p;
-    {attribute 'pytmc' := 'pv: MR2K2:FLAT:COATING'}
-    fbCoatingStates: FB_PositionStatePMPS1D;
-    {attribute 'pytmc' := '
-      pv: MR2K2:FLAT:COATING:STATE:SET
-      io: io
-    '}
-    eStateSet: E_B4C_Rh_CoatingStates;
-    {attribute 'pytmc' := '
-      pv: MR2K2:FLAT:COATING:STATE:GET
-      io: i
-    '}
-    eStateGet: E_B4C_Rh_CoatingStates;
-    fbXSetup: FB_StateSetupHelper;
-    astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[//FB_Motion stages for MR2K2 Axes
@@ -133,35 +120,7 @@ nEncCntrXM2K2  := ULINT_TO_UDINT(M27.nRawEncoderULINT);
 
 // Axilon Cooling Panel
 fbCoolingPanel();
-
-// States
-fbXSetup(stPositionState:=GVL_States.stDefaultKBX, bSetDefault:=TRUE);
-// B4C
-fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.B4C],
-    sName:='B4C',
-    sPmpsState:='MR2K2:FLAT-B4C',
-    nEncoderCount:=
-);
-
-// Rh
-fbXSetup(stPositionState:=astCoatingStatesX[E_B4C_Rh_CoatingStates.Rh],
-    sName:='Rh',
-    sPmpsState:='MR2K2:FLAT-RHODIUM',
-    nEncoderCount:=
-);
-
-fbCoatingStates(
-    stMotionStage:=Main.M25,
-    astPositionState:=astCoatingStatesX,
-    eEnumSet:=eStateSet,
-    eEnumGet:=eStateGet,
-    fbFFHWO:=GVL_PMPS.fbFastFaultOutput2,
-    fbArbiter:=GVL_PMPS.fbArbiter2,
-    bEnableMotion:=TRUE,
-    bEnableBeamParams:=TRUE,
-    sDeviceName:='MR2K2:FLAT',
-    sTransitionKey:='MR2K2:FLAT-TRANSITION',
-);]]></ST>
+]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -322,7 +322,7 @@ fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.LRG],
     nEncoderCount:=,
 );
 
-fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.UNRULED],
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.Unruled],
     sName:='UNRULED',
     sPmpsState:='SP1K1:MONO-UNRULED',
     nEncoderCount:=,

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -224,6 +224,31 @@ VAR
     '}
     fSP1K1_Press_1_val : LREAL;
 
+     stDefaultGH : ST_PositionState := (
+        fDelta:=2000,
+        fVelocity:=875.0,
+        fAccel:=6923,
+        fDecel:=6923,
+        bMoveOk:=TRUE,
+        bValid:=TRUE,
+        bUseRawCounts:=TRUE
+    );
+    {attribute 'pytmc' := 'pv: SP1K1:MONO:GRATING'}
+    fbCoatingStates: FB_PositionStatePMPS1D;
+    {attribute 'pytmc' := '
+      pv: SP1K1:MONO:GRATING:STATE:SET
+      io: io
+    '}
+    eStateSet: E_Grating_States;
+    {attribute 'pytmc' := '
+      pv: SP1K1:MONO:GRATING:STATE:GET
+      io: i
+    '}
+    eStateGet: E_Grating_States;
+    fbGHSetup: FB_StateSetupHelper;
+
+    astGratingStates: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -288,6 +313,57 @@ fSP1K1_Flow_2_val := fSP1K1_Flow_2.fReal;
 
 fSP1K1_Press_1(iTermBits:=15, fTermMax:=4.0, fTermMin:=0);
 fSP1K1_Press_1_val := fSP1K1_Press_1.fReal;
+
+fbGHSetup(stPositionState:=stDefaultGH, bSetDefault:=TRUE);
+
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.LRG],
+    sName:='LRG',
+    sPmpsState:='SP1K1:MONO-LRG',
+    nEncoderCount:=,
+);
+
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.UNRULED],
+    sName:='UNRULED',
+    sPmpsState:='SP1K1:MONO-UNRULED',
+    nEncoderCount:=,
+);
+
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.YAG],
+    sName:='YAG',
+    sPmpsState:='SP1K1:MONO-YAG',
+    nEncoderCount:=,
+);
+
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.MEG],
+    sName:='MEG',
+    sPmpsState:='SP1K1:MONO-MEG',
+    nEncoderCount:=,
+);
+
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.HEG],
+    sName:='HEG',
+    sPmpsState:='SP1K1:MONO-HEG',
+    nEncoderCount:=,
+);
+
+fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.LEG],
+    sName:='LEG',
+    sPmpsState:='SP1K1:MONO-LEG',
+    nEncoderCount:=,
+);
+
+fbCoatingStates(
+    stMotionStage:=Main.M9,
+    astPositionState:=astGratingStates,
+    eEnumSet:=eStateSet,
+    eEnumGet:=eStateGet,
+    fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,
+    fbArbiter:=GVL_PMPS.fbArbiter1,
+    bEnableMotion:=TRUE,
+    bEnableBeamParams:=TRUE,
+    sDeviceName:='SP1K1:MONO',
+    sTransitionKey:='SP1K1:MONO-TRANSITION',
+);
 ]]></ST>
     </Implementation>
   </POU>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_SP1K1_MONO.TcPOU
@@ -233,8 +233,9 @@ VAR
         bValid:=TRUE,
         bUseRawCounts:=TRUE
     );
+
     {attribute 'pytmc' := 'pv: SP1K1:MONO:GRATING'}
-    fbCoatingStates: FB_PositionStatePMPS1D;
+    fbGratingStates: FB_PositionStatePMPS1D;
     {attribute 'pytmc' := '
       pv: SP1K1:MONO:GRATING:STATE:SET
       io: io
@@ -319,40 +320,40 @@ fbGHSetup(stPositionState:=stDefaultGH, bSetDefault:=TRUE);
 fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.LRG],
     sName:='LRG',
     sPmpsState:='SP1K1:MONO-LRG',
-    nEncoderCount:=,
+    nEncoderCount:=7599807,
 );
 
 fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.Unruled],
     sName:='UNRULED',
     sPmpsState:='SP1K1:MONO-UNRULED',
-    nEncoderCount:=,
+    nEncoderCount:=10000269,
 );
 
 fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.YAG],
     sName:='YAG',
     sPmpsState:='SP1K1:MONO-YAG',
-    nEncoderCount:=,
+    nEncoderCount:=16000506,
 );
 
 fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.MEG],
     sName:='MEG',
     sPmpsState:='SP1K1:MONO-MEG',
-    nEncoderCount:=,
+    nEncoderCount:=25420841,
 );
 
 fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.HEG],
     sName:='HEG',
     sPmpsState:='SP1K1:MONO-HEG',
-    nEncoderCount:=,
+    nEncoderCount:=42600635,
 );
 
 fbGHSetup(stPositionState:=astGratingStates[E_Grating_States.LEG],
     sName:='LEG',
     sPmpsState:='SP1K1:MONO-LEG',
-    nEncoderCount:=,
+    nEncoderCount:=59802448,
 );
 
-fbCoatingStates(
+fbGratingStates(
     stMotionStage:=Main.M9,
     astPositionState:=astGratingStates,
     eEnumSet:=eStateSet,
@@ -362,7 +363,7 @@ fbCoatingStates(
     bEnableMotion:=TRUE,
     bEnableBeamParams:=TRUE,
     sDeviceName:='SP1K1:MONO',
-    sTransitionKey:='SP1K1:MONO-TRANSITION',
+    sTransitionKey:='SP1K1:MONO-TRANSITION'
 );
 ]]></ST>
     </Implementation>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -29,6 +29,9 @@
     <Compile Include="DUTs\E_B4C_Rh_CoatingStates.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DUTs\E_MR1K1_States.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="DUTs\E_Grating_States.TcDUT">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -263,7 +263,7 @@
     </PlaceholderReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryReference Include="lcls-twincat-motion,4.0.8,SLAC">
+    <LibraryReference Include="lcls-twincat-motion,4.1.1,SLAC">
       <Namespace>lcls_twincat_motion</Namespace>
     </LibraryReference>
   </ItemGroup>
@@ -272,7 +272,7 @@
       <Resolution>LCLS General, 2.10.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 4.0.8 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, 4.1.1 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-optics">
       <Resolution>lcls-twincat-optics, 0.7.0 (SLAC)</Resolution>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -29,6 +29,9 @@
     <Compile Include="DUTs\E_B4C_Rh_CoatingStates.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DUTs\E_Grating_States.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Function Blocks\FB_XS_YAG_States.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.plcproj
@@ -26,6 +26,9 @@
     <Compile Include="DUTs\ENUM_XS_YAG_States.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DUTs\E_B4C_Rh_CoatingStates.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Function Blocks\FB_XS_YAG_States.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -67,6 +70,10 @@
     </Compile>
     <Compile Include="GVLs\GVL_SerialIO.TcGVL">
       <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="GVLs\GVL_States.TcGVL">
+      <SubType>Code</SubType>
+      <LinkAlways>true</LinkAlways>
     </Compile>
     <Compile Include="GVLs\Main.TcGVL">
       <SubType>Code</SubType>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D56FD35A-A82E-BED9-95CE-C5B9B904C156}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{6F7A53A0-C2D9-A16A-9BED-F44FF998AD64}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10419,31 +10419,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163477768</GetCodeOffs>
+        <GetCodeOffs>163053400</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163477840</GetCodeOffs>
+        <GetCodeOffs>163053472</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163477856</GetCodeOffs>
+        <GetCodeOffs>163053488</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163477816</GetCodeOffs>
+        <GetCodeOffs>163053448</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163477848</GetCodeOffs>
+        <GetCodeOffs>163053480</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11695,15 +11695,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163477640</GetCodeOffs>
-        <SetCodeOffs>163477688</SetCodeOffs>
+        <GetCodeOffs>163053272</GetCodeOffs>
+        <SetCodeOffs>163053320</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163477720</GetCodeOffs>
-        <SetCodeOffs>163477744</SetCodeOffs>
+        <GetCodeOffs>163053352</GetCodeOffs>
+        <SetCodeOffs>163053376</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11944,31 +11944,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>163477952</GetCodeOffs>
+        <GetCodeOffs>163053584</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163477912</GetCodeOffs>
+        <GetCodeOffs>163053544</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163478088</GetCodeOffs>
+        <GetCodeOffs>163053720</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163478096</GetCodeOffs>
+        <GetCodeOffs>163053728</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163478008</GetCodeOffs>
+        <GetCodeOffs>163053640</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11980,7 +11980,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163478104</GetCodeOffs>
+        <GetCodeOffs>163053736</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12573,7 +12573,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163478160</GetCodeOffs>
+        <GetCodeOffs>163053792</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -27356,175 +27356,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</Name>
-      <BitSize>30144</BitSize>
-      <SubItem>
-        <Name>io_fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, FB will run. Reads when enable goes TRUE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPlcName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> E.g. lfe-motion</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bRefresh</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE to cause an extra read.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>784</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: REFRESH
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDirectory</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Directory where the DB is stored.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>792</BitOffs>
-        <Default>
-          <String>/Hard Disk/ftp/PMPS/</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nLastRefreshTime</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1440</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: LAST_REFRESH
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1472</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtEnable</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtRefresh</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbTime</Name>
-        <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
-        <Comment> Time tracking liften from Arbiter PLCs</Comment>
-        <BitSize>20800</BitSize>
-        <BitOffs>1920</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.bEnable</Name>
-            <Bool>true</Bool>
-          </SubItem>
-          <SubItem>
-            <Name>.dwCycle</Name>
-            <Value>1</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbTime_to_UTC</Name>
-        <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>22720</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetTimeZone</Name>
-        <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
-        <BitSize>3776</BitSize>
-        <BitOffs>26368</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Name>
       <BitSize>64</BitSize>
       <SubItem>
@@ -36985,7 +36816,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163489816</GetCodeOffs>
+        <GetCodeOffs>163065448</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -38913,31 +38744,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163489216</GetCodeOffs>
+        <GetCodeOffs>163064848</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163489304</GetCodeOffs>
+        <GetCodeOffs>163064936</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163489232</GetCodeOffs>
+        <GetCodeOffs>163064864</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163489280</GetCodeOffs>
+        <GetCodeOffs>163064912</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163489320</GetCodeOffs>
+        <GetCodeOffs>163064952</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -54778,34 +54609,142 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name>E_B4C_Rh_CoatingStates</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>B4C</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Rh</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
+      <Name Namespace="LCLS_General">FB_TempSensor</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>fResolution</Name>
+        <Type>LREAL</Type>
+        <Comment> Resolution parameter from the Beckhoff docs. Default is 0.1 for 0.1 degree resolution</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0.1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTemp</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TEMP
+        io: input
+        field: EGU C
+        field: PREC 2
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bConnected</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: CONN
+        io: input
+        field: ONAM Connected
+        field: ZNAM Disconnected
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUnderrange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOverrange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iRaw</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
       <Properties>
         <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -55028,6 +54967,767 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
+      <BitSize>3200</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <Comment> State to move to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start move on rising edge, stop move on falling edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GO
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge error reset</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when a move is already active</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the motor is at this state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: AT_STATE
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Error description</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we are moving to a state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>936</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we are not moving and we reached a state successfully on our last move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>944</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
+        <BitSize>1920</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>3008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerExec</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3136</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAllowMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLatchAllowErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3168</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_RawCountConverter</Name>
+      <BitSize>8576</BitSize>
+      <SubItem>
+        <Name>stParameters</Name>
+        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
+        <Comment> Parameters to check against</Comment>
+        <BitSize>8192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCountCheck</Name>
+        <Type>UDINT</Type>
+        <Comment> Optional count to convert to a real position</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosCheck</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional position to convert to encoder counts</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>8320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCountGet</Name>
+        <Type>UDINT</Type>
+        <Comment> If converting position, the number of counts</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosGet</Name>
+        <Type>LREAL</Type>
+        <Comment> If converting counts, the position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>8448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> True during a parameter get/calc</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> True after a successful get/calc</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> True if the calculation errored</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateLock</Name>
+      <BitSize>3904</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCachedPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3840</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternal</Name>
+      <BitSize>12672</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbEncConverter</Name>
+        <Type Namespace="lcls_twincat_motion">FB_RawCountConverter</Type>
+        <BitSize>8576</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLock</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateLock</Type>
+        <BitSize>3904</BitSize>
+        <BitOffs>8768</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
+      <BitSize>256512</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> On rising edge, reset this FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, there is an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error ID</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The error that caused bError to flip TRUE</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are moving the motor</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>840</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>848</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrStates</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Pre-allocated array of states</Comment>
+        <BitSize>54720</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+        io: io
+        expand: %.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>setState</Name>
+        <Type>INT</Type>
+        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>goalState</Name>
+        <Type>INT</Type>
+        <Comment> The current position we are trying to reach, or 0</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>getState</Name>
+        <Type>INT</Type>
+        <Comment> The readback position</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>55664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stUnknown</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>55680</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stGoal</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>59328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
+        <BitSize>3200</BitSize>
+        <BitOffs>62976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>190080</BitSize>
+        <BitOffs>66176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>256256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewGoal</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerExec</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveRequested</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256448</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>StateHandler</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionState1D instead</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">I_HigherAuthority</Name>
@@ -56351,357 +57051,129 @@ ELSE:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Name>
-      <BitSize>32</BitSize>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</Name>
+      <BitSize>20096</BitSize>
       <SubItem>
-        <Name>nSetValue</Name>
-        <Type>UINT</Type>
-        <Comment> For internal use only. This holds new goal positions as an integer, else it is 0 if there is no new state move request. It is written to from the user's input enum.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to acknowledge and clear an error.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
           </Property>
         </Properties>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Name>
-      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>arrStates</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
       <SubItem>
         <Name>bArbiterEnabled</Name>
         <Type>BOOL</Type>
-        <Comment> User setting: TRUE to enable the arbiter, FALSE to disable it.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
+        <BitOffs>192</BitOffs>
         <Default>
           <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:ARB:ENABLE
-        io: io
-    </Value>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
         <Name>bMaintMode</Name>
         <Type>BOOL</Type>
-        <Comment> User setting: TRUE to enable maintenance mode (Fast fault, free motion), FALSE to disable it.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:MAINT
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Name>
-      <BitSize>768</BitSize>
-      <SubItem>
-        <Name>nGetValue</Name>
-        <Type>UINT</Type>
-        <Comment> For internal use only. This holds the current position index as an integer, else it is 0 if we are changing states or not at any particular state.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be TRUE when we are in an active state move and FALSE otherwise.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be TRUE after a move completes and FALSE otherwise.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be TRUE if the most recent move had an error and FALSE otherwise.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> This will be set to an NC error code during an error if one exists or left at 0 otherwise.</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMsg</Name>
-        <Type>STRING(80)</Type>
-        <Comment> This will be set to an appropriate error message during an error if one exists or left as an empty string otherwise.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Name>
-      <BitSize>2496</BitSize>
-      <SubItem>
-        <Name>stTransitionDb</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <Comment> The database entry for the transition state. This should always be present.</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PMPS:TRANS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StatesInputHandler</Name>
-      <BitSize>384</BitSize>
-      <SubItem>
-        <Name>stUserInput</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
-        <Comment> The user's inputs from EPICS. This is an IN_OUT variable because we will write values back to this to help us detect when the same value is re-caput</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> The bBusy boolean from the motion FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nStartingState</Name>
-        <Type>UINT</Type>
-        <Comment> The starting state number to seed nCurrGoal with</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we have a move error, to prevent moves</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGoal</Name>
-        <Type>UINT</Type>
-        <Comment> The goal index to input to the motion FB. This will be clamped to the range 0..GeneralConstants.MAX_STATES</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecMove</Name>
-        <Type>BOOL</Type>
-        <Comment> The bExecute boolean to input to the motion FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bResetMove</Name>
-        <Type>BOOL</Type>
-        <Comment> The bReset boolean to input to the motion FB</Comment>
         <BitSize>8</BitSize>
         <BitOffs>200</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Output</Value>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MAINT
+        io: io
+    </Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>nState</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
+        <Name>bRequestTransition</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nQueuedGoal</Name>
-        <Type>UINT</Type>
+        <Name>setState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getState</Name>
+        <Type>INT</Type>
         <BitSize>16</BitSize>
         <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>bNewMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
+        <Name>fStateBoundaryDeadband</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
         <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCachedStart</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IDLE</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>288</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>GOING</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>304</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>WAIT_STOP</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <Value>2</Value>
+          <DateTime>T#1s</DateTime>
         </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_RawCountConverter</Name>
-      <BitSize>8576</BitSize>
-      <SubItem>
-        <Name>stParameters</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
-        <Comment> Parameters to check against</Comment>
-        <BitSize>8192</BitSize>
-        <BitOffs>64</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -56710,11 +57182,13 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>nCountCheck</Name>
-        <Type>UDINT</Type>
-        <Comment> Optional count to convert to a real position</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8256</BitOffs>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>352</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -56723,1232 +57197,288 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fPosCheck</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional position to convert to encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountGet</Name>
-        <Type>UDINT</Type>
-        <Comment> If converting position, the number of counts</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosGet</Name>
-        <Type>LREAL</Type>
-        <Comment> If converting counts, the position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> True during a parameter get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> True after a successful get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if the calculation errored</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateLock</Name>
-      <BitSize>3904</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
+        <Name>bTransitionAuthorized</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
+        <BitOffs>360</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
+            <Value>Output</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stCachedPositionState</Name>
+        <Name>bForwardAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>368</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBackwardAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>376</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionDb</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <BitSize>2496</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TRANS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionBeam</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>2912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionState</Name>
         <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>192</BitOffs>
+        <BitOffs>4672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>3840</BitOffs>
+        <BitOffs>8320</BitOffs>
         <Default>
-          <Bool>false</Bool>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternal</Name>
-      <BitSize>12672</BitSize>
       <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbEncConverter</Name>
-        <Type Namespace="lcls_twincat_motion">FB_RawCountConverter</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbLock</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateLock</Type>
-        <BitSize>3904</BitSize>
-        <BitOffs>8768</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Name>
-      <BitSize>570496</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All the motors to apply the standard routines to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbStateInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
-        <ArrayInfo Level="0">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> The individual instantiated internal FBs. Must have the same bounds as astPositionState.</Comment>
-        <BitSize>570240</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterMotors</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>570432</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterStates</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>570464</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
-      <BitSize>3200</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <Comment> State to move to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
+        <Name>bTransDone</Name>
         <Type>BOOL</Type>
-        <Comment> Start move on rising edge, stop move on falling edge</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GO
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
+        <BitOffs>8328</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Rising edge error reset</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
-        <Comment> Define behavior for when a move is already active</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the motor is at this state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: AT_STATE
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we have an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Error description</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we are moving to a state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we are not moving and we reached a state successfully on our last move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>944</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
-        <BitSize>1920</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
+        <Name>rtTransReq</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>128</BitSize>
-        <BitOffs>2880</BitOffs>
+        <BitOffs>8384</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>rtReset</Name>
+        <Name>bBPTMDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtBPTMDone</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>128</BitSize>
-        <BitOffs>3008</BitOffs>
+        <BitOffs>8576</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bInnerExec</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3136</BitOffs>
+        <Name>ftMotorExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8704</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bAllowMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3144</BitOffs>
+        <Name>rtTransDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8832</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>nLatchAllowErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>3168</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Name>
-      <BitSize>10752</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Array of motors to move together</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
+        <Name>rtDoLateFinish</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8960</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> 1D Position states: the current position to send each axis to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
+        <Name>tonDone</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>9088</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start all moves on rising edge, stop all moves on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Reset any errors</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
-        <Comment> Define behavior for when a move request is interrupted with a new request</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ALL of the motors are at their goal states</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ANY of this FB's moves are in progress</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ALL motors have completed the last move request from this FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if ANY of this FB's moves had an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>264</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorCount</Name>
-        <Type>UINT</Type>
-        <Comment> How many FBs are erroring</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nShownError</Name>
-        <Type>DINT</Type>
-        <Comment> Which component is the source of the example/summarized error</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> One of the error ids</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The error error message matching the ID</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbPositionStateMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> 1D State movers: FBs to move the motors</Comment>
-        <BitSize>9600</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>10624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>10656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLowerBound</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>10688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nUpperBound</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>10720</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>DoStateMoves</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>CombineOutputs</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateRead</Name>
-      <BitSize>4096</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The motor to check the state of</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> The allowed states for this motor</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bKnownState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're standing still at a known state, or moving within the bounds of a state to another location in the bounds.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMovingState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're moving to some other state or to another non-state position.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nPositionIndex</Name>
-        <Type>UINT</Type>
-        <Comment> If we're at a known state, this will be the index in the astPositionState array that matches the state. Otherwise, this will be 0, which is below the bounds of the array, so it cannot be confused with a valid output.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCurrentPosition</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <Comment> A copy of the details of the current position state, for convenience. This may be a moving state or an unknown state as a placeholder if we are not at a known state.</Comment>
-        <BitSize>3648</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abAtPosition</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> A full description of whether we're at each of our states. This is used in 2D, 3D, etc. to clarify cases where states may overlap in 1D.</Comment>
-        <BitSize>120</BitSize>
-        <BitOffs>3904</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>4032</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateReadND</Name>
-      <BitSize>12736</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The motors with a combined N-dimensional state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bKnownState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're standing still at a known state.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMovingState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're moving, there can be no valid state if we are moving.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nPositionIndex</Name>
-        <Type>UINT</Type>
-        <Comment> If we're at a known state, this will be the state index along the enclosed states arrays. Otherwise, it will be zero, which is below the bounds of the states array.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the active motor count was invalid</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abAtPosition</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> A full description of whether we're at each of our states. This is used to clarify cases where states may overlap.</Comment>
-        <BitSize>120</BitSize>
-        <BitOffs>248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbPositionStateRead</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateRead</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The individual position state reader function blocks</Comment>
-        <BitSize>12288</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>12672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter2</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>12688</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>DoStateReads</Name>
-      </Action>
-      <Action>
-        <Name>CombineOutputs</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Name>
-      <BitSize>609536</BitSize>
-      <SubItem>
-        <Name>astMotionStageMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionStateMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All position states for all motors, including unused/invalid states.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
-        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
-        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumSet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumGet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGoal</Name>
-        <Type>UINT</Type>
-        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbInput</Name>
-        <Type Namespace="lcls_twincat_motion">FB_StatesInputHandler</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Type>
-        <BitSize>570496</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Type>
-        <BitSize>10752</BitSize>
-        <BitOffs>571392</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbRead</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateReadND</Type>
-        <BitSize>12736</BitSize>
-        <BitOffs>582144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astMoveGoals</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <BitSize>10944</BitSize>
-        <BitOffs>594880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stInvalidPos</Name>
+        <Name>stStateReq</Name>
         <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>605824</BitOffs>
+        <BitOffs>9344</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>nIterMotor</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>609472</BitOffs>
+        <Name>mcPower</Name>
+        <Type Namespace="Tc2_MC2">MC_Power</Type>
+        <BitSize>960</BitSize>
+        <BitOffs>12992</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>fUpperBound</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>13952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLowerBound</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>14016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>14080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stGoalState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>14144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fActPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>17792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fReqPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>17856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInTransition</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>17920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stBeamNeeded</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>17952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFwdOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBwdOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonArbiter</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>19776</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLateFinish</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInternalAuth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20040</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>AssertHere</Name>
+      </Action>
+      <Action>
+        <Name>HandleBPTM</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>ClearAsserts</Name>
+      </Action>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandlePmpsDb</Name>
+      </Action>
+      <Method>
+        <Name>GetBeamFromState</Name>
+        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
+        <ReturnBitSize>1760</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stState</Name>
+          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+          <BitSize>3648</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetStateCode</Name>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetStateStruct</Name>
+        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
+        <ReturnBitSize>3648</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -58265,246 +57795,6 @@ ELSE:
           <BitSize>16</BitSize>
         </Local>
       </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Name>
-      <BitSize>205632</BitSize>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction. These will not be modified.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Hardware output to fault to if there is a problem.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The database lookup key for the transition state. This has no corresponding ST_PositionState.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A name to use for fast faults, etc.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>840</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadNow</Name>
-        <Type>BOOL</Type>
-        <Comment> For debug: set this to TRUE in online mode to read the database immediately.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1488</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> The raw lookup results from this FB. Index 0 is the transition beam, the rest of the indices match the state positions.</Comment>
-        <BitSize>39936</BitSize>
-        <BitOffs>1504</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstReadDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we've had at least one successful read.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>41440</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> This will be set to TRUE if there was an error reading from the database.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>41448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ffError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>41472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbReadPmpsDb</Name>
-        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
-        <BitSize>115008</BitSize>
-        <BitOffs>67392</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftDbBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>182400</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftRead</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>182528</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>182656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterMotor</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>182688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterState</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>182720</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIterState2</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>182752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sLoopNewKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>182784</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sLoopPrevKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>183432</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>abStateError</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>128</BitSize>
-        <BitOffs>184080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>asLookupKeys</Name>
-        <Type>STRING(80)</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>10368</BitSize>
-        <BitOffs>184208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>asPrevLookupKeys</Name>
-        <Type>STRING(80)</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>10368</BitSize>
-        <BitOffs>194576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewKeys</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>204944</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sTempBackfill</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>204952</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>SelectLookupKeys</Name>
-      </Action>
-      <Action>
-        <Name>BackfillInfo</Name>
-      </Action>
-      <Action>
-        <Name>ReadDatabase</Name>
-      </Action>
-      <Action>
-        <Name>RunFastFaults</Name>
-      </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -59084,31 +58374,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionBPTM</Name>
-      <BitSize>115072</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Array of motors that will move for this beam transition</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Name>
+      <BitSize>396032</BitSize>
+      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</ExtendsType>
       <SubItem>
         <Name>fbArbiter</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam states from</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
+        <BitOffs>20096</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59119,9 +58392,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
+        <BitOffs>20160</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59130,50 +58402,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stGoalParams</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
-        <Comment> The parameters we want to transition to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransParams</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
-        <Comment> The parameters we want to use during the transition</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
+        <Name>bReadPmpsDb</Name>
         <Type>BOOL</Type>
-        <Comment> Set to TRUE to use the BPTM, FALSE to stop using the BPTM.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>400</BitOffs>
+        <BitOffs>20224</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59182,24 +58414,10 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're at the physical state that matches the goal parameters</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
+        <Name>sPmpsDeviceName</Name>
         <Type>STRING(80)</Type>
-        <Comment> A device name to use in the GUI</Comment>
         <BitSize>648</BitSize>
-        <BitOffs>416</BitOffs>
+        <BitOffs>20232</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -59208,900 +58426,191 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>tArbiterTimeout</Name>
-        <Type>TIME</Type>
-        <Comment> How long to wait for parameters before timing out</Comment>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>20880</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPmpsDoc</Name>
+        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>21568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stHighBeamThreshold</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>21632</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBPOKAutoReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23392</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrPMPS</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>39936</BitSize>
+        <BitOffs>23424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nBPIndex</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>63360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTransitionAssertionID</Name>
+        <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Default>
-          <DateTime>T#1s</DateTime>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
+        <BitOffs>63392</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bMoveOnArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <Comment> Whether to fault and move on timeout (TRUE) or to wait (FALSE)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1120</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
+        <Name>nLastReqAssertionID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>63424</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bResetBPTMTimeout</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE when it is safe to reset the BPTM timeout fast fault, to reset it early.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
+        <Name>fbReadPmpsDb</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>115008</BitSize>
+        <BitOffs>63488</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment> This becomes TRUE when the motors are allowed to move to their destinations.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
+        <Name>ftDbBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>178496</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> This becomes TRUE once the full beam transition is done.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
+        <Name>rtReadDBExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>178624</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're using a bad motor count</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
+        <Name>ftRead</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>178752</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bptm</Name>
         <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
         <BitSize>61568</BitSize>
-        <BitOffs>1216</BitOffs>
+        <BitOffs>178880</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bDoneMoving</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>62784</BitOffs>
+        <Name>ffBeamParamsOk</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>240448</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>nPrevID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>62816</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>62848</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInternalAuth</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>62880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bDoneResetQueued</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>62888</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonArbiter</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>62912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>63168</BitOffs>
+        <Name>ffZeroRate</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>266368</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffBPTMTimeoutAndMove</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>63232</BitOffs>
+        <BitOffs>292288</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffBPTMError</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>89152</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>HandleTimeout</Name>
-      </Action>
-      <Action>
-        <Name>SetDoneMoving</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Action>
-        <Name>RunBPTM</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Name>
-      <BitSize>448</BitSize>
-      <SubItem>
-        <Name>astDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <Comment> All states to deactivate: transition + the static position states</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter who made the PMPS assert requests</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Clear asserts on rising edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">E_StatePMPSStatus</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>UNKNOWN</Text>
-        <Enum>0</Enum>
-        <Comment> No other enum state describes it</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TRANSITION</Text>
-        <Enum>1</Enum>
-        <Comment> Moving toward a known state</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AT_STATE</Text>
-        <Enum>2</Enum>
-        <Comment> Within a known state, not trying to leave</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>DISABLED</Text>
-        <Enum>3</Enum>
-        <Comment> PMPS is in some way disabled, either with maint mode or arbiter disable</Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Name>
-      <BitSize>27456</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The motor with a position state.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All possible position states for this motor.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Hardware output to fault to if there is a problem.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, do the limits as normal. If FALSE, allow all moves regardless of the limits defined here.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalStateIndex</Name>
-        <Type>UINT</Type>
-        <Comment> The state that the motor is moving to.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eStatePMPSStatus</Name>
-        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
-        <Comment> The overal PMPS FB state</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment> Connect to the BPTM</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> The enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>312</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bForwardEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> The forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBackwardEnabled</Name>
-        <Type>BOOL</Type>
-        <Comment> The backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>328</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValidGoal</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>mc_power</Name>
-        <Type Namespace="Tc2_MC2">MC_Power</Type>
-        <BitSize>960</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nPrevStateIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLowerPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fUpperPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffNoGoal</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>1536</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>SetEnables</Name>
-      </Action>
-      <Action>
-        <Name>ApplyEnables</Name>
-      </Action>
-      <Action>
-        <Name>GetBounds</Name>
-      </Action>
-      <Action>
-        <Name>RunFastFaults</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Name>
-      <BitSize>135360</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The motors with a combined N-dimensional state</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Each motor's respective position states along its direction</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Hardware output to fault to if there is a problem.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> Whether or not to do anything</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalStateIndex</Name>
-        <Type>UINT</Type>
-        <Comment> The state that the motors are moving to, along dimension 2 of the position state array. This may be the same as the current state.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A name to use for this state mover in the case of fast faults.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMaintMode</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE to put motors into maintenance mode. This allows us to freely move the motors at the cost of a fast fault.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>952</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eStatePMPSStatus</Name>
-        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
-        <Comment> The overal PMPS FB state</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <Comment> Connect from bptm bTransitionAuthorized</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>976</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abEnabled</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>984</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abForwardEnabled</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>1008</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abBackwardEnabled</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>1032</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>abValidGoal</Name>
-        <Type>BOOL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> Per-motor TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
-        <BitSize>24</BitSize>
-        <BitOffs>1056</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE if the arrays have mismatched sizing. For this FB, this means the motor won't ever get an enable.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1080</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbStateEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> The individual state limit function blocks</Comment>
-        <BitSize>82368</BitSize>
-        <BitOffs>1088</BitOffs>
+        <BitOffs>318208</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffMaint</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>83456</BitOffs>
+        <BitOffs>344128</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>ffProgrammerError</Name>
+        <Name>ffUnknown</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>109376</BitOffs>
+        <BitOffs>370048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFFOxOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>395968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAtSafeState</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>395976</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nIter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>135296</BitOffs>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>395984</BitOffs>
       </SubItem>
       <Action>
-        <Name>DoLimits</Name>
+        <Name>HandlePmpsDb</Name>
       </Action>
       <Action>
-        <Name>CheckCount</Name>
+        <Name>HandleFFO</Name>
       </Action>
       <Action>
-        <Name>RunFastFaults</Name>
+        <Name>AssertHere</Name>
+      </Action>
+      <Action>
+        <Name>ClearAsserts</Name>
+      </Action>
+      <Action>
+        <Name>HandleBPTM</Name>
       </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Name>
-      <BitSize>106944</BitSize>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam states from</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> A name to link to these fast faults</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCurrentBeamReq</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <Comment> Current requested beam details: either a known state or the transition beam</Comment>
-        <BitSize>1760</BitSize>
-        <BitOffs>864</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bKnownState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we're at a known state (doesn't matter which)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>2624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTransitionID</Name>
-        <Type>DWORD</Type>
-        <Comment> Lookup ID of the transition beam</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2656</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nMaxTrips</Name>
-        <Type>UINT</Type>
-        <Comment> Number of consecutive trips before we debounce</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2688</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>tTripReset</Name>
-        <Type>TIME</Type>
-        <Comment> Decrease trip count by 1 after this much time has passed</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>2720</BitOffs>
-        <Default>
-          <DateTime>T#1s</DateTime>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ffBeamParamsOk</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> If the beam parameters are wrong, it is a fault! This encompasses all unknown arbiter-related errors.</Comment>
-        <BitSize>25920</BitSize>
-        <BitOffs>2752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffZeroRate</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> If we asked for zero rate (NC or SC) then we can cut the beam early. This is somewhat redundant.</Comment>
-        <BitSize>25920</BitSize>
-        <BitOffs>28672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffUnknown</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> Trip the beam for unknown state</Comment>
-        <BitSize>25920</BitSize>
-        <BitOffs>54592</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffDebounce</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <Comment> Trip the beam (no autoreset) if ffBeamParamsOK faults/resets multiple times too quickly.</Comment>
-        <BitSize>25920</BitSize>
-        <BitOffs>80512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nTripCount</Name>
-        <Type>UINT</Type>
-        <Comment> Number of consecutive trips so far</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>106432</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftTripCount</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <Comment> Increase by 1 whenever there is a fault (rising edge)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>106496</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonTripCount</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <Comment> Decrease trip count by 1 each timeout</Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>106624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCycle</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE on only the first cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>106880</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <Properties>
         <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -60357,2046 +58866,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Name>
-      <BitSize>114048</BitSize>
-      <SubItem>
-        <Name>astMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All motors associated with the state mover.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> Fast fault output to fault to.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> The number of motors we're actually using</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Identifying name to use in group fast faults</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMotorCountError</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE if the arrays don't have the same bounds. In this FB, that's an automatic fault.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>856</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>afbEncError</Name>
-        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <BitSize>87168</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffProgrammerError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>88064</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>113984</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>HandleLoops</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
-        <Name>CheckCount</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Name>
-      <BitSize>682048</BitSize>
-      <SubItem>
-        <Name>astMotionStageMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionStateMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0" ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All position states for all motors, including unused/invalid states.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
-        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSEpicsToPlc</Type>
-        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
-        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSPlcToEpics</Type>
-        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam conditions from.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableBeamParams</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnablePositionLimits</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>584</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nActiveMotorCount</Name>
-        <Type>UINT</Type>
-        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>592</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>608</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the transition state in the PMPS database.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>1256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGoal</Name>
-        <Type>UINT</Type>
-        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1904</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadDBNow</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1920</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <Comment> The PMPS database lookup associated with the current position state.</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>1952</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionReadPMPSDB</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Type>
-        <BitSize>205632</BitSize>
-        <BitOffs>4480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionBPTM</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionBPTM</Type>
-        <BitSize>115072</BitSize>
-        <BitOffs>210112</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionClearAsserts</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Type>
-        <BitSize>448</BitSize>
-        <BitOffs>325184</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStatePMPSEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Type>
-        <BitSize>135360</BitSize>
-        <BitOffs>325632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMiscStatesErrorFFO</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Type>
-        <BitSize>106944</BitSize>
-        <BitOffs>460992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbPerMotorFFO</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Type>
-        <BitSize>114048</BitSize>
-        <BitOffs>567936</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eStatePMPSStatus</Name>
-        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>681984</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
-      <BitSize>1541120</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The motor to move.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All possible position states, including unused/invalid states.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATE
-        io: io
-        expand: :%.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumSet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumGet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam conditions from.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableMotion</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableBeamParams</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnablePositionLimits</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>472</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the transition state in the PMPS database.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>1120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
-        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1776</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
-        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1808</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadDBNow</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1824</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
-        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>768</BitSize>
-        <BitOffs>1856</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
-        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>2624</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <Comment> The PMPS database lookup associated with the current position state.</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>5120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbCore</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
-        <BitSize>609536</BitSize>
-        <BitOffs>7616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbPMPSCore</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
-        <BitSize>682048</BitSize>
-        <BitOffs>617152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astMotionStageMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <BitSize>77760</BitSize>
-        <BitOffs>1299200</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionStateMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>164160</BitSize>
-        <BitOffs>1376960</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
-      <BitSize>92352</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSetDefault</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bForceUpdate</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosition</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nEncoderCount</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAccel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDecel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bLocked</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValid</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUseRawCounts</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPmpsState</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>1248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDefault</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>1920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbWarning</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>86080</BitSize>
-        <BitOffs>5568</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bHasDefault</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>91648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bHasWarned</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>91656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sJson</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>91664</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_TempSensor</Name>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>fResolution</Name>
-        <Type>LREAL</Type>
-        <Comment> Resolution parameter from the Beckhoff docs. Default is 0.1 for 0.1 degree resolution</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0.1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fTemp</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: TEMP
-        io: input
-        field: EGU C
-        field: PREC 2
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bConnected</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: CONN
-        io: input
-        field: ONAM Connected
-        field: ZNAM Disconnected
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: input
-        field: ONAM True
-        field: ZNAM False
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUnderrange</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bOverrange</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iRaw</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>E_Grating_States</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>LRG</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Unruled</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>YAG</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MEG</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>HEG</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>LEG</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
-      <BitSize>256512</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> On rising edge, reset this FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, there is an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error ID</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The error that caused bError to flip TRUE</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Pre-allocated array of states</Comment>
-        <BitSize>54720</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-        io: io
-        expand: %.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>setState</Name>
-        <Type>INT</Type>
-        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>goalState</Name>
-        <Type>INT</Type>
-        <Comment> The current position we are trying to reach, or 0</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
-        <Comment> The readback position</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>55664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stUnknown</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>55680</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoal</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>59328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
-        <BitSize>3200</BitSize>
-        <BitOffs>62976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>190080</BitSize>
-        <BitOffs>66176</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>256256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewGoal</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerExec</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>256320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveRequested</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256448</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>StateHandler</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionState1D instead</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</Name>
-      <BitSize>20096</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bArbiterEnabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMaintMode</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MAINT
-        io: io
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bRequestTransition</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>setState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fStateBoundaryDeadband</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>tArbiterTimeout</Name>
-        <Type>TIME</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <DateTime>T#1s</DateTime>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveOnArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>352</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>360</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bForwardAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>368</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBackwardAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>376</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionDb</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <BitSize>2496</BitSize>
-        <BitOffs>416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: TRANS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionBeam</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>2912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>4672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8320</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bTransDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTransReq</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBPTMDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtBPTMDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftMotorExec</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTransDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtDoLateFinish</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonDone</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>9088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stStateReq</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>9344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>mcPower</Name>
-        <Type Namespace="Tc2_MC2">MC_Power</Type>
-        <BitSize>960</BitSize>
-        <BitOffs>12992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fUpperBound</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>13952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLowerBound</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>14016</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>14080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoalState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>14144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fActPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>17792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fReqPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>17856</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInTransition</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>17920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stBeamNeeded</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>17952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFwdOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBwdOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19720</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonArbiter</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>19776</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLateFinish</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20032</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInternalAuth</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20040</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>AssertHere</Name>
-      </Action>
-      <Action>
-        <Name>HandleBPTM</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
-        <Name>ClearAsserts</Name>
-      </Action>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandlePmpsDb</Name>
-      </Action>
-      <Method>
-        <Name>GetBeamFromState</Name>
-        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
-        <ReturnBitSize>1760</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stState</Name>
-          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-          <BitSize>3648</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetStateCode</Name>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetStateStruct</Name>
-        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
-        <ReturnBitSize>3648</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Name>
-      <BitSize>396032</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</ExtendsType>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>20096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>20160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>20232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>20880</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPmpsDoc</Name>
-        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>21568</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stHighBeamThreshold</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>21632</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBPOKAutoReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>23392</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrPMPS</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>39936</BitSize>
-        <BitOffs>23424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nBPIndex</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>63360</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nTransitionAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>63392</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLastReqAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>63424</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbReadPmpsDb</Name>
-        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
-        <BitSize>115008</BitSize>
-        <BitOffs>63488</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftDbBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>178496</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReadDBExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>178624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftRead</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>178752</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bptm</Name>
-        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
-        <BitSize>61568</BitSize>
-        <BitOffs>178880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffBeamParamsOk</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>240448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffZeroRate</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>266368</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffBPTMTimeoutAndMove</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>292288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffBPTMError</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>318208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffMaint</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>344128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffUnknown</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>370048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFFOxOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>395968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAtSafeState</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>395976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>395984</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>HandlePmpsDb</Name>
-      </Action>
-      <Action>
-        <Name>HandleFFO</Name>
-      </Action>
-      <Action>
-        <Name>AssertHere</Name>
-      </Action>
-      <Action>
-        <Name>ClearAsserts</Name>
-      </Action>
-      <Action>
-        <Name>HandleBPTM</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -75759,6 +72228,9597 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Property>
       </Properties>
     </DataType>
+    <DataType>
+      <Name>E_B4C_Rh_CoatingStates</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>B4C</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Rh</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{CC929187-3970-4CF4-8F39-946BEC12422D}">TcIPCDiagEventClass</Name>
+      <DisplayName TxtId="">TcIPCDiagEventClass</DisplayName>
+      <EventId>
+        <Name Id="#x0001">Fail</Name>
+        <DisplayName TxtId="">Fail - unspecified error.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0100">InvalidIndex</Name>
+        <DisplayName TxtId="">Invalid index.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0101">InvalidAccess</Name>
+        <DisplayName TxtId="">Invalid access.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0102">BufferTooSmall</Name>
+        <DisplayName TxtId="">Buffer is too small.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0103">TypeNotSupported</Name>
+        <DisplayName TxtId="">Type is not supported.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0104">OutOfMemory</Name>
+        <DisplayName TxtId="">Out of memory.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0105">NoDataAvailable</Name>
+        <DisplayName TxtId="">No data available.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0106">InvalidData</Name>
+        <DisplayName TxtId="">Invalid data.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0107">InvalidArgument</Name>
+        <DisplayName TxtId="">Invalid argument.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0108">OutOfRange</Name>
+        <DisplayName TxtId="">Value is out of range.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0200">ServerBusy</Name>
+        <DisplayName TxtId="">Server is busy.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0201">NotInit</Name>
+        <DisplayName TxtId="">MDP API is not initialized.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x0F00">NotImplemented</Name>
+        <DisplayName TxtId="">Not implemented.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x1000">NotSupported</Name>
+        <DisplayName TxtId="">Not supported.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{5437A241-9D17-41D0-8629-34B822946252}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name>ST_TcIPCDiagEventClass</Name>
+      <BitSize>2688</BitSize>
+      <SubItem>
+        <Name>Fail</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.Fail</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InvalidIndex</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.InvalidIndex</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InvalidAccess</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.InvalidAccess</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>BufferTooSmall</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.BufferTooSmall</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>TypeNotSupported</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.TypeNotSupported</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>OutOfMemory</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>960</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.OutOfMemory</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>NoDataAvailable</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.NoDataAvailable</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InvalidData</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1344</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.InvalidData</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InvalidArgument</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1536</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.InvalidArgument</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>OutOfRange</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.OutOfRange</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ServerBusy</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1920</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.ServerBusy</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>NotInit</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>2112</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.NotInit</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>NotImplemented</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>2304</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.NotImplemented</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>NotSupported</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>2496</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>3432157575</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>14704</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>19700</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>143</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>57</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>148</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>107</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>236</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>18</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>66</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagEventClass.NotSupported</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>TcTypeSystem</Name>
+        </Property>
+        <Property>
+          <Name>signature_flag</Name>
+          <Value>33554432</Value>
+        </Property>
+        <Property>
+          <Name>checksuperglobal</Name>
+        </Property>
+        <Property>
+          <Name>show</Name>
+        </Property>
+        <Property>
+          <Name>no-analysis</Name>
+        </Property>
+        <Property>
+          <Name>TcEventClass</Name>
+          <Value>TcIPCDiagEventClass</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{20226F4C-54BA-479F-BA48-FBE52D0E9CD5}">TcIPCDiagPlcApiEventClass</Name>
+      <DisplayName TxtId="">TcIPCDiagPlcApiEventClass</DisplayName>
+      <EventId>
+        <Name Id="1">InvalidModList</Name>
+        <DisplayName TxtId="">Invalid module list (initialization of IPCDiag required).</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x2">UnavailableModule</Name>
+        <DisplayName TxtId="">Module of parameter is unavailable (not existing).</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x3">UnavailableParameter</Name>
+        <DisplayName TxtId="">Parameter is unavailable (not existing).</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x4">NoValidData</Name>
+        <DisplayName TxtId="">No valid parameter value available (reading is pending or failed).</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x5">InvalidBuffer</Name>
+        <DisplayName TxtId="">Allocated buffer is invalid (pointer is zero or buffer size is too small).</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x6">InvalidIndex</Name>
+        <DisplayName TxtId="">Allocated index is invalid.</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="7">BadParameterValues</Name>
+        <DisplayName TxtId="">Error that some of the requested parameter values returned an error (use GetParameterByIdx).</DisplayName>
+        <Severity>Error</Severity>
+      </EventId>
+      <EventId>
+        <Name Id="#x8">BadParameterValues_Info</Name>
+        <DisplayName TxtId="">Info that some of the requested parameter values returned an error (use GetParameterByIdx).</DisplayName>
+        <Severity>Info</Severity>
+      </EventId>
+      <Hides>
+        <Hide GUID="{1F50550E-82AC-4486-B681-048F0AEF9609}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name>ST_TcIPCDiagPlcApiEventClass</Name>
+      <BitSize>1536</BitSize>
+      <SubItem>
+        <Name>InvalidModList</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.InvalidModList</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>UnavailableModule</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.UnavailableModule</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>UnavailableParameter</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.UnavailableParameter</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>NoValidData</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.NoValidData</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InvalidBuffer</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.InvalidBuffer</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>InvalidIndex</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>960</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.InvalidIndex</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>BadParameterValues</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.BadParameterValues</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>BadParameterValues_Info</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>1344</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>539127628</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>21690</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>18335</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>186</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>72</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>251</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>229</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>45</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>14</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>156</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>213</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_TcIPCDiagPlcApiEventClass.BadParameterValues_Info</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Info</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>TcTypeSystem</Name>
+        </Property>
+        <Property>
+          <Name>signature_flag</Name>
+          <Value>33554432</Value>
+        </Property>
+        <Property>
+          <Name>checksuperglobal</Name>
+        </Property>
+        <Property>
+          <Name>show</Name>
+        </Property>
+        <Property>
+          <Name>no-analysis</Name>
+        </Property>
+        <Property>
+          <Name>TcEventClass</Name>
+          <Value>TcIPCDiagPlcApiEventClass</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>E_Grating_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>LRG</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Unruled</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>YAG</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MEG</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>HEG</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>LEG</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</Name>
+      <BitSize>16</BitSize>
+      <BaseType>WORD</BaseType>
+      <EnumInfo>
+        <Text>AccessControl</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UserManagement</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>RAS</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FTP</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>SMB</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TwinCAT</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Datastore</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>CPU</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Memory</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Firewall</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FileSystemObject</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PLC</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>DisplayDevice</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EWF</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FBWF</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>SiliconDrive</Text>
+        <Enum>23</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OS</Text>
+        <Enum>24</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Raid</Text>
+        <Enum>25</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Fan</Text>
+        <Enum>27</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Mainboard</Text>
+        <Enum>28</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>DiskManagement</Text>
+        <Enum>29</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS</Text>
+        <Enum>30</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhysicalDrive</Text>
+        <Enum>31</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStorage</Text>
+        <Enum>32</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF</Text>
+        <Enum>33</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Misc</Text>
+        <Enum>256</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_Module</Name>
+      <BitSize>48</BitSize>
+      <SubItem>
+        <Name>eModType</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nModId</Name>
+        <Type>BYTE</Type>
+        <Comment> dynamically created module id </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nModIdx</Name>
+        <Type>USINT</Type>
+        <Comment> 1= first instance of this module type (= default) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nModCnt</Name>
+        <Type>USINT</Type>
+        <Comment> quantity of instances of this module type in the module list </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_ModuleList</Name>
+      <Comment> list of modules of the configuration area </Comment>
+      <BitSize>12496</BitSize>
+      <SubItem>
+        <Name>aModules</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_Module</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>256</Elements>
+        </ArrayInfo>
+        <Comment> array idx = nModId of the module </Comment>
+        <BitSize>12288</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nModules</Name>
+        <Type>UINT</Type>
+        <Comment> number of all instantiated modules (max.256) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>12288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>12304</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">ADSREADEX</Name>
+      <Comment> Extended ADS read command. </Comment>
+      <BitSize>1472</BitSize>
+      <SubItem>
+        <Name>NETID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> Ams net id </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PORT</Name>
+        <Type Namespace="Tc2_System">T_AmsPort</Type>
+        <Comment> Ads communication port </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>IDXGRP</Name>
+        <Type>UDINT</Type>
+        <Comment> Index group </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>IDXOFFS</Name>
+        <Type>UDINT</Type>
+        <Comment> Index offset </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LEN</Name>
+        <Type>UDINT</Type>
+        <Comment> Max. number of data bytes to read (LEN &lt;= max. size of destination buffer) </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>DESTADDR</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Pointer to destination buffer </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>TcIgnorePersistent</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>READ</Name>
+        <Type>BOOL</Type>
+        <Comment> Rising edge starts command execution </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TMOUT</Name>
+        <Type>TIME</Type>
+        <Comment> Maximum time allowed for the execution of this ADS command </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BUSY</Name>
+        <Type>BOOL</Type>
+        <Comment> Busy flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ERR</Name>
+        <Type>BOOL</Type>
+        <Comment> Error flag </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ERRID</Name>
+        <Type>UDINT</Type>
+        <Comment> ADS error code </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>COUNT_R</Name>
+        <Type>UDINT</Type>
+        <Comment> Count of bytes actually read </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>hide_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPRead</Name>
+      <Comment> reads a single MDP parameter by its address</Comment>
+      <BitSize>2240</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Function block execution is triggered by a rising edge at this input.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nFlags</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nSubIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>104</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pDstBuf</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Contains the address of the buffer for the received data. </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nDstBufSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Contains the max. number of bytes to be received. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> States the time before the function is cancelled. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> keep empty '' for the local device </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCount</Name>
+        <Type>UDINT</Type>
+        <Comment> returns the number of bytes received </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIdxOffset</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsReadEx</Name>
+        <Type Namespace="Tc2_System">ADSREADEX</Type>
+        <BitSize>1472</BitSize>
+        <BitOffs>640</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PORT</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXGRP</Name>
+            <Value>62210</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2112</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_GetModuleList</Name>
+      <Comment> requests the full MDP module list </Comment>
+      <BitSize>27712</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Function block execution is triggered by a rising edge at this input.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> States the time before the function is cancelled. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> keep empty '' for the local device </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stModuleList</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_ModuleList</Type>
+        <BitSize>12496</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cMaxNoModules</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12880</BitOffs>
+        <Default>
+          <Value>256</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cMaxModType</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12896</BitOffs>
+        <Default>
+          <Value>512</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bSubExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>12912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bSubBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>12920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>aModTypeCnt</Name>
+        <Type>USINT</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>513</Elements>
+        </ArrayInfo>
+        <BitSize>4104</BitSize>
+        <BitOffs>12928</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nListIdx</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>17040</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eModType</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>17056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCntModules</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>17072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadMDP</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPRead</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>17088</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.nIndex</Name>
+            <Value>61456</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nFlags</Name>
+            <Value>1</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nSubIndex</Name>
+            <Value>0</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>aDataList</Name>
+        <Type>WORD</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>513</Elements>
+        </ArrayInfo>
+        <BitSize>8208</BitSize>
+        <BitOffs>19328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>27584</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_Register</Name>
+      <Comment> initializes the PLC API for IPC diagnostics on a specific IPC</Comment>
+      <BitSize>45376</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> States the time before the function is cancelled. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> keep empty '' for the local device </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> read data available =(NOT bBusy AND NOT bError) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if an error occurred.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <Comment> '&lt; 0' = error; '&gt; 0' = info; '0' = no error/info</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipErrorMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
+        <Comment> shows detailed information about occurred errors</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stModuleList</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_ModuleList</Type>
+        <BitSize>12496</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>12992</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetModList</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_GetModuleList</Type>
+        <BitSize>27712</BitSize>
+        <BitOffs>13120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbErrorMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
+        <BitSize>4224</BitSize>
+        <BitOffs>40832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FallingEdgeBUSY</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>45056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEventEntryTemp</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>45184</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>USINT (1..255)</Name>
+      <BitSize>8</BitSize>
+      <BaseType>USINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>255</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">I_IPCDiag_AccessParameter</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>GetParameter</Name>
+        <Comment> access a read parameter (if more than one value is available all values can be copied at once, except for STRING types)</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetParameterByIdx</Name>
+        <Comment> access a read parameter by index specification </Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one parameter value)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nParameterIdx</Name>
+          <Comment> selection of parameter value (1..nReadParameterValues) (e.g. equals list index in case of list parameter)</Comment>
+          <Type>USINT (1..255)</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetParameterStrings</Name>
+        <Comment> access a read string parameter (if more than one value is available all values can be copied to an ARRAY OF STRING at once)</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nStrings</Name>
+          <Comment> number of strings to be copied (each string with size=nBufferSize/nStrings)</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Name>
+      <BitSize>64</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <PropertyItem>
+        <Name>nAllocatedSize</Name>
+        <Type>ULINT</Type>
+        <Comment> currently allocated dynamic memory byte size</Comment>
+        <BitSize>64</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nBufferCount</Name>
+        <Type>ULINT</Type>
+        <Comment> current number of allocated byte buffers</Comment>
+        <BitSize>64</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nObjectCount</Name>
+        <Type>ULINT</Type>
+        <Comment> current number of allocated objects</Comment>
+        <BitSize>64</BitSize>
+      </PropertyItem>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getnAllocatedSize</Name>
+        <ReturnType RpcDirection="out">ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__getnBufferCount</Name>
+        <ReturnType RpcDirection="out">ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="3">__getnObjectCount</Name>
+        <ReturnType RpcDirection="out">ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Alloc</Name>
+        <Comment>| Method allocates new dynamic memory with the given size.
+| If the return value is 0 memory was unavailable.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Parameter>
+          <Name>nSize</Name>
+          <Comment> requested size in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bReset</Name>
+          <Comment> zero the allocated memory	</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Free</Name>
+        <Parameter>
+          <Name>p</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" ReferenceTo="true">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ParameterKey</Name>
+      <BitSize>64</BitSize>
+      <BaseType>LWORD</BaseType>
+      <EnumInfo>
+        <Text>Unselected</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IPCDeviceName</Text>
+        <Enum>30399297753710592</Enum>
+        <Comment> IPC device name, STRING, read/write (MDP general area)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IPCHardwareVersion</Text>
+        <Enum>7881299616923648</Enum>
+        <Comment> IPC hardware version, STRING, constant (MDP general area)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IPCImageVersion</Text>
+        <Enum>7881299616989184</Enum>
+        <Comment> IPC image version, STRING, constant (MDP general area)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IPCVendor</Text>
+        <Enum>6473924734353409</Enum>
+        <Comment> IPC vendor, UDINT, constant (MDP general area)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>IPCSerialNumber</Text>
+        <Enum>12384903168524288</Enum>
+        <Comment> serial number (or BTN) of Beckhoff IPC, STRING, read-only (MDP device area)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>CPU_Name</Text>
+        <Enum>12384948368441347</Enum>
+        <Comment> CPU name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>CPU_Frequency</Text>
+        <Enum>6473973857583105</Enum>
+        <Comment> CPU Frequency, UDINT, constant</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>CPU_Usage</Text>
+        <Enum>10414623531532290</Enum>
+        <Comment> Current CPU Usage (%), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>CPU_Temp</Text>
+        <Enum>10133148554821635</Enum>
+        <Comment> Current CPU Temperature (°C), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_NoVolumes</Text>
+        <Enum>10414700840943616</Enum>
+        <Comment> number of volumes (VolumeList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_VolumeList_DriveLetter</Text>
+        <Enum>156500213753774081</Enum>
+        <Comment> drive letter, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_VolumeList_Label</Text>
+        <Enum>174514612263321601</Enum>
+        <Comment> volume label, STRING, read/write (write is not supported under WinCE)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_VolumeList_FileSystem</Text>
+        <Enum>156500213753905153</Enum>
+        <Comment> file system, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_VolumeList_DriveType</Text>
+        <Enum>155092838870417409</Enum>
+        <Comment> drive type (0=Unknown,1=Fixed,2=Removable,4=CDROM), UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_VolumeList_TotelSize</Text>
+        <Enum>155655788823904257</Enum>
+        <Comment> total size (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_VolumeList_FreeSpace</Text>
+        <Enum>155655788823969793</Enum>
+        <Comment> free space (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_FreeSpaceOfVolumeC</Text>
+        <Enum>9234912637602496512</Enum>
+        <Comment> free space of the volume with drive letter 'C' (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Disk_FreeSpaceOfVolumeD</Text>
+        <Enum>9234912637602496513</Enum>
+        <Comment> free space of the volume with drive letter 'D' (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_ModuleCnt</Text>
+        <Enum>81909301975711744</Enum>
+        <Comment> number of Display modules, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_Name</Text>
+        <Enum>12384982728179715</Enum>
+        <Comment> display device name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_IdxOfActiveMode</Text>
+        <Enum>27866106447331329</Enum>
+        <Comment> index of active display mode (1..n), USINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_NoModes</Text>
+        <Enum>10414657891336192</Enum>
+        <Comment> number of available display modes (ModeList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_ModeList_ModeDef</Text>
+        <Enum>156500170804166657</Enum>
+        <Comment> display mode definition, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_PrimaryDisplay</Text>
+        <Enum>9288757984559105</Enum>
+        <Comment> is primary display, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_ComPort</Text>
+        <Enum>30399381237858306</Enum>
+        <Comment> COM port, STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_Version</Text>
+        <Enum>10977607844823043</Enum>
+        <Comment> version, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_Brightness</Text>
+        <Enum>28992006354305028</Enum>
+        <Comment> brightness in % (20..100), UDINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Display_Light</Text>
+        <Enum>27303156494041093</Enum>
+        <Comment> light, BOOL, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Fan_ModuleCnt</Text>
+        <Enum>81909336335450112</Enum>
+        <Comment> number of Fan modules, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Fan_Name</Text>
+        <Enum>12385017087918083</Enum>
+        <Comment> fan adapter name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Fan_Speed</Text>
+        <Enum>10133217274298369</Enum>
+        <Comment> fan speed (rpm), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_Type</Text>
+        <Enum>12385021382950913</Enum>
+        <Comment> mainboard type, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_SerialNumber</Text>
+        <Enum>12385021382950914</Enum>
+        <Comment> mainboard serial number, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_ProductionDate</Text>
+        <Enum>12385021382950915</Enum>
+        <Comment> mainboard production date, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_BootCnt</Text>
+        <Enum>10977646499397636</Enum>
+        <Comment> boot count, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_OperationTime</Text>
+        <Enum>10977646499397637</Enum>
+        <Comment> opertaion time (minutes), UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_MinTemperature</Text>
+        <Enum>10696171522686982</Enum>
+        <Comment> min.mainboard temperature (°C), DINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_MaxTemperature</Text>
+        <Enum>10696171522686983</Enum>
+        <Comment> max.mainboard temperature (°C), DINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_MinInputVoltage</Text>
+        <Enum>10696171522686984</Enum>
+        <Comment> min.mainboard input voltage (mV), DINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_MaxInputVoltage</Text>
+        <Enum>10696171522686985</Enum>
+        <Comment> max.mainboard input voltage (mV), DINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_Temperature</Text>
+        <Enum>10133221569265674</Enum>
+        <Comment> mainboard temperature (°C), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_Revision</Text>
+        <Enum>9851746592620545</Enum>
+        <Comment> mainboard revision, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_BiosVersionMajor</Text>
+        <Enum>9851746592620546</Enum>
+        <Comment> bios major version, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_BiosVersionMinor</Text>
+        <Enum>9851746592620547</Enum>
+        <Comment> bios minor version, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_BiosVersion</Text>
+        <Enum>12385021383016452</Enum>
+        <Comment> bios version, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_NoVoltageMeasurements</Text>
+        <Enum>10414696546107392</Enum>
+        <Comment> number of voltage measurements (VoltageList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_VoltageList_Name</Text>
+        <Enum>154248409645252609</Enum>
+        <Comment> name of voltage measurement, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_VoltageList_Location</Text>
+        <Enum>154248409645318145</Enum>
+        <Comment> location of voltage measurement (E_IPCDiag_MBVoltageLocation), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_VoltageList_Value</Text>
+        <Enum>154248409645383681</Enum>
+        <Comment> value of voltage measurement (mV), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MB_VoltageList_NominalValue</Text>
+        <Enum>154248409645449217</Enum>
+        <Comment> nominal value of voltage measurement (mV), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Memory_ProgramMemoryAllocated</Text>
+        <Enum>11540527733342214</Enum>
+        <Comment> program memory (RAM) allocated (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Memory_ProgramMemoryAvailable</Text>
+        <Enum>11540527733342215</Enum>
+        <Comment> program memory (RAM) available (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Misc_StartupNumLockState</Text>
+        <Enum>27304174401159169</Enum>
+        <Comment> Numlock state at system startup, BOOL, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Misc_AutoLogonUser</Text>
+        <Enum>12386000635494405</Enum>
+        <Comment> auto logon user at system startup, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_ModuleCnt</Text>
+        <Enum>81909228961267712</Enum>
+        <Comment> number of NIC modules, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_Name</Text>
+        <Enum>12384909713735683</Enum>
+        <Comment> NIC adapter name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_MACAddress</Text>
+        <Enum>7881310086430721</Enum>
+        <Comment> MAC address, STRING, constant</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_IPv4Address</Text>
+        <Enum>30399308223283202</Enum>
+        <Comment> IPv4 Address, STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_IPv4SubnetMask</Text>
+        <Enum>30399308223283203</Enum>
+        <Comment> IPv4 Subnet Mask, STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_DHCP</Text>
+        <Enum>27303083479465988</Enum>
+        <Comment> DHCP, BOOL, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_IPv4DefGateway</Text>
+        <Enum>30399308223283205</Enum>
+        <Comment> IPv4 Default Gateway, STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_IPv4DNSServers</Text>
+        <Enum>30399308223283206</Enum>
+        <Comment> IPv4 DNS servers (comma separated), STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_IPv4DNS</Text>
+        <Enum>30399308223283206</Enum>
+        <Comment> IPv4 DNS servers (comma separated), STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_VirtualDeviceName</Text>
+        <Enum>30399308223283207</Enum>
+        <Comment> virtual device name, STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>NIC_IPv4DNSServersActive</Text>
+        <Enum>12384909713801224</Enum>
+        <Comment> IPv4 DNS active servers (only under TC/BSD and TC/RTOS), STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OS_Name</Text>
+        <Enum>12385004203016195</Enum>
+        <Comment> name of OS (operating system), STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OS_VersionMajor</Text>
+        <Enum>28992027829010433</Enum>
+        <Comment> OS major version, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OS_VersionMinor</Text>
+        <Enum>28992027829010434</Enum>
+        <Comment> OS minor version, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OS_VersionBuild</Text>
+        <Enum>28992027829010435</Enum>
+        <Comment> OS build version, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OS_CSDVersion</Text>
+        <Enum>30399402712563716</Enum>
+        <Comment> OS CSD version, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_ModuleCnt</Text>
+        <Enum>81909353515319296</Enum>
+        <Comment> number of physical drive modules, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SerialNumber</Text>
+        <Enum>12385034267787267</Enum>
+        <Comment> serial number of physical drive, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_Index</Text>
+        <Enum>10977659384299521</Enum>
+        <Comment> index, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_Caption</Text>
+        <Enum>12385034267852802</Enum>
+        <Comment> caption, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_LogicalPartitions</Text>
+        <Enum>12385034267852803</Enum>
+        <Comment> logical partitions (comma separated list), STRING, read-only  </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_PartitionCnt</Text>
+        <Enum>10977659384299524</Enum>
+        <Comment> partition count, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_TotalCylinders</Text>
+        <Enum>11540609337720837</Enum>
+        <Comment> total cylinders, ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_TotalHeads</Text>
+        <Enum>10977659384299526</Enum>
+        <Comment> total heads, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_TotalSectors</Text>
+        <Enum>11540609337720839</Enum>
+        <Comment> total sectors, ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_TotalTracks</Text>
+        <Enum>11540609337720840</Enum>
+        <Comment> total tracks, ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_NoSMARTAttributes</Text>
+        <Enum>10414709430943744</Enum>
+        <Comment> number of SMART attributes (SMARTAttrList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SMARTAttrList_ID</Text>
+        <Enum>153966947553378305</Enum>
+        <Comment> attribute ID, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SMARTAttrList_StatusFlag</Text>
+        <Enum>154529897506865153</Enum>
+        <Comment> status flag, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SMARTAttrList_CurrentValue</Text>
+        <Enum>153966947553509377</Enum>
+        <Comment> current value, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SMARTAttrList_WorstValue</Text>
+        <Enum>153966947553574913</Enum>
+        <Comment> worst value, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SMARTAttrList_RawData</Text>
+        <Enum>156500222344036353</Enum>
+        <Comment> raw data (6 bytes), STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PhyDrv_SMARTAttrList_Threshold</Text>
+        <Enum>153966947553705985</Enum>
+        <Comment> threshold, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_NoDrives</Text>
+        <Enum>10414713725845504</Enum>
+        <Comment> number of mass storage drives (DriveList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_SerialNumber</Text>
+        <Enum>156500226638675969</Enum>
+        <Comment> serial number of mass storage drive, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_SataPort</Text>
+        <Enum>153966951848345601</Enum>
+        <Comment> SATA-Port of mass storage drive, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_PartitionLetter</Text>
+        <Enum>156500226638807041</Enum>
+        <Comment> partition letter(s) of mass storage drive, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_DriveName</Text>
+        <Enum>156500226638872577</Enum>
+        <Comment> drive name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_DriveType</Text>
+        <Enum>153966951848542209</Enum>
+        <Comment> drive type (0=Unknown,1=HD,2=SSD,3=CFast,4=CF), USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_EraseCntAverage</Text>
+        <Enum>155655801708871681</Enum>
+        <Comment> erase count average (flashdrive SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_EraseCntSpec</Text>
+        <Enum>155655801708937217</Enum>
+        <Comment> erase count specified (flashdrive SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_EraseCyclesLeft</Text>
+        <Enum>154248426825449473</Enum>
+        <Comment> erase cycles left in percent (flashdrive SMART), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_SpareBlocksRemain</Text>
+        <Enum>155655801709068289</Enum>
+        <Comment> spare blocks remaining (flashdrive SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_SpareBlocksInit</Text>
+        <Enum>155655801709133825</Enum>
+        <Comment> spare blocks initial (flashdrive SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_SpareBlocksLeft</Text>
+        <Enum>154248426825646081</Enum>
+        <Comment> spare blocks left in percent (flashdrive SMART), INT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_ReallocatedSectors</Text>
+        <Enum>155655801709264897</Enum>
+        <Comment> reallocated sectors (harddisk SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_SpinRetries</Text>
+        <Enum>155655801709330433</Enum>
+        <Comment> spin retries (harddisk SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_PendingSectors</Text>
+        <Enum>155655801709395969</Enum>
+        <Comment> pending sectors (harddisk SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MassStg_DriveList_UltraDmaCrcErrors</Text>
+        <Enum>155655801709461505</Enum>
+        <Comment> Ultra DMA CRC Errors (harddisk SMART), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software_MDPVersion</Text>
+        <Enum>9235756980928249856</Enum>
+        <Comment> version of the MDP.exe service, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software_NoSoftwares</Text>
+        <Enum>10414619236564992</Enum>
+        <Comment> number of software components (SWList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software_SWList_Name</Text>
+        <Enum>156500132149395457</Enum>
+        <Comment> name of software, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software_SWList_Company</Text>
+        <Enum>156500132149460993</Enum>
+        <Comment> company of software, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software_SWList_Date</Text>
+        <Enum>156500132149526529</Enum>
+        <Comment> date of software, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Software_SWList_Version</Text>
+        <Enum>156500132149592065</Enum>
+        <Comment> version of software, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_Version</Text>
+        <Enum>9235756972338315264</Enum>
+        <Comment> TwinCAT version, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_VersionMajor</Text>
+        <Enum>10414610646630401</Enum>
+        <Comment> TwinCAT major version, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_VersionMinor</Text>
+        <Enum>10414610646630402</Enum>
+        <Comment> TwinCAT minor version, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_VersionBuild</Text>
+        <Enum>10414610646630403</Enum>
+        <Comment> TwinCAT build version, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_VersionRevision</Text>
+        <Enum>10414610646630412</Enum>
+        <Comment> TwinCAT revision version, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_AmsNetID</Text>
+        <Enum>30399333993086980</Enum>
+        <Comment> Ams Net ID, STRING, read/write (reboot required)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_Status</Text>
+        <Enum>10414610646630406</Enum>
+        <Comment> TwinCAT status, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RunAsDev</Text>
+        <Enum>28429009156112391</Enum>
+        <Comment> run as device (only under WinCE), UINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_ShowTargetVisu</Text>
+        <Enum>28429009156112392</Enum>
+        <Comment> show target visu (only under WinCE), UINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_LogFileSize</Text>
+        <Enum>28991959109533705</Enum>
+        <Comment> log file size (only under WinCE), UDINT, read/write	</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_LogFilePath</Text>
+        <Enum>30399333993086986</Enum>
+        <Comment> log file path (only under WinCE), STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_SystemID</Text>
+        <Enum>12384935483605003</Enum>
+        <Comment> TwinCAT system ID, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_NoRoutes</Text>
+        <Enum>10414610646695936</Enum>
+        <Comment> number of TwinCAT ads routes (RouteList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouteList_Name</Text>
+        <Enum>156500123559526401</Enum>
+        <Comment> name of TC ads route, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouteList_Address</Text>
+        <Enum>156500123559591937</Enum>
+        <Comment> address of TC ads route, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouteList_AmsAddress</Text>
+        <Enum>156500123559657473</Enum>
+        <Comment> address of TC ads route, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouteList_Flags</Text>
+        <Enum>155092748676169729</Enum>
+        <Comment> flags of TC ads route, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouteList_Timeout</Text>
+        <Enum>155092748676235265</Enum>
+        <Comment> timeout of TC ads route, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouteList_Transport</Text>
+        <Enum>154529798722879489</Enum>
+        <Comment> transport type of TC ads route (Tc2_Utilities.E_RouteTransportType), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_Logfile</Text>
+        <Enum>12384935484063744</Enum>
+        <Comment> TwinCAT Logfile, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterMemoryMaximum</Text>
+        <Enum>11540510553997313</Enum>
+        <Comment> maximum router memory size (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterMemoryAvailable</Text>
+        <Enum>11540510553997314</Enum>
+        <Comment> available router memory size (bytes), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterRegisteredPorts</Text>
+        <Enum>10977560600576003</Enum>
+        <Comment> registered ports, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterRegisteredDrivers</Text>
+        <Enum>10977560600576004</Enum>
+        <Comment> registered drivers, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterRegisteredTransports</Text>
+        <Enum>10977560600576005</Enum>
+        <Comment> registered transports, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterDebugWindow</Text>
+        <Enum>9288710740312070</Enum>
+        <Comment> debug window (TRUE if ADS logger is active), BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterMailboxSize</Text>
+        <Enum>10977560600576007</Enum>
+        <Comment> router mailbox size, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_RouterMailboxUsedEntries</Text>
+        <Enum>10977560600576008</Enum>
+        <Comment> used entries in router mailbox, UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_HeapMemoryMaximum</Text>
+        <Enum>11540510554062849</Enum>
+        <Comment> maximum memory for TcOS (bytes) (only under TC/RTOS), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TC_HeapMemoryAvailable</Text>
+        <Enum>11540510554062850</Enum>
+        <Comment> available memory in TcOS (bytes) (only under TC/RTOS), ULINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_SNTPServer</Text>
+        <Enum>30399312518250497</Enum>
+        <Comment> SNTP server name or IP (empty string if no sync), STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_SNTPRefresh</Text>
+        <Enum>28991937634697218</Enum>
+        <Comment> SNTP refresh in seconds, UDINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_SecondsSince1970UTC</Text>
+        <Enum>28991937634697219</Enum>
+        <Comment> seconds since midnight January 1. 1970 as UTC, UDINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_DateAndTime</Text>
+        <Enum>30399312518250500</Enum>
+        <Comment> date and time (ISO 8601) as local time, STRING, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_OffsetLocalTimeToUTC</Text>
+        <Enum>28710462657986566</Enum>
+        <Comment> offset in seconds of local time to UTC, DINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Time_SecondsSince1970</Text>
+        <Enum>28991937634697223</Enum>
+        <Comment> seconds since midnight January 1. 1970 as local time, UDINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_Name</Text>
+        <Enum>12385029972819971</Enum>
+        <Comment> UPS name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_Model</Text>
+        <Enum>12385029972885505</Enum>
+        <Comment> UPS model, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_Vendor</Text>
+        <Enum>12385029972885506</Enum>
+        <Comment> vendor name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_Version</Text>
+        <Enum>9851755182489603</Enum>
+        <Comment> version, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_Revision</Text>
+        <Enum>9851755182489604</Enum>
+        <Comment> revision, USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_Build</Text>
+        <Enum>10414705135910917</Enum>
+        <Comment> build, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_SerialNumber</Text>
+        <Enum>12385029972885510</Enum>
+        <Comment> serial number, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_PowerStatus</Text>
+        <Enum>9851755182489607</Enum>
+        <Comment> power status (0=Unknown,1=Online,2=OnBatteries), USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_ComStatus</Text>
+        <Enum>9851755182489608</Enum>
+        <Comment> communication status (0=Unknown,1=Ok,2=Error), USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_BatteryStatus</Text>
+        <Enum>9851755182489609</Enum>
+        <Comment> battery status (0=Unknown,1=Ok,2=ChangeBattery), USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_BatteryCapacity</Text>
+        <Enum>9851755182489610</Enum>
+        <Comment> battery capacity (%), USINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_BatteryRuntime</Text>
+        <Enum>10977655089332235</Enum>
+        <Comment> battery runtime (s), UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_PersPowerFailCnt</Text>
+        <Enum>9288805229068300</Enum>
+        <Comment> persistent power fail count, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_PowerFailCnt</Text>
+        <Enum>10414705135910925</Enum>
+        <Comment> power fail counter, UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_FanError</Text>
+        <Enum>9288805229068302</Enum>
+        <Comment> fan error, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_NoBattery</Text>
+        <Enum>9288805229068303</Enum>
+        <Comment> no battery, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_TestCapacity</Text>
+        <Enum>18296004483809296</Enum>
+        <Comment> test capacity, BOOL, write-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_BatteryReplaceDate</Text>
+        <Enum>12385029972885521</Enum>
+        <Comment> battery replace date, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UPS_IntervalServiceStatus</Text>
+        <Enum>9288805229068306</Enum>
+        <Comment> interval service status, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_CurrentState</Text>
+        <Enum>9288818113970177</Enum>
+        <Comment> current protection state, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_CurrentOverlayMode</Text>
+        <Enum>10977667974234114</Enum>
+        <Comment> overlay mode of current state (0=RAM,1=Disk), UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_CurrentOverlaySize</Text>
+        <Enum>10977667974234115</Enum>
+        <Comment> overlay size of current state (MB), UDINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_NextState</Text>
+        <Enum>27303216623517697</Enum>
+        <Comment> next protection state, BOOL, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_NextOverlayMode</Text>
+        <Enum>28992066483781634</Enum>
+        <Comment> overlay mode of next state (0=RAM,1=Disk), UDINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_NextOverlaySize</Text>
+        <Enum>28992066483781635</Enum>
+        <Comment> overlay size of next state (MB), UDINT, read/write</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_NoVolumes</Text>
+        <Enum>10414718020943872</Enum>
+        <Comment> number of volumes (VolumeList length), UINT, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_VolumeList_Name</Text>
+        <Enum>156500230933774337</Enum>
+        <Comment> volume name, STRING, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_VolumeList_CurrentState</Text>
+        <Enum>153404006190022657</Enum>
+        <Comment> current protection state of volume, BOOL, read-only</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UWF_VolumeList_NextState</Text>
+        <Enum>153404006190088193</Enum>
+        <Comment> next protection state of volume, BOOL, read-only</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>USINT (USINT#1..255)</Name>
+      <BitSize>8</BitSize>
+      <BaseType>USINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>1</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>255</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_Datatype</Name>
+      <Comment> parameter datatype 1..15</Comment>
+      <BitSize>8</BitSize>
+      <BaseType>BYTE</BaseType>
+      <EnumInfo>
+        <Text>eBOOL</Text>
+        <Enum>1</Enum>
+        <Comment> size: 1 byte </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eSINT</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eUSINT</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eINT</Text>
+        <Enum>4</Enum>
+        <Comment> size: 2 bytes </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eUINT</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eDINT</Text>
+        <Enum>6</Enum>
+        <Comment> size: 4 bytes </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eUDINT</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eREAL</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eULINT</Text>
+        <Enum>9</Enum>
+        <Comment> size: 8 bytes 
+	eLINT	:= 8,</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eSTRING</Text>
+        <Enum>12</Enum>
+        <Comment>	eLREAL	:= 16#B,
+ default size: 256 bytes </Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_ParameterKey</Name>
+      <BitSize>896</BitSize>
+      <SubItem>
+        <Name>eParamKey</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ParameterKey</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>_eDatatype</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_Datatype</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_Access</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>67553994410557440</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_Datatype</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>4222124650659840</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_ModType</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>281470681743360</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_Area</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>4026531840</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_ModIdx</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <Value>267386880</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_TableId</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Default>
+          <Value>983040</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_Flags</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <Value>65280</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_SubIdx</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+        <Default>
+          <Value>255</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_IsList</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Default>
+          <Value>144115188075855872</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_IsModuleCnt</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <Value>72057594037927936</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cKeyMask_IsConstant</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Default>
+          <Value>4503599627370496</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>IsModuleCnt</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetMDPArea</Name>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetMDPTableID</Name>
+        <Comment> returns the MDP table id (part of MDP address) </Comment>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetMDPSubIndex</Name>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>__geteDatatype</Name>
+        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_Datatype</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>eDatatype</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_Datatype</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetMDPFlags</Name>
+        <ReturnType>BYTE</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsListParam</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>IsConstantParam</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>nAccess</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetMDPModuleType</Name>
+        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>SetKey</Name>
+        <Parameter>
+          <Name>eParamKey</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ParameterKey</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">FB_DynMem_Buffer</Name>
+      <Comment> provides a dynamically created buffer for individual data.</Comment>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>_pBuffer</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>_nBufferSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipMemMan</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name Static="true">nInstanceCnt</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+      </SubItem>
+      <PropertyItem>
+        <Name>bAvailable</Name>
+        <Type>BOOL</Type>
+        <Comment> is TRUE if a buffer is available.</Comment>
+        <BitSize>8</BitSize>
+        <GetCodeOffs>164007896</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nBufferSize</Name>
+        <Type>UDINT</Type>
+        <Comment> current buffer size in bytes.</Comment>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>164007800</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nBufferSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Resize</Name>
+        <Comment>| This method performs a resize of the buffer memory.
+| Return value: TRUE =&gt; Success, FALSE =&gt; Failure</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nSize</Name>
+          <Comment> new buffer size [in bytes]</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bPreserve</Name>
+          <Comment> TRUE =&gt; preserve old content, FALSE=&gt; don't preserve old content</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bReset</Name>
+          <Comment> zero the allocated memory (before preserving)</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>pNew</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>cbNew</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CreateBuffer</Name>
+        <Comment>| creates a buffer by allocating dynamic memory.
+| Returns TRUE if succeeded.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nSize</Name>
+          <Comment> buffer size [in bytes]</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bReset</Name>
+          <Comment> zero the allocated memory</Comment>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <Comment>| This method clears the buffer memory.
+| Return value: TRUE =&gt; Success, FALSE =&gt; Failure</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>PassBufferOwnership</Name>
+        <Comment> returns TRUE if succeeded
+ returns FALSE if no buffers was available.
+ returns FALSE if one of the inputs is invalid.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" ReferenceTo="true">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RetrieveBufferOwnership</Name>
+        <Comment> returns TRUE if succeeded</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" ReferenceTo="true">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Type ReferenceTo="true">UDINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getpBuffer</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>pBuffer</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getbAvailable</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>bAvailable</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>DeleteBuffer</Name>
+        <Comment>| deletes the created buffer and frees the allocated memory.
+| Returns TRUE if succeeded.</Comment>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>tc_no_symbol</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPReadTable</Name>
+      <Comment> reads a full table of MDP parameters</Comment>
+      <BitSize>2240</BitSize>
+      <ExtendsType Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPRead</ExtendsType>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_MDPAddress</Name>
+      <Comment> size of structure instance: 4 bytes</Comment>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nFlags</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nSubIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPReadSumCmd</Name>
+      <Comment> reads multiple MDP addresses with parameters of the same datatype </Comment>
+      <BitSize>3200</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Function block execution is triggered by a rising edge at this input.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pMDPAddress</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_MDPAddress</Type>
+        <ArrayInfo PointerTo="1">
+          <LBound>0</LBound>
+          <Elements>1001</Elements>
+        </ArrayInfo>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cbMDPAddress</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pDstBuf</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Contains the address of the buffer for the received data. </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nDstBufSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Contains the max. number of bytes to be received. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> States the time before the function is cancelled. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>352</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> keep empty '' for the local device </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>584</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCount</Name>
+        <Type>UDINT</Type>
+        <Comment> returns the number of bytes received </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nDataOffset</Name>
+        <Type>UDINT</Type>
+        <Comment> offset describes beginning of data in read buffer </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbCmdBuffer</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">FB_DynMem_Buffer</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCmds</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIdxOffset</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nDataLen</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1056</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nDataLenSum</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsRdWrEx</Name>
+        <Type Namespace="Tc2_System">ADSRDWRTEX</Type>
+        <BitSize>1792</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.PORT</Name>
+            <Value>10000</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.IDXGRP</Name>
+            <Value>62212</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>i</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3072</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>cSizeOfMDPAddress</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3104</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cIdxGrp</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3136</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cCmdSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3168</BitOffs>
+        <Default>
+          <Value>12</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_ReadParameterBase</Name>
+      <Comment>| reads an IPC diagnostic parameter.
+| If the parameter exists in more than one module (configuration area) all values can be read at once.
+| If the parameter is a list parameter the full list will be read. (but only of one specified module)</Comment>
+      <BitSize>15232</BitSize>
+      <Implements Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">I_IPCDiag_AccessParameter</Implements>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eParameterKey</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ParameterKey</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nModuleIdx</Name>
+        <Type>USINT</Type>
+        <Comment> optional module selection for parameters of configuration area: 0=all corresponding modules are read (or rather the first module is read in case of list parameters) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> ADS communication timeout </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> keep empty '' for the local device </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xReserved</Name>
+        <Type>DWORD</Type>
+        <Comment> for future extension, do not use </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbRegister</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag" ReferenceTo="true">FB_IPCDiag_Register</Type>
+        <Comment> read-only</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> read data available =(NOT bBusy AND NOT bError) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if an error occurred.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>656</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <Comment> '&lt; 0' = error; '&gt; 0' = info; '0' = no error/info</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipErrorMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
+        <Comment> shows detailed information about occurred errors</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nReadParameterValues</Name>
+        <Type>USINT</Type>
+        <Comment> number of read parameter values </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nModuleCount</Name>
+        <Type>USINT</Type>
+        <Comment> number of module instances (configuration area) with the demanded parameter </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbKey</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_ParameterKey</Type>
+        <BitSize>896</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nParamDatatypeSize</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1728</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nModuleIdxSelected</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1744</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nListLen</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbResultBuffer</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">FB_DynMem_Buffer</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>1792</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nValidDataOffset</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2048</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2112</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSubExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSubBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadMDP</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPRead</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>2304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>WORD</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>4544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nFlags</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nSubIndex</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nArea</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nModuleId</Name>
+        <Type>BYTE</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>4584</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eModuleType</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ModuleType</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>4592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTempDW</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>4608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTempLW</Name>
+        <Type>LWORD</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>4672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadTable</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPReadTable</Type>
+        <BitSize>2240</BitSize>
+        <BitOffs>4736</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbBufferAddresses</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">FB_DynMem_Buffer</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>6976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>old_input_assignments</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nAddresses</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>7232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadSum</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_MDPReadSumCmd</Type>
+        <BitSize>3200</BitSize>
+        <BitOffs>7296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMDPAddress</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">ST_IPCDiag_MDPAddress</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>i</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>10528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTemp</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbErrorMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
+        <BitSize>4224</BitSize>
+        <BitOffs>10624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FallingEdgeBUSY</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>14848</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEventEntryTemp</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>14976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cSizeOfMDPAddress</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>15168</BitOffs>
+        <Default>
+          <Value>4</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cStateReadSingle</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>15176</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cStateReadTable</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>15184</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cStateReadSum</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>15192</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cStateBusy</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>15200</BitOffs>
+        <Default>
+          <Value>11</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>cStateExit</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>15208</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <PropertyItem>
+        <Name>ipMemMan</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+        <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
+        <BitSize>64</BitSize>
+        <GetCodeOffs>164008048</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>GetParameterByIdx</Name>
+        <Comment> access a read parameter by index specification </Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one parameter value)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nParameterIdx</Name>
+          <Comment> selection of parameter value (1..nReadParameterValues) (e.g. equals list index in case of list parameter)</Comment>
+          <Type>USINT (1..255)</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nErrTmp</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>CopyStringFromBuffer</Name>
+        <Comment> if multiple strings are available (by Sum Read) one string can be copied with this method</Comment>
+        <Parameter>
+          <Name>pDstBuf</Name>
+          <Comment> Contains the address of the buffer for the received data. </Comment>
+          <Type PointerTo="1">BYTE</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nDstBufSize</Name>
+          <Comment> Contains the max. number of bytes to be received. </Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nParaIdx</Name>
+          <Comment> selection of module idx or list idx (in case of list parameter) </Comment>
+          <Type>USINT (1..255)</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nParaSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>nLenSum</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>nLenTemp</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>k</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
+        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipMemMan</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetParameter</Name>
+        <Comment> access a read parameter (if more than one value is available all values can be copied at once, except for STRING types)</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetParameterStrings</Name>
+        <Comment>| access a read string parameter with multiple values.
+| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nStrings</Name>
+          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nParameterIdx</Name>
+          <Type>USINT (USINT#1..255)</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>nStringSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_ReadParameter</Name>
+      <Comment>| reads an IPC diagnostic parameter.
+| If the parameter exists in more than one module (configuration area) all values can be read at once.
+| If the parameter is a list parameter the full list will be read. (but only of one specified module)</Comment>
+      <BitSize>22144</BitSize>
+      <Implements Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">I_IPCDiag_AccessParameter</Implements>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eParameterKey</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ParameterKey</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nModuleIdx</Name>
+        <Type>USINT</Type>
+        <Comment> optional module selection for parameters of configuration area: 0=all corresponding modules are read (or rather the first module is read in case of list parameters) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> ADS communication timeout </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <DateTime>5000</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sNetId</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> keep empty '' for the local device </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>xReserved</Name>
+        <Type>DWORD</Type>
+        <Comment> for future extension, do not use </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbRegister</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag" ReferenceTo="true">FB_IPCDiag_Register</Type>
+        <Comment> read-only</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> read data available =(NOT bBusy AND NOT bError) </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>648</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if an error occurred.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>656</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <Comment> '&lt; 0' = error; '&gt; 0' = info; '0' = no error/info</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ipErrorMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
+        <Comment> shows detailed information about occurred errors</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nReadParameterValues</Name>
+        <Type>USINT</Type>
+        <Comment> number of read parameter values </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nModuleCount</Name>
+        <Type>USINT</Type>
+        <Comment> number of module instances (configuration area) with the demanded parameter </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RisingEdge</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eParamSelected</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">E_IPCDiag_ParameterKey</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadParam</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_ReadParameterBase</Type>
+        <BitSize>15232</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbErrorMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
+        <BitSize>4224</BitSize>
+        <BitOffs>16256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FallingEdgeBUSY</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>20480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEventEntryTemp</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>20608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sMdpTcVersion</Name>
+        <Type>STRING(31)</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>20800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nFreeSpaceOfVol</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>21056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__NSTATE</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__NNOVOLUMES</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__SDRIVELETTER</Name>
+        <Type>STRING(7)</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>21136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__NFOUNDIDX</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__HR</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>21216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__I</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__NSTATE</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__NNOSOFTWARES</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__SSWNAME</Name>
+        <Type>STRING(79)</Type>
+        <BitSize>640</BitSize>
+        <BitOffs>21272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__NFOUNDIDX</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21912</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__HR</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>21920</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__I</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NSTATE</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>21960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NMAJOR</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>21968</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NMINOR</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>21984</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NBUILD</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>22000</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NREVISION</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>22016</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__HR</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>22048</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__FB_IPCDIAG_READPARAMETER__READTCVERSION__I</Name>
+        <Type>USINT</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>22080</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <PropertyItem>
+        <Name>ipMemMan</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+        <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
+        <BitSize>64</BitSize>
+        <GetCodeOffs>164008160</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetFreeSpaceOfVol</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getipMemMan</Name>
+        <ReturnType Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory" RpcDirection="out">I_DynMem_Manager</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>ipMemMan</Name>
+          <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetMDPVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetTCVersion</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nLen</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetParameterStrings</Name>
+        <Comment>| access a read string parameter with multiple values.
+| If more than one value is available all values can be copied to an ARRAY OF STRING at once.</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nStrings</Name>
+          <Comment> number of strings to be copied (each string with buffer size=nBufferSize/nStrings)</Comment>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ReadFreeSpaceOfVol</Name>
+        <Local>
+          <Name>nState</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__NSTATE</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nNoVolumes</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__NNOVOLUMES</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>sDriveLetter</Name>
+          <Type>STRING(7)</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__SDRIVELETTER</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nFoundIdx</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__NFOUNDIDX</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__HR</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>i</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READFREESPACEOFVOL__I</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>ReadMDPVersion</Name>
+        <Local>
+          <Name>nState</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__NSTATE</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nNoSoftwares</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__NNOSOFTWARES</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>sSWName</Name>
+          <Type>STRING(79)</Type>
+          <BitSize>640</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__SSWNAME</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nFoundIdx</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__NFOUNDIDX</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__HR</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>i</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READMDPVERSION__I</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetParameterByIdx</Name>
+        <Comment> access a read parameter by index specification </Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one parameter value)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nParameterIdx</Name>
+          <Comment> selection of parameter value (1..nReadParameterValues) (e.g. equals list index in case of list parameter)	</Comment>
+          <Type>USINT (1..255)</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>ReadTCVersion</Name>
+        <Local>
+          <Name>nState</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NSTATE</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nMajor</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NMAJOR</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nMinor</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NMINOR</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nBuild</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NBUILD</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>nRevision</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__NREVISION</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__HR</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>i</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__FB_IPCDIAG_READPARAMETER__READTCVERSION__I</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetParameter</Name>
+        <Comment> access a read parameter (if more than one value is available all values can be copied at once, except for STRING types)</Comment>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pBuffer</Name>
+          <Comment> parameter buffer with a given size of nBufferSize</Comment>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nBufferSize</Name>
+          <Comment> buffer size in bytes (for one or more values)</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</Name>
+      <BitSize>98368</BitSize>
+      <SubItem>
+        <Name>io_fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, FB will run. Reads when enable goes TRUE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPlcName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> E.g. lfe-motion</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRefresh</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE to cause an extra read.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>784</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: REFRESH
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDirectory</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Directory where the DB is stored.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>792</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLastRefreshTime</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1440</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: LAST_REFRESH
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtEnable</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtRefresh</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbTime</Name>
+        <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
+        <Comment> Time tracking liften from Arbiter PLCs</Comment>
+        <BitSize>20800</BitSize>
+        <BitOffs>1920</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.bEnable</Name>
+            <Bool>true</Bool>
+          </SubItem>
+          <SubItem>
+            <Name>.dwCycle</Name>
+            <Value>1</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbTime_to_UTC</Name>
+        <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>22720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetTimeZone</Name>
+        <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
+        <BitSize>3776</BitSize>
+        <BitOffs>26368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbIPCReg</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_Register</Type>
+        <BitSize>45376</BitSize>
+        <BitOffs>30144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbCheckOS</Name>
+        <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag">FB_IPCDiag_ReadParameter</Type>
+        <BitSize>22144</BitSize>
+        <BitOffs>75520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sOSName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>97664</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>nCheckOSTries</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>98320</BitOffs>
+        <Default>
+          <Value>3</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
+      <BitSize>92352</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSetDefault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForceUpdate</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDecel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bLocked</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUseRawCounts</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPmpsState</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDefault</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbWarning</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>86080</BitSize>
+        <BitOffs>5568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHasDefault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>91648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHasWarned</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>91656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sJson</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>91664</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>nSetValue</Name>
+        <Type>UINT</Type>
+        <Comment> For internal use only. This holds new goal positions as an integer, else it is 0 if there is no new state move request. It is written to from the user's input enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to acknowledge and clear an error.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Name>
+      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>bArbiterEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> User setting: TRUE to enable the arbiter, FALSE to disable it.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:ARB:ENABLE
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <Comment> User setting: TRUE to enable maintenance mode (Fast fault, free motion), FALSE to disable it.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:MAINT
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>nGetValue</Name>
+        <Type>UINT</Type>
+        <Comment> For internal use only. This holds the current position index as an integer, else it is 0 if we are changing states or not at any particular state.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE when we are in an active state move and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE after a move completes and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE if the most recent move had an error and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> This will be set to an NC error code during an error if one exists or left at 0 otherwise.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMsg</Name>
+        <Type>STRING(80)</Type>
+        <Comment> This will be set to an appropriate error message during an error if one exists or left as an empty string otherwise.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Name>
+      <BitSize>2496</BitSize>
+      <SubItem>
+        <Name>stTransitionDb</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The database entry for the transition state. This should always be present.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:TRANS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatesInputHandler</Name>
+      <BitSize>384</BitSize>
+      <SubItem>
+        <Name>stUserInput</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> The user's inputs from EPICS. This is an IN_OUT variable because we will write values back to this to help us detect when the same value is re-caput</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> The bBusy boolean from the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nStartingState</Name>
+        <Type>UINT</Type>
+        <Comment> The starting state number to seed nCurrGoal with</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have a move error, to prevent moves</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The goal index to input to the motion FB. This will be clamped to the range 0..GeneralConstants.MAX_STATES</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecMove</Name>
+        <Type>BOOL</Type>
+        <Comment> The bExecute boolean to input to the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetMove</Name>
+        <Type>BOOL</Type>
+        <Comment> The bReset boolean to input to the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nQueuedGoal</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCachedStart</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IDLE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>GOING</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>304</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_STOP</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Name>
+      <BitSize>570496</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All the motors to apply the standard routines to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbStateInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> The individual instantiated internal FBs. Must have the same bounds as astPositionState.</Comment>
+        <BitSize>570240</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotors</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>570432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterStates</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>570464</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Name>
+      <BitSize>10752</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Array of motors to move together</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> 1D Position states: the current position to send each axis to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start all moves on rising edge, stop all moves on falling edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset any errors</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when a move request is interrupted with a new request</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ALL of the motors are at their goal states</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ANY of this FB's moves are in progress</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ALL motors have completed the last move request from this FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ANY of this FB's moves had an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorCount</Name>
+        <Type>UINT</Type>
+        <Comment> How many FBs are erroring</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nShownError</Name>
+        <Type>DINT</Type>
+        <Comment> Which component is the source of the example/summarized error</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> One of the error ids</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The error error message matching the ID</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbPositionStateMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> 1D State movers: FBs to move the motors</Comment>
+        <BitSize>9600</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>10656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLowerBound</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nUpperBound</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10720</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>DoStateMoves</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>CombineOutputs</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateRead</Name>
+      <BitSize>4096</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to check the state of</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> The allowed states for this motor</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're standing still at a known state, or moving within the bounds of a state to another location in the bounds.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMovingState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're moving to some other state or to another non-state position.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nPositionIndex</Name>
+        <Type>UINT</Type>
+        <Comment> If we're at a known state, this will be the index in the astPositionState array that matches the state. Otherwise, this will be 0, which is below the bounds of the array, so it cannot be confused with a valid output.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentPosition</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> A copy of the details of the current position state, for convenience. This may be a moving state or an unknown state as a placeholder if we are not at a known state.</Comment>
+        <BitSize>3648</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abAtPosition</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> A full description of whether we're at each of our states. This is used in 2D, 3D, etc. to clarify cases where states may overlap in 1D.</Comment>
+        <BitSize>120</BitSize>
+        <BitOffs>3904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>4032</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateReadND</Name>
+      <BitSize>12736</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The motors with a combined N-dimensional state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're standing still at a known state.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMovingState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're moving, there can be no valid state if we are moving.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nPositionIndex</Name>
+        <Type>UINT</Type>
+        <Comment> If we're at a known state, this will be the state index along the enclosed states arrays. Otherwise, it will be zero, which is below the bounds of the states array.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the active motor count was invalid</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abAtPosition</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> A full description of whether we're at each of our states. This is used to clarify cases where states may overlap.</Comment>
+        <BitSize>120</BitSize>
+        <BitOffs>248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbPositionStateRead</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateRead</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The individual position state reader function blocks</Comment>
+        <BitSize>12288</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter2</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12688</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>DoStateReads</Name>
+      </Action>
+      <Action>
+        <Name>CombineOutputs</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Name>
+      <BitSize>609536</BitSize>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All position states for all motors, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbInput</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatesInputHandler</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Type>
+        <BitSize>570496</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Type>
+        <BitSize>10752</BitSize>
+        <BitOffs>571392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbRead</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateReadND</Type>
+        <BitSize>12736</BitSize>
+        <BitOffs>582144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMoveGoals</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>10944</BitSize>
+        <BitOffs>594880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInvalidPos</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>605824</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotor</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>609472</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Name>
+      <BitSize>205632</BitSize>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction. These will not be modified.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The database lookup key for the transition state. This has no corresponding ST_PositionState.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to use for fast faults, etc.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>840</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadNow</Name>
+        <Type>BOOL</Type>
+        <Comment> For debug: set this to TRUE in online mode to read the database immediately.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1488</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> The raw lookup results from this FB. Index 0 is the transition beam, the rest of the indices match the state positions.</Comment>
+        <BitSize>39936</BitSize>
+        <BitOffs>1504</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstReadDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we've had at least one successful read.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>41440</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be set to TRUE if there was an error reading from the database.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>41448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ffError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>41472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadPmpsDb</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>115008</BitSize>
+        <BitOffs>67392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftDbBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>182400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftRead</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>182528</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>182656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotor</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>182688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterState</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>182720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterState2</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>182752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sLoopNewKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>182784</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sLoopPrevKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>183432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>abStateError</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>128</BitSize>
+        <BitOffs>184080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>asLookupKeys</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>10368</BitSize>
+        <BitOffs>184208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>asPrevLookupKeys</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>10368</BitSize>
+        <BitOffs>194576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewKeys</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>204944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sTempBackfill</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>204952</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>SelectLookupKeys</Name>
+      </Action>
+      <Action>
+        <Name>BackfillInfo</Name>
+      </Action>
+      <Action>
+        <Name>ReadDatabase</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionBPTM</Name>
+      <BitSize>115072</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Array of motors that will move for this beam transition</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam states from</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stGoalParams</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
+        <Comment> The parameters we want to transition to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransParams</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
+        <Comment> The parameters we want to use during the transition</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE to use the BPTM, FALSE to stop using the BPTM.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're at the physical state that matches the goal parameters</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A device name to use in the GUI</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> How long to wait for parameters before timing out</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Default>
+          <DateTime>T#1s</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether to fault and move on timeout (TRUE) or to wait (FALSE)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1120</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetBPTMTimeout</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE when it is safe to reset the BPTM timeout fast fault, to reset it early.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> This becomes TRUE when the motors are allowed to move to their destinations.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> This becomes TRUE once the full beam transition is done.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're using a bad motor count</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bptm</Name>
+        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
+        <BitSize>61568</BitSize>
+        <BitOffs>1216</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDoneMoving</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>62784</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPrevID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>62816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>62848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInternalAuth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>62880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDoneResetQueued</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>62888</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonArbiter</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>62912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>63168</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBPTMTimeoutAndMove</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>63232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBPTMError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>89152</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>HandleTimeout</Name>
+      </Action>
+      <Action>
+        <Name>SetDoneMoving</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>RunBPTM</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Name>
+      <BitSize>448</BitSize>
+      <SubItem>
+        <Name>astDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> All states to deactivate: transition + the static position states</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter who made the PMPS assert requests</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Clear asserts on rising edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">E_StatePMPSStatus</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>UNKNOWN</Text>
+        <Enum>0</Enum>
+        <Comment> No other enum state describes it</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TRANSITION</Text>
+        <Enum>1</Enum>
+        <Comment> Moving toward a known state</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AT_STATE</Text>
+        <Enum>2</Enum>
+        <Comment> Within a known state, not trying to leave</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>DISABLED</Text>
+        <Enum>3</Enum>
+        <Comment> PMPS is in some way disabled, either with maint mode or arbiter disable</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Name>
+      <BitSize>27520</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor with a position state.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for this motor.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, do the limits as normal. If FALSE, allow all moves regardless of the limits defined here.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalStateIndex</Name>
+        <Type>UINT</Type>
+        <Comment> The state that the motor is moving to.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <Comment> The overal PMPS FB state</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect to the BPTM</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForwardEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBackwardEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValidGoal</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>mc_power</Name>
+        <Type Namespace="Tc2_MC2">MC_Power</Type>
+        <BitSize>960</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPrevStateIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLowerPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fUpperPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffNoGoal</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLockBounds</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>27456</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bErrorMsg</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>27464</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>SetEnables</Name>
+      </Action>
+      <Action>
+        <Name>ApplyEnables</Name>
+      </Action>
+      <Action>
+        <Name>GetBounds</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Name>
+      <BitSize>135552</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The motors with a combined N-dimensional state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether or not to do anything</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalStateIndex</Name>
+        <Type>UINT</Type>
+        <Comment> The state that the motors are moving to, along dimension 2 of the position state array. This may be the same as the current state.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to use for this state mover in the case of fast faults.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE to put motors into maintenance mode. This allows us to freely move the motors at the cost of a fast fault.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <Comment> The overal PMPS FB state</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect from bptm bTransitionAuthorized</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>984</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abForwardEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>1008</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abBackwardEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>1032</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abValidGoal</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>1056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE if the arrays have mismatched sizing. For this FB, this means the motor won't ever get an enable.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1080</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbStateEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The individual state limit function blocks</Comment>
+        <BitSize>82560</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffMaint</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>83648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffProgrammerError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>109568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>135488</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>DoLimits</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Name>
+      <BitSize>106944</BitSize>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam states from</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to link to these fast faults</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentBeamReq</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> Current requested beam details: either a known state or the transition beam</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>864</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're at a known state (doesn't matter which)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTransitionID</Name>
+        <Type>DWORD</Type>
+        <Comment> Lookup ID of the transition beam</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2656</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMaxTrips</Name>
+        <Type>UINT</Type>
+        <Comment> Number of consecutive trips before we debounce</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2688</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tTripReset</Name>
+        <Type>TIME</Type>
+        <Comment> Decrease trip count by 1 after this much time has passed</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2720</BitOffs>
+        <Default>
+          <DateTime>T#1s</DateTime>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ffBeamParamsOk</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> If the beam parameters are wrong, it is a fault! This encompasses all unknown arbiter-related errors.</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>2752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffZeroRate</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> If we asked for zero rate (NC or SC) then we can cut the beam early. This is somewhat redundant.</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>28672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffUnknown</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Trip the beam for unknown state</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>54592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffDebounce</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Trip the beam (no autoreset) if ffBeamParamsOK faults/resets multiple times too quickly.</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>80512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTripCount</Name>
+        <Type>UINT</Type>
+        <Comment> Number of consecutive trips so far</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>106432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftTripCount</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <Comment> Increase by 1 whenever there is a fault (rising edge)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>106496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonTripCount</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Decrease trip count by 1 each timeout</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>106624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCycle</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE on only the first cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>106880</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Name>
+      <BitSize>114048</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors associated with the state mover.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Identifying name to use in group fast faults</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE if the arrays don't have the same bounds. In this FB, that's an automatic fault.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbEncError</Name>
+        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>87168</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffProgrammerError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>88064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>113984</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>HandleLoops</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Name>
+      <BitSize>682240</BitSize>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All position states for all motors, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>584</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1920</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>1952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionReadPMPSDB</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Type>
+        <BitSize>205632</BitSize>
+        <BitOffs>4480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionBPTM</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionBPTM</Type>
+        <BitSize>115072</BitSize>
+        <BitOffs>210112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionClearAsserts</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>325184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStatePMPSEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Type>
+        <BitSize>135552</BitSize>
+        <BitOffs>325632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMiscStatesErrorFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Type>
+        <BitSize>106944</BitSize>
+        <BitOffs>461184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPerMotorFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Type>
+        <BitSize>114048</BitSize>
+        <BitOffs>568128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>682176</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
+      <BitSize>1541312</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to move.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1824</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>5120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
+        <BitSize>609536</BitSize>
+        <BitOffs>7616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPMPSCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
+        <BitSize>682240</BitSize>
+        <BitOffs>617152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>77760</BitSize>
+        <BitOffs>1299392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>164160</BitSize>
+        <BitOffs>1377152</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{5356792D-144F-4F3E-8B04-D35060997D7C}" TcSmClass="TComPlcObjDef" TargetPlatform="TwinCAT RT (x64)">
@@ -75837,7 +81897,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -75853,14 +81913,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299015744</BitOffs>
+            <BitOffs>1295628736</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -75874,14 +81934,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299015936</BitOffs>
+            <BitOffs>1295628928</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -75898,7 +81958,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296963200</BitOffs>
+            <BitOffs>1293576192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -75909,7 +81969,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296965712</BitOffs>
+            <BitOffs>1293578704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -75923,7 +81983,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307522880</BitOffs>
+            <BitOffs>1304135872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -75937,7 +81997,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530048</BitOffs>
+            <BitOffs>1304143040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -75951,7 +82011,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530080</BitOffs>
+            <BitOffs>1304143072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -75972,14 +82032,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530368</BitOffs>
+            <BitOffs>1304143360</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -75990,14 +82050,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300497024</BitOffs>
+            <BitOffs>1297110016</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -76099,7 +82159,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300495936</BitOffs>
+            <BitOffs>1297108928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -76113,7 +82173,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530112</BitOffs>
+            <BitOffs>1304143104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -76127,7 +82187,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530144</BitOffs>
+            <BitOffs>1304143136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -76148,20 +82208,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307531264</BitOffs>
+            <BitOffs>1304144256</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265714880</BitOffs>
+            <BitOffs>1264934016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -76196,7 +82256,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971456</BitOffs>
+            <BitOffs>1293584448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -76210,7 +82270,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530176</BitOffs>
+            <BitOffs>1304143168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -76224,7 +82284,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530208</BitOffs>
+            <BitOffs>1304143200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -76245,14 +82305,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307532160</BitOffs>
+            <BitOffs>1304145152</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -76268,7 +82328,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934720</BitOffs>
+            <BitOffs>1265050816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -76284,7 +82344,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934784</BitOffs>
+            <BitOffs>1265050880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -76300,14 +82360,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1264934848</BitOffs>
+            <BitOffs>1265050944</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -76432,7 +82492,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1264934912</BitOffs>
+            <BitOffs>1265051008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bSendToTest</Name>
@@ -76441,7 +82501,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1264934920</BitOffs>
+            <BitOffs>1265051016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.sTestHost</Name>
@@ -76451,7 +82511,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1264934928</BitOffs>
+            <BitOffs>1265051024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -76460,7 +82520,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1264935576</BitOffs>
+            <BitOffs>1265051672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -76469,14 +82529,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1264935584</BitOffs>
+            <BitOffs>1265051680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1264935592</BitOffs>
+            <BitOffs>1265051688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -76491,7 +82551,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1264935600</BitOffs>
+            <BitOffs>1265051696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -76500,20 +82560,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1264935616</BitOffs>
+            <BitOffs>1265051712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264935680</BitOffs>
+            <BitOffs>1265051776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264935744</BitOffs>
+            <BitOffs>1265051840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -76522,19 +82582,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1264935808</BitOffs>
+            <BitOffs>1265051904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264935872</BitOffs>
+            <BitOffs>1265051968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264935936</BitOffs>
+            <BitOffs>1265052032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -76549,25 +82609,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1264936000</BitOffs>
+            <BitOffs>1265052096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1264936064</BitOffs>
+            <BitOffs>1265052160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264936320</BitOffs>
+            <BitOffs>1265052416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264936384</BitOffs>
+            <BitOffs>1265052480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -76576,79 +82636,79 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1264936448</BitOffs>
+            <BitOffs>1265052544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264936512</BitOffs>
+            <BitOffs>1265052608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264936576</BitOffs>
+            <BitOffs>1265052672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1264936640</BitOffs>
+            <BitOffs>1265052736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1264937664</BitOffs>
+            <BitOffs>1265053760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264937728</BitOffs>
+            <BitOffs>1265053824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264937792</BitOffs>
+            <BitOffs>1265053888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1264937856</BitOffs>
+            <BitOffs>1265053952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1264937920</BitOffs>
+            <BitOffs>1265054016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265048512</BitOffs>
+            <BitOffs>1265164608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265323712</BitOffs>
+            <BitOffs>1265439808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265434304</BitOffs>
+            <BitOffs>1265550400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265709504</BitOffs>
+            <BitOffs>1265825600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -76660,7 +82720,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265710016</BitOffs>
+            <BitOffs>1265826112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -76672,14 +82732,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265710592</BitOffs>
+            <BitOffs>1265826688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265711424</BitOffs>
+            <BitOffs>1265827520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -76695,7 +82755,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711712</BitOffs>
+            <BitOffs>1265827808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -76710,7 +82770,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711744</BitOffs>
+            <BitOffs>1265827840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -76728,7 +82788,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307524928</BitOffs>
+            <BitOffs>1304137920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -76742,7 +82802,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530240</BitOffs>
+            <BitOffs>1304143232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -76756,7 +82816,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530272</BitOffs>
+            <BitOffs>1304143264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -76777,14 +82837,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307533056</BitOffs>
+            <BitOffs>1304146048</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -77137,7 +83197,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281598272</BitOffs>
+            <BitOffs>1281587712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
@@ -77149,7 +83209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281598280</BitOffs>
+            <BitOffs>1281587720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
@@ -77162,7 +83222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281598336</BitOffs>
+            <BitOffs>1281587776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
@@ -77174,7 +83234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281598464</BitOffs>
+            <BitOffs>1281587904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
@@ -77186,7 +83246,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281598592</BitOffs>
+            <BitOffs>1281588032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
@@ -77198,7 +83258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281598720</BitOffs>
+            <BitOffs>1281588160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -77211,7 +83271,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281599488</BitOffs>
+            <BitOffs>1281588928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -77224,7 +83284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281599616</BitOffs>
+            <BitOffs>1281589056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -77237,7 +83297,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281610240</BitOffs>
+            <BitOffs>1281599680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -77250,7 +83310,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281610368</BitOffs>
+            <BitOffs>1281599808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77262,19 +83322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282849088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283184128</BitOffs>
+            <BitOffs>1282838528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
@@ -77291,7 +83339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283509296</BitOffs>
+            <BitOffs>1283170896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
@@ -77307,7 +83355,19 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283509304</BitOffs>
+            <BitOffs>1283170904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283173568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
@@ -77320,7 +83380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283514496</BitOffs>
+            <BitOffs>1283503936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2.iRaw</Name>
@@ -77333,7 +83393,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283515072</BitOffs>
+            <BitOffs>1283504512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
@@ -77346,346 +83406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283515648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284816448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
-            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
-            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
-            <Comment> NO Home Switch: TRUE if at home</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
-            <Comment> NC STO Input: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
-            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
-            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
-            <Comment> Raw encoder IO for INT (LVDT)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284842368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
-            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
-            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
-            <Comment> NO Home Switch: TRUE if at home</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
-            <Comment> NC STO Input: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
-            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
-            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
-            <Comment> Raw encoder IO for INT (LVDT)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284868288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
-            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
-            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876232</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
-            <Comment> NO Home Switch: TRUE if at home</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
-            <Comment> NC STO Input: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
-            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
-            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
-            <Comment> Raw encoder IO for INT (LVDT)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876368</BitOffs>
+            <BitOffs>1283505088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77697,7 +83418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285207296</BitOffs>
+            <BitOffs>1283508544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77709,7 +83430,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285534720</BitOffs>
+            <BitOffs>1283835968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77721,7 +83442,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285862144</BitOffs>
+            <BitOffs>1284163392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77733,7 +83454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286189568</BitOffs>
+            <BitOffs>1284490816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77745,7 +83466,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286516992</BitOffs>
+            <BitOffs>1284818240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77757,7 +83478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286844416</BitOffs>
+            <BitOffs>1285145664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upe</Name>
@@ -77779,7 +83500,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169216</BitOffs>
+            <BitOffs>1285470464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upe</Name>
@@ -77801,7 +83522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169344</BitOffs>
+            <BitOffs>1285470592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bError</Name>
@@ -77825,7 +83546,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169800</BitOffs>
+            <BitOffs>1285471048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bUnderrange</Name>
@@ -77837,7 +83558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169808</BitOffs>
+            <BitOffs>1285471056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bOverrange</Name>
@@ -77849,7 +83570,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169816</BitOffs>
+            <BitOffs>1285471064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.iRaw</Name>
@@ -77861,7 +83582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169824</BitOffs>
+            <BitOffs>1285471072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bError</Name>
@@ -77885,7 +83606,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170056</BitOffs>
+            <BitOffs>1285471304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bUnderrange</Name>
@@ -77897,7 +83618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170064</BitOffs>
+            <BitOffs>1285471312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bOverrange</Name>
@@ -77909,7 +83630,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170072</BitOffs>
+            <BitOffs>1285471320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.iRaw</Name>
@@ -77921,7 +83642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170080</BitOffs>
+            <BitOffs>1285471328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bError</Name>
@@ -77945,7 +83666,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170312</BitOffs>
+            <BitOffs>1285471560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bUnderrange</Name>
@@ -77957,7 +83678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170320</BitOffs>
+            <BitOffs>1285471568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bOverrange</Name>
@@ -77969,7 +83690,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170328</BitOffs>
+            <BitOffs>1285471576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.iRaw</Name>
@@ -77981,7 +83702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170336</BitOffs>
+            <BitOffs>1285471584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bError</Name>
@@ -78005,7 +83726,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170568</BitOffs>
+            <BitOffs>1285471816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bUnderrange</Name>
@@ -78017,7 +83738,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170576</BitOffs>
+            <BitOffs>1285471824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bOverrange</Name>
@@ -78029,7 +83750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170584</BitOffs>
+            <BitOffs>1285471832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.iRaw</Name>
@@ -78041,7 +83762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170592</BitOffs>
+            <BitOffs>1285471840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bError</Name>
@@ -78065,7 +83786,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170824</BitOffs>
+            <BitOffs>1285472072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bUnderrange</Name>
@@ -78077,7 +83798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170832</BitOffs>
+            <BitOffs>1285472080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bOverrange</Name>
@@ -78089,7 +83810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170840</BitOffs>
+            <BitOffs>1285472088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.iRaw</Name>
@@ -78101,7 +83822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170848</BitOffs>
+            <BitOffs>1285472096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bError</Name>
@@ -78125,7 +83846,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171080</BitOffs>
+            <BitOffs>1285472328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bUnderrange</Name>
@@ -78137,7 +83858,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171088</BitOffs>
+            <BitOffs>1285472336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bOverrange</Name>
@@ -78149,7 +83870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171096</BitOffs>
+            <BitOffs>1285472344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.iRaw</Name>
@@ -78161,7 +83882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171104</BitOffs>
+            <BitOffs>1285472352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bError</Name>
@@ -78185,7 +83906,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171336</BitOffs>
+            <BitOffs>1285472584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bUnderrange</Name>
@@ -78197,7 +83918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171344</BitOffs>
+            <BitOffs>1285472592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bOverrange</Name>
@@ -78209,7 +83930,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171352</BitOffs>
+            <BitOffs>1285472600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.iRaw</Name>
@@ -78221,7 +83942,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171360</BitOffs>
+            <BitOffs>1285472608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bError</Name>
@@ -78245,7 +83966,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171592</BitOffs>
+            <BitOffs>1285472840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bUnderrange</Name>
@@ -78257,7 +83978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171600</BitOffs>
+            <BitOffs>1285472848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bOverrange</Name>
@@ -78269,7 +83990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171608</BitOffs>
+            <BitOffs>1285472856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.iRaw</Name>
@@ -78281,7 +84002,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171616</BitOffs>
+            <BitOffs>1285472864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bError</Name>
@@ -78305,7 +84026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171848</BitOffs>
+            <BitOffs>1285473096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bUnderrange</Name>
@@ -78317,7 +84038,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171856</BitOffs>
+            <BitOffs>1285473104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bOverrange</Name>
@@ -78329,7 +84050,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171864</BitOffs>
+            <BitOffs>1285473112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.iRaw</Name>
@@ -78341,7 +84062,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171872</BitOffs>
+            <BitOffs>1285473120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bError</Name>
@@ -78365,7 +84086,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172104</BitOffs>
+            <BitOffs>1285473352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bUnderrange</Name>
@@ -78377,7 +84098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172112</BitOffs>
+            <BitOffs>1285473360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bOverrange</Name>
@@ -78389,7 +84110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172120</BitOffs>
+            <BitOffs>1285473368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.iRaw</Name>
@@ -78401,7 +84122,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172128</BitOffs>
+            <BitOffs>1285473376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bError</Name>
@@ -78425,7 +84146,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172360</BitOffs>
+            <BitOffs>1285473608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bUnderrange</Name>
@@ -78437,7 +84158,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172368</BitOffs>
+            <BitOffs>1285473616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bOverrange</Name>
@@ -78449,7 +84170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172376</BitOffs>
+            <BitOffs>1285473624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.iRaw</Name>
@@ -78461,7 +84182,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172384</BitOffs>
+            <BitOffs>1285473632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bError</Name>
@@ -78485,7 +84206,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172616</BitOffs>
+            <BitOffs>1285473864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bUnderrange</Name>
@@ -78497,7 +84218,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172624</BitOffs>
+            <BitOffs>1285473872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bOverrange</Name>
@@ -78509,7 +84230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172632</BitOffs>
+            <BitOffs>1285473880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.iRaw</Name>
@@ -78521,7 +84242,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172640</BitOffs>
+            <BitOffs>1285473888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw</Name>
@@ -78534,7 +84255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287198912</BitOffs>
+            <BitOffs>1285500096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2.iRaw</Name>
@@ -78547,7 +84268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287199488</BitOffs>
+            <BitOffs>1285500672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
@@ -78560,346 +84281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287200064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288504512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
-            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
-            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
-            <Comment> NO Home Switch: TRUE if at home</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
-            <Comment> NC STO Input: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
-            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
-            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
-            <Comment> Raw encoder IO for INT (LVDT)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288530432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
-            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
-            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
-            <Comment> NO Home Switch: TRUE if at home</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
-            <Comment> NC STO Input: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
-            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
-            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
-            <Comment> Raw encoder IO for INT (LVDT)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288556352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
-            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
-            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
-            <Comment> NO Home Switch: TRUE if at home</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
-            <Comment> NC STO Input: TRUE if ok to move</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHardwareEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if STO not hit
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
-            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
-            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
-            <Comment> Raw encoder IO for INT (LVDT)</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288564432</BitOffs>
+            <BitOffs>1285501248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78911,7 +84293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288925120</BitOffs>
+            <BitOffs>1285538112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78923,7 +84305,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289252544</BitOffs>
+            <BitOffs>1285865536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78935,7 +84317,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289579968</BitOffs>
+            <BitOffs>1286192960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78947,7 +84329,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289907392</BitOffs>
+            <BitOffs>1286520384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78959,7 +84341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290234816</BitOffs>
+            <BitOffs>1286847808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bError</Name>
@@ -78983,7 +84365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254536</BitOffs>
+            <BitOffs>1287867528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bUnderrange</Name>
@@ -78995,7 +84377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254544</BitOffs>
+            <BitOffs>1287867536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bOverrange</Name>
@@ -79007,7 +84389,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254552</BitOffs>
+            <BitOffs>1287867544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.iRaw</Name>
@@ -79019,7 +84401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254560</BitOffs>
+            <BitOffs>1287867552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bError</Name>
@@ -79043,7 +84425,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254792</BitOffs>
+            <BitOffs>1287867784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bUnderrange</Name>
@@ -79055,7 +84437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254800</BitOffs>
+            <BitOffs>1287867792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bOverrange</Name>
@@ -79067,7 +84449,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254808</BitOffs>
+            <BitOffs>1287867800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.iRaw</Name>
@@ -79079,7 +84461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254816</BitOffs>
+            <BitOffs>1287867808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bError</Name>
@@ -79103,7 +84485,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255048</BitOffs>
+            <BitOffs>1287868040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bUnderrange</Name>
@@ -79115,7 +84497,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255056</BitOffs>
+            <BitOffs>1287868048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bOverrange</Name>
@@ -79127,7 +84509,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255064</BitOffs>
+            <BitOffs>1287868056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.iRaw</Name>
@@ -79139,7 +84521,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255072</BitOffs>
+            <BitOffs>1287868064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bError</Name>
@@ -79163,7 +84545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255304</BitOffs>
+            <BitOffs>1287868296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bUnderrange</Name>
@@ -79175,7 +84557,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255312</BitOffs>
+            <BitOffs>1287868304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bOverrange</Name>
@@ -79187,7 +84569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255320</BitOffs>
+            <BitOffs>1287868312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.iRaw</Name>
@@ -79199,7 +84581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255328</BitOffs>
+            <BitOffs>1287868320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbGetIllPercent.iRaw</Name>
@@ -79212,7 +84594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255680</BitOffs>
+            <BitOffs>1287868672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter.iRaw</Name>
@@ -79225,7 +84607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291256832</BitOffs>
+            <BitOffs>1287869824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79237,7 +84619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291260224</BitOffs>
+            <BitOffs>1287873216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -79253,7 +84635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291587200</BitOffs>
+            <BitOffs>1288200192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -79274,7 +84656,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291590720</BitOffs>
+            <BitOffs>1288203712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -79295,7 +84677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291590721</BitOffs>
+            <BitOffs>1288203713</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable1</Name>
@@ -79312,7 +84694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291889264</BitOffs>
+            <BitOffs>1288502256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2</Name>
@@ -79328,7 +84710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291889272</BitOffs>
+            <BitOffs>1288502264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -79341,7 +84723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293081088</BitOffs>
+            <BitOffs>1289694080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -79354,7 +84736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293081600</BitOffs>
+            <BitOffs>1289694592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
@@ -79367,7 +84749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293082176</BitOffs>
+            <BitOffs>1289695168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
@@ -79380,7 +84762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021376</BitOffs>
+            <BitOffs>1291634368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
@@ -79392,7 +84774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021384</BitOffs>
+            <BitOffs>1291634376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
@@ -79404,7 +84786,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021392</BitOffs>
+            <BitOffs>1291634384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
@@ -79416,7 +84798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021400</BitOffs>
+            <BitOffs>1291634392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
@@ -79428,7 +84810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021408</BitOffs>
+            <BitOffs>1291634400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -79440,7 +84822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021416</BitOffs>
+            <BitOffs>1291634408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -79457,7 +84839,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021424</BitOffs>
+            <BitOffs>1291634416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -79473,7 +84855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021432</BitOffs>
+            <BitOffs>1291634424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -79486,7 +84868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295021696</BitOffs>
+            <BitOffs>1291634688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -79499,7 +84881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295022208</BitOffs>
+            <BitOffs>1291635200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -79523,7 +84905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961608</BitOffs>
+            <BitOffs>1293574600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -79535,7 +84917,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961616</BitOffs>
+            <BitOffs>1293574608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -79547,7 +84929,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961624</BitOffs>
+            <BitOffs>1293574616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -79559,7 +84941,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961632</BitOffs>
+            <BitOffs>1293574624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -79583,7 +84965,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961864</BitOffs>
+            <BitOffs>1293574856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -79595,7 +84977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961872</BitOffs>
+            <BitOffs>1293574864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -79607,7 +84989,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961880</BitOffs>
+            <BitOffs>1293574872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -79619,7 +85001,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961888</BitOffs>
+            <BitOffs>1293574880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -79632,7 +85014,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961920</BitOffs>
+            <BitOffs>1293574912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -79644,7 +85026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961928</BitOffs>
+            <BitOffs>1293574920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -79656,7 +85038,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961936</BitOffs>
+            <BitOffs>1293574928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -79668,7 +85050,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961944</BitOffs>
+            <BitOffs>1293574936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -79680,7 +85062,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961952</BitOffs>
+            <BitOffs>1293574944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -79692,7 +85074,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961960</BitOffs>
+            <BitOffs>1293574952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -79709,7 +85091,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961968</BitOffs>
+            <BitOffs>1293574960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -79725,7 +85107,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296961976</BitOffs>
+            <BitOffs>1293574968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -79738,7 +85120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296962240</BitOffs>
+            <BitOffs>1293575232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -79751,7 +85133,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296962752</BitOffs>
+            <BitOffs>1293575744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -79771,7 +85153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296968224</BitOffs>
+            <BitOffs>1293581216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -79790,7 +85172,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296968240</BitOffs>
+            <BitOffs>1293581232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
@@ -79803,7 +85185,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296970688</BitOffs>
+            <BitOffs>1293583680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -79822,7 +85204,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971136</BitOffs>
+            <BitOffs>1293584128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -79842,7 +85224,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971152</BitOffs>
+            <BitOffs>1293584144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -79861,7 +85243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971168</BitOffs>
+            <BitOffs>1293584160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -79880,7 +85262,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971184</BitOffs>
+            <BitOffs>1293584176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
@@ -79893,7 +85275,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296973888</BitOffs>
+            <BitOffs>1293586880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -79913,7 +85295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974464</BitOffs>
+            <BitOffs>1293587456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -79932,7 +85314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974480</BitOffs>
+            <BitOffs>1293587472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -79951,7 +85333,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974496</BitOffs>
+            <BitOffs>1293587488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -79971,7 +85353,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974512</BitOffs>
+            <BitOffs>1293587504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -79990,7 +85372,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974528</BitOffs>
+            <BitOffs>1293587520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -80009,7 +85391,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974544</BitOffs>
+            <BitOffs>1293587536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -80029,7 +85411,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974560</BitOffs>
+            <BitOffs>1293587552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -80048,7 +85430,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974576</BitOffs>
+            <BitOffs>1293587568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -80067,7 +85449,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975168</BitOffs>
+            <BitOffs>1293588160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -80087,7 +85469,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975184</BitOffs>
+            <BitOffs>1293588176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -80106,7 +85488,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975200</BitOffs>
+            <BitOffs>1293588192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -80125,7 +85507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975216</BitOffs>
+            <BitOffs>1293588208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -80137,7 +85519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299031808</BitOffs>
+            <BitOffs>1295644800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -80150,7 +85532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039744</BitOffs>
+            <BitOffs>1295652736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -80163,7 +85545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039752</BitOffs>
+            <BitOffs>1295652744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -80176,7 +85558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039760</BitOffs>
+            <BitOffs>1295652752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -80199,7 +85581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039776</BitOffs>
+            <BitOffs>1295652768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -80212,7 +85594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039808</BitOffs>
+            <BitOffs>1295652800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -80225,7 +85607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039872</BitOffs>
+            <BitOffs>1295652864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -80238,7 +85620,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039888</BitOffs>
+            <BitOffs>1295652880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80250,7 +85632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299059264</BitOffs>
+            <BitOffs>1295672256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -80262,7 +85644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299385152</BitOffs>
+            <BitOffs>1295998144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -80275,7 +85657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393088</BitOffs>
+            <BitOffs>1296006080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -80288,7 +85670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393096</BitOffs>
+            <BitOffs>1296006088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -80301,7 +85683,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393104</BitOffs>
+            <BitOffs>1296006096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -80324,7 +85706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393120</BitOffs>
+            <BitOffs>1296006112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -80337,7 +85719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393152</BitOffs>
+            <BitOffs>1296006144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -80350,7 +85732,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393216</BitOffs>
+            <BitOffs>1296006208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -80363,7 +85745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393232</BitOffs>
+            <BitOffs>1296006224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80375,7 +85757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299412608</BitOffs>
+            <BitOffs>1296025600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -80387,7 +85769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299738496</BitOffs>
+            <BitOffs>1296351488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -80400,7 +85782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746432</BitOffs>
+            <BitOffs>1296359424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -80413,7 +85795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746440</BitOffs>
+            <BitOffs>1296359432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -80426,7 +85808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746448</BitOffs>
+            <BitOffs>1296359440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -80449,7 +85831,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746464</BitOffs>
+            <BitOffs>1296359456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -80462,7 +85844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746496</BitOffs>
+            <BitOffs>1296359488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -80475,7 +85857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746560</BitOffs>
+            <BitOffs>1296359552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -80488,7 +85870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746576</BitOffs>
+            <BitOffs>1296359568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80500,7 +85882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299765952</BitOffs>
+            <BitOffs>1296378944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -80512,7 +85894,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300091840</BitOffs>
+            <BitOffs>1296704832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -80525,7 +85907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099776</BitOffs>
+            <BitOffs>1296712768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -80538,7 +85920,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099784</BitOffs>
+            <BitOffs>1296712776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -80551,7 +85933,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099792</BitOffs>
+            <BitOffs>1296712784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -80574,7 +85956,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099808</BitOffs>
+            <BitOffs>1296712800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -80587,7 +85969,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099840</BitOffs>
+            <BitOffs>1296712832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -80600,7 +85982,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099904</BitOffs>
+            <BitOffs>1296712896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -80613,7 +85995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099920</BitOffs>
+            <BitOffs>1296712912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80625,7 +86007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300119296</BitOffs>
+            <BitOffs>1296732288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -80637,7 +86019,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300445184</BitOffs>
+            <BitOffs>1297058176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -80650,7 +86032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453120</BitOffs>
+            <BitOffs>1297066112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -80663,7 +86045,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453128</BitOffs>
+            <BitOffs>1297066120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -80676,7 +86058,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453136</BitOffs>
+            <BitOffs>1297066128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -80699,7 +86081,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453152</BitOffs>
+            <BitOffs>1297066144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -80712,7 +86094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453184</BitOffs>
+            <BitOffs>1297066176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -80725,7 +86107,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453248</BitOffs>
+            <BitOffs>1297066240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -80738,7 +86120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453264</BitOffs>
+            <BitOffs>1297066256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -80750,7 +86132,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300471104</BitOffs>
+            <BitOffs>1297084096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -80763,7 +86145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479040</BitOffs>
+            <BitOffs>1297092032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -80776,7 +86158,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479048</BitOffs>
+            <BitOffs>1297092040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -80789,7 +86171,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479056</BitOffs>
+            <BitOffs>1297092048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -80812,7 +86194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479072</BitOffs>
+            <BitOffs>1297092064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -80825,7 +86207,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479104</BitOffs>
+            <BitOffs>1297092096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -80838,7 +86220,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479168</BitOffs>
+            <BitOffs>1297092160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -80851,7 +86233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479184</BitOffs>
+            <BitOffs>1297092176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -80864,7 +86246,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300504960</BitOffs>
+            <BitOffs>1297117952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -80877,7 +86259,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300504968</BitOffs>
+            <BitOffs>1297117960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -80890,7 +86272,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300504976</BitOffs>
+            <BitOffs>1297117968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -80913,7 +86295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300504992</BitOffs>
+            <BitOffs>1297117984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -80926,7 +86308,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300505024</BitOffs>
+            <BitOffs>1297118016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -80939,7 +86321,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300505088</BitOffs>
+            <BitOffs>1297118080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -80952,7 +86334,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300505104</BitOffs>
+            <BitOffs>1297118096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -80964,7 +86346,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300522944</BitOffs>
+            <BitOffs>1297135936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -80977,7 +86359,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300530880</BitOffs>
+            <BitOffs>1297143872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -80990,7 +86372,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300530888</BitOffs>
+            <BitOffs>1297143880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -81003,7 +86385,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300530896</BitOffs>
+            <BitOffs>1297143888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -81026,7 +86408,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300530912</BitOffs>
+            <BitOffs>1297143904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -81039,7 +86421,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300530944</BitOffs>
+            <BitOffs>1297143936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -81052,7 +86434,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300531008</BitOffs>
+            <BitOffs>1297144000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -81065,7 +86447,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300531024</BitOffs>
+            <BitOffs>1297144016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -81077,7 +86459,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300548864</BitOffs>
+            <BitOffs>1297161856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -81090,7 +86472,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556800</BitOffs>
+            <BitOffs>1297169792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -81103,7 +86485,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556808</BitOffs>
+            <BitOffs>1297169800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -81116,7 +86498,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556816</BitOffs>
+            <BitOffs>1297169808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -81139,7 +86521,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556832</BitOffs>
+            <BitOffs>1297169824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -81152,7 +86534,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556864</BitOffs>
+            <BitOffs>1297169856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -81165,7 +86547,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556928</BitOffs>
+            <BitOffs>1297169920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -81178,7 +86560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556944</BitOffs>
+            <BitOffs>1297169936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -81190,7 +86572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300574784</BitOffs>
+            <BitOffs>1297187776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -81203,7 +86585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582720</BitOffs>
+            <BitOffs>1297195712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -81216,7 +86598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582728</BitOffs>
+            <BitOffs>1297195720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -81229,7 +86611,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582736</BitOffs>
+            <BitOffs>1297195728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -81252,7 +86634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582752</BitOffs>
+            <BitOffs>1297195744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -81265,7 +86647,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582784</BitOffs>
+            <BitOffs>1297195776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -81278,7 +86660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582848</BitOffs>
+            <BitOffs>1297195840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -81291,7 +86673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582864</BitOffs>
+            <BitOffs>1297195856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -81303,7 +86685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300600704</BitOffs>
+            <BitOffs>1297213696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -81316,7 +86698,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608640</BitOffs>
+            <BitOffs>1297221632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -81329,7 +86711,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608648</BitOffs>
+            <BitOffs>1297221640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -81342,7 +86724,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608656</BitOffs>
+            <BitOffs>1297221648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -81365,7 +86747,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608672</BitOffs>
+            <BitOffs>1297221664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -81378,7 +86760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608704</BitOffs>
+            <BitOffs>1297221696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -81391,7 +86773,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608768</BitOffs>
+            <BitOffs>1297221760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -81404,7 +86786,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608784</BitOffs>
+            <BitOffs>1297221776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -81416,7 +86798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300626624</BitOffs>
+            <BitOffs>1297239616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -81429,7 +86811,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634560</BitOffs>
+            <BitOffs>1297247552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -81442,7 +86824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634568</BitOffs>
+            <BitOffs>1297247560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -81455,7 +86837,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634576</BitOffs>
+            <BitOffs>1297247568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -81478,7 +86860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634592</BitOffs>
+            <BitOffs>1297247584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -81491,7 +86873,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634624</BitOffs>
+            <BitOffs>1297247616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -81504,7 +86886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634688</BitOffs>
+            <BitOffs>1297247680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -81517,7 +86899,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634704</BitOffs>
+            <BitOffs>1297247696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81529,7 +86911,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300654080</BitOffs>
+            <BitOffs>1297267072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -81541,7 +86923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300979968</BitOffs>
+            <BitOffs>1297592960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -81554,7 +86936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300987904</BitOffs>
+            <BitOffs>1297600896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -81567,7 +86949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300987912</BitOffs>
+            <BitOffs>1297600904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -81580,7 +86962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300987920</BitOffs>
+            <BitOffs>1297600912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -81603,7 +86985,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300987936</BitOffs>
+            <BitOffs>1297600928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -81616,7 +86998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300987968</BitOffs>
+            <BitOffs>1297600960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -81629,7 +87011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300988032</BitOffs>
+            <BitOffs>1297601024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -81642,7 +87024,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300988048</BitOffs>
+            <BitOffs>1297601040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81654,7 +87036,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301007424</BitOffs>
+            <BitOffs>1297620416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -81666,7 +87048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301333312</BitOffs>
+            <BitOffs>1297946304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -81679,7 +87061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341248</BitOffs>
+            <BitOffs>1297954240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -81692,7 +87074,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341256</BitOffs>
+            <BitOffs>1297954248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -81705,7 +87087,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341264</BitOffs>
+            <BitOffs>1297954256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -81728,7 +87110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341280</BitOffs>
+            <BitOffs>1297954272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -81741,7 +87123,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341312</BitOffs>
+            <BitOffs>1297954304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -81754,7 +87136,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341376</BitOffs>
+            <BitOffs>1297954368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -81767,7 +87149,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341392</BitOffs>
+            <BitOffs>1297954384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81779,7 +87161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301360768</BitOffs>
+            <BitOffs>1297973760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -81791,7 +87173,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301686656</BitOffs>
+            <BitOffs>1298299648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -81804,7 +87186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694592</BitOffs>
+            <BitOffs>1298307584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -81817,7 +87199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694600</BitOffs>
+            <BitOffs>1298307592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -81830,7 +87212,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694608</BitOffs>
+            <BitOffs>1298307600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -81853,7 +87235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694624</BitOffs>
+            <BitOffs>1298307616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -81866,7 +87248,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694656</BitOffs>
+            <BitOffs>1298307648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -81879,7 +87261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694720</BitOffs>
+            <BitOffs>1298307712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -81892,7 +87274,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694736</BitOffs>
+            <BitOffs>1298307728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -81904,7 +87286,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301714112</BitOffs>
+            <BitOffs>1298327104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -81916,7 +87298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302040000</BitOffs>
+            <BitOffs>1298652992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -81929,7 +87311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302047936</BitOffs>
+            <BitOffs>1298660928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -81942,7 +87324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302047944</BitOffs>
+            <BitOffs>1298660936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -81955,7 +87337,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302047952</BitOffs>
+            <BitOffs>1298660944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -81978,7 +87360,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302047968</BitOffs>
+            <BitOffs>1298660960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -81991,7 +87373,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302048000</BitOffs>
+            <BitOffs>1298660992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -82004,7 +87386,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302048064</BitOffs>
+            <BitOffs>1298661056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -82017,7 +87399,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302048080</BitOffs>
+            <BitOffs>1298661072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -82029,7 +87411,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302065920</BitOffs>
+            <BitOffs>1298678912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -82042,7 +87424,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073856</BitOffs>
+            <BitOffs>1298686848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -82055,7 +87437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073864</BitOffs>
+            <BitOffs>1298686856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -82068,7 +87450,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073872</BitOffs>
+            <BitOffs>1298686864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -82091,7 +87473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073888</BitOffs>
+            <BitOffs>1298686880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -82104,7 +87486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073920</BitOffs>
+            <BitOffs>1298686912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -82117,7 +87499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073984</BitOffs>
+            <BitOffs>1298686976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -82130,7 +87512,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302074000</BitOffs>
+            <BitOffs>1298686992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82142,7 +87524,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302093376</BitOffs>
+            <BitOffs>1298706368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -82154,7 +87536,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302419264</BitOffs>
+            <BitOffs>1299032256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -82167,7 +87549,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427200</BitOffs>
+            <BitOffs>1299040192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -82180,7 +87562,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427208</BitOffs>
+            <BitOffs>1299040200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -82193,7 +87575,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427216</BitOffs>
+            <BitOffs>1299040208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -82216,7 +87598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427232</BitOffs>
+            <BitOffs>1299040224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -82229,7 +87611,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427264</BitOffs>
+            <BitOffs>1299040256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -82242,7 +87624,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427328</BitOffs>
+            <BitOffs>1299040320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -82255,7 +87637,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427344</BitOffs>
+            <BitOffs>1299040336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -82267,7 +87649,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302446720</BitOffs>
+            <BitOffs>1299059712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -82279,7 +87661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302772608</BitOffs>
+            <BitOffs>1299385600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -82292,7 +87674,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780544</BitOffs>
+            <BitOffs>1299393536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -82305,7 +87687,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780552</BitOffs>
+            <BitOffs>1299393544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -82318,7 +87700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780560</BitOffs>
+            <BitOffs>1299393552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -82341,7 +87723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780576</BitOffs>
+            <BitOffs>1299393568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -82354,7 +87736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780608</BitOffs>
+            <BitOffs>1299393600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -82367,7 +87749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780672</BitOffs>
+            <BitOffs>1299393664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -82380,7 +87762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780688</BitOffs>
+            <BitOffs>1299393680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -82392,7 +87774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302798528</BitOffs>
+            <BitOffs>1299411520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -82405,7 +87787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806464</BitOffs>
+            <BitOffs>1299419456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -82418,7 +87800,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806472</BitOffs>
+            <BitOffs>1299419464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -82431,7 +87813,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806480</BitOffs>
+            <BitOffs>1299419472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -82454,7 +87836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806496</BitOffs>
+            <BitOffs>1299419488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -82467,7 +87849,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806528</BitOffs>
+            <BitOffs>1299419520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -82480,7 +87862,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806592</BitOffs>
+            <BitOffs>1299419584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -82493,7 +87875,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806608</BitOffs>
+            <BitOffs>1299419600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -82505,7 +87887,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302824448</BitOffs>
+            <BitOffs>1299437440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -82518,7 +87900,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832384</BitOffs>
+            <BitOffs>1299445376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -82531,7 +87913,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832392</BitOffs>
+            <BitOffs>1299445384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -82544,7 +87926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832400</BitOffs>
+            <BitOffs>1299445392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -82567,7 +87949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832416</BitOffs>
+            <BitOffs>1299445408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -82580,7 +87962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832448</BitOffs>
+            <BitOffs>1299445440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -82593,7 +87975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832512</BitOffs>
+            <BitOffs>1299445504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -82606,7 +87988,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832528</BitOffs>
+            <BitOffs>1299445520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -82618,7 +88000,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302850368</BitOffs>
+            <BitOffs>1299463360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -82631,7 +88013,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858304</BitOffs>
+            <BitOffs>1299471296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -82644,7 +88026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858312</BitOffs>
+            <BitOffs>1299471304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -82657,7 +88039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858320</BitOffs>
+            <BitOffs>1299471312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -82680,7 +88062,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858336</BitOffs>
+            <BitOffs>1299471328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -82693,7 +88075,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858368</BitOffs>
+            <BitOffs>1299471360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -82706,7 +88088,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858432</BitOffs>
+            <BitOffs>1299471424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -82719,7 +88101,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858448</BitOffs>
+            <BitOffs>1299471440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -82731,7 +88113,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302876288</BitOffs>
+            <BitOffs>1299489280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -82744,7 +88126,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884224</BitOffs>
+            <BitOffs>1299497216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -82757,7 +88139,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884232</BitOffs>
+            <BitOffs>1299497224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -82770,7 +88152,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884240</BitOffs>
+            <BitOffs>1299497232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -82793,7 +88175,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884256</BitOffs>
+            <BitOffs>1299497248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -82806,7 +88188,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884288</BitOffs>
+            <BitOffs>1299497280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -82819,7 +88201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884352</BitOffs>
+            <BitOffs>1299497344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -82832,7 +88214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884368</BitOffs>
+            <BitOffs>1299497360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -82844,7 +88226,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302902208</BitOffs>
+            <BitOffs>1299515200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -82857,7 +88239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910144</BitOffs>
+            <BitOffs>1299523136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -82870,7 +88252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910152</BitOffs>
+            <BitOffs>1299523144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -82883,7 +88265,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910160</BitOffs>
+            <BitOffs>1299523152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -82906,7 +88288,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910176</BitOffs>
+            <BitOffs>1299523168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -82919,7 +88301,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910208</BitOffs>
+            <BitOffs>1299523200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -82932,7 +88314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910272</BitOffs>
+            <BitOffs>1299523264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -82945,7 +88327,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910288</BitOffs>
+            <BitOffs>1299523280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -82957,7 +88339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302928128</BitOffs>
+            <BitOffs>1299541120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -82970,7 +88352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936064</BitOffs>
+            <BitOffs>1299549056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -82983,7 +88365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936072</BitOffs>
+            <BitOffs>1299549064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -82996,7 +88378,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936080</BitOffs>
+            <BitOffs>1299549072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -83019,7 +88401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936096</BitOffs>
+            <BitOffs>1299549088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -83032,7 +88414,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936128</BitOffs>
+            <BitOffs>1299549120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -83045,7 +88427,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936192</BitOffs>
+            <BitOffs>1299549184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -83058,7 +88440,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936208</BitOffs>
+            <BitOffs>1299549200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83070,7 +88452,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302955584</BitOffs>
+            <BitOffs>1299568576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -83082,7 +88464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303281472</BitOffs>
+            <BitOffs>1299894464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -83095,7 +88477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289408</BitOffs>
+            <BitOffs>1299902400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -83108,7 +88490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289416</BitOffs>
+            <BitOffs>1299902408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -83121,7 +88503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289424</BitOffs>
+            <BitOffs>1299902416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -83144,7 +88526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289440</BitOffs>
+            <BitOffs>1299902432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -83157,7 +88539,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289472</BitOffs>
+            <BitOffs>1299902464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -83170,7 +88552,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289536</BitOffs>
+            <BitOffs>1299902528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -83183,7 +88565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289552</BitOffs>
+            <BitOffs>1299902544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83195,7 +88577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303308928</BitOffs>
+            <BitOffs>1299921920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -83207,7 +88589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303634816</BitOffs>
+            <BitOffs>1300247808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -83220,7 +88602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642752</BitOffs>
+            <BitOffs>1300255744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -83233,7 +88615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642760</BitOffs>
+            <BitOffs>1300255752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -83246,7 +88628,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642768</BitOffs>
+            <BitOffs>1300255760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -83269,7 +88651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642784</BitOffs>
+            <BitOffs>1300255776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -83282,7 +88664,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642816</BitOffs>
+            <BitOffs>1300255808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -83295,7 +88677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642880</BitOffs>
+            <BitOffs>1300255872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -83308,7 +88690,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642896</BitOffs>
+            <BitOffs>1300255888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83320,7 +88702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303662272</BitOffs>
+            <BitOffs>1300275264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -83332,7 +88714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303988160</BitOffs>
+            <BitOffs>1300601152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -83345,7 +88727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996096</BitOffs>
+            <BitOffs>1300609088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -83358,7 +88740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996104</BitOffs>
+            <BitOffs>1300609096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -83371,7 +88753,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996112</BitOffs>
+            <BitOffs>1300609104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -83394,7 +88776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996128</BitOffs>
+            <BitOffs>1300609120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -83407,7 +88789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996160</BitOffs>
+            <BitOffs>1300609152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -83420,7 +88802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996224</BitOffs>
+            <BitOffs>1300609216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -83433,7 +88815,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996240</BitOffs>
+            <BitOffs>1300609232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83445,7 +88827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304015616</BitOffs>
+            <BitOffs>1300628608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -83457,7 +88839,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304341504</BitOffs>
+            <BitOffs>1300954496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -83470,7 +88852,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349440</BitOffs>
+            <BitOffs>1300962432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -83483,7 +88865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349448</BitOffs>
+            <BitOffs>1300962440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -83496,7 +88878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349456</BitOffs>
+            <BitOffs>1300962448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -83519,7 +88901,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349472</BitOffs>
+            <BitOffs>1300962464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -83532,7 +88914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349504</BitOffs>
+            <BitOffs>1300962496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -83545,7 +88927,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349568</BitOffs>
+            <BitOffs>1300962560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -83558,7 +88940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349584</BitOffs>
+            <BitOffs>1300962576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83570,7 +88952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304368960</BitOffs>
+            <BitOffs>1300981952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -83582,7 +88964,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304694848</BitOffs>
+            <BitOffs>1301307840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -83595,7 +88977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702784</BitOffs>
+            <BitOffs>1301315776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -83608,7 +88990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702792</BitOffs>
+            <BitOffs>1301315784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -83621,7 +89003,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702800</BitOffs>
+            <BitOffs>1301315792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -83644,7 +89026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702816</BitOffs>
+            <BitOffs>1301315808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -83657,7 +89039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702848</BitOffs>
+            <BitOffs>1301315840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -83670,7 +89052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702912</BitOffs>
+            <BitOffs>1301315904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -83683,7 +89065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702928</BitOffs>
+            <BitOffs>1301315920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83695,7 +89077,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1304722304</BitOffs>
+            <BitOffs>1301335296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -83707,7 +89089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305048192</BitOffs>
+            <BitOffs>1301661184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -83720,7 +89102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056128</BitOffs>
+            <BitOffs>1301669120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -83733,7 +89115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056136</BitOffs>
+            <BitOffs>1301669128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -83746,7 +89128,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056144</BitOffs>
+            <BitOffs>1301669136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -83769,7 +89151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056160</BitOffs>
+            <BitOffs>1301669152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -83782,7 +89164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056192</BitOffs>
+            <BitOffs>1301669184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -83795,7 +89177,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056256</BitOffs>
+            <BitOffs>1301669248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -83808,7 +89190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056272</BitOffs>
+            <BitOffs>1301669264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83820,7 +89202,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305075648</BitOffs>
+            <BitOffs>1301688640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -83832,7 +89214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305401536</BitOffs>
+            <BitOffs>1302014528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -83845,7 +89227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409472</BitOffs>
+            <BitOffs>1302022464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -83858,7 +89240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409480</BitOffs>
+            <BitOffs>1302022472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -83871,7 +89253,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409488</BitOffs>
+            <BitOffs>1302022480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -83894,7 +89276,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409504</BitOffs>
+            <BitOffs>1302022496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -83907,7 +89289,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409536</BitOffs>
+            <BitOffs>1302022528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -83920,7 +89302,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409600</BitOffs>
+            <BitOffs>1302022592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -83933,7 +89315,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409616</BitOffs>
+            <BitOffs>1302022608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -83945,7 +89327,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305428992</BitOffs>
+            <BitOffs>1302041984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -83957,7 +89339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305754880</BitOffs>
+            <BitOffs>1302367872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -83970,7 +89352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762816</BitOffs>
+            <BitOffs>1302375808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -83983,7 +89365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762824</BitOffs>
+            <BitOffs>1302375816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -83996,7 +89378,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762832</BitOffs>
+            <BitOffs>1302375824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -84019,7 +89401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762848</BitOffs>
+            <BitOffs>1302375840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -84032,7 +89414,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762880</BitOffs>
+            <BitOffs>1302375872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -84045,7 +89427,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762944</BitOffs>
+            <BitOffs>1302375936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -84058,7 +89440,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762960</BitOffs>
+            <BitOffs>1302375952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84070,7 +89452,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1305782336</BitOffs>
+            <BitOffs>1302395328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -84082,7 +89464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306108224</BitOffs>
+            <BitOffs>1302721216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -84095,7 +89477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116160</BitOffs>
+            <BitOffs>1302729152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -84108,7 +89490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116168</BitOffs>
+            <BitOffs>1302729160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -84121,7 +89503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116176</BitOffs>
+            <BitOffs>1302729168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -84144,7 +89526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116192</BitOffs>
+            <BitOffs>1302729184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -84157,7 +89539,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116224</BitOffs>
+            <BitOffs>1302729216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -84170,7 +89552,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116288</BitOffs>
+            <BitOffs>1302729280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -84183,7 +89565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116304</BitOffs>
+            <BitOffs>1302729296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84195,7 +89577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306135680</BitOffs>
+            <BitOffs>1302748672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -84207,7 +89589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306461568</BitOffs>
+            <BitOffs>1303074560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -84220,7 +89602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469504</BitOffs>
+            <BitOffs>1303082496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -84233,7 +89615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469512</BitOffs>
+            <BitOffs>1303082504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -84246,7 +89628,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469520</BitOffs>
+            <BitOffs>1303082512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -84269,7 +89651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469536</BitOffs>
+            <BitOffs>1303082528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -84282,7 +89664,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469568</BitOffs>
+            <BitOffs>1303082560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -84295,7 +89677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469632</BitOffs>
+            <BitOffs>1303082624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -84308,7 +89690,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469648</BitOffs>
+            <BitOffs>1303082640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84320,7 +89702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306489024</BitOffs>
+            <BitOffs>1303102016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -84332,7 +89714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306814912</BitOffs>
+            <BitOffs>1303427904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -84345,7 +89727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822848</BitOffs>
+            <BitOffs>1303435840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -84358,7 +89740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822856</BitOffs>
+            <BitOffs>1303435848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -84371,7 +89753,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822864</BitOffs>
+            <BitOffs>1303435856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -84394,7 +89776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822880</BitOffs>
+            <BitOffs>1303435872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -84407,7 +89789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822912</BitOffs>
+            <BitOffs>1303435904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -84420,7 +89802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822976</BitOffs>
+            <BitOffs>1303435968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -84433,7 +89815,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822992</BitOffs>
+            <BitOffs>1303435984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84445,7 +89827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306842368</BitOffs>
+            <BitOffs>1303455360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -84457,7 +89839,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307168256</BitOffs>
+            <BitOffs>1303781248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -84470,7 +89852,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176192</BitOffs>
+            <BitOffs>1303789184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -84483,7 +89865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176200</BitOffs>
+            <BitOffs>1303789192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -84496,7 +89878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176208</BitOffs>
+            <BitOffs>1303789200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -84519,7 +89901,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176224</BitOffs>
+            <BitOffs>1303789216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -84532,7 +89914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176256</BitOffs>
+            <BitOffs>1303789248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -84545,7 +89927,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176320</BitOffs>
+            <BitOffs>1303789312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -84558,7 +89940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176336</BitOffs>
+            <BitOffs>1303789328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84570,7 +89952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307195712</BitOffs>
+            <BitOffs>1303808704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -84585,7 +89967,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520512</BitOffs>
+            <BitOffs>1304133504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -84600,14 +89982,692 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520528</BitOffs>
+            <BitOffs>1304133520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319259520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319285440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319311360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320800832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320826752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320852672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860752</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -84760,7 +90820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282848064</BitOffs>
+            <BitOffs>1282837504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -84772,154 +90832,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283183104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284815424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284824408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284841344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284850328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284867264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284876248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1285206272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1285533696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1285861120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1286188544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1286515968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1286843392</BitOffs>
+            <BitOffs>1283172544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower01</Name>
@@ -84944,7 +90857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172800</BitOffs>
+            <BitOffs>1283498720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower02</Name>
@@ -84969,7 +90882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172808</BitOffs>
+            <BitOffs>1283498728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower03</Name>
@@ -84994,7 +90907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172816</BitOffs>
+            <BitOffs>1283498736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bFanOn</Name>
@@ -85018,10 +90931,10 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172824</BitOffs>
+            <BitOffs>1283498744</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -85030,23 +90943,10 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288503488</BitOffs>
+            <BitOffs>1283507520</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288512472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -85055,23 +90955,10 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288529408</BitOffs>
+            <BitOffs>1283834944</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1288538392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -85080,20 +90967,43 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288555328</BitOffs>
+            <BitOffs>1284162368</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288564312</BitOffs>
+            <BitOffs>1284489792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284817216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285144640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85105,7 +91015,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288924096</BitOffs>
+            <BitOffs>1285537088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85117,7 +91027,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289251520</BitOffs>
+            <BitOffs>1285864512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85129,7 +91039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289578944</BitOffs>
+            <BitOffs>1286191936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85141,7 +91051,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1289906368</BitOffs>
+            <BitOffs>1286519360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85153,7 +91063,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290233792</BitOffs>
+            <BitOffs>1286846784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bLEDPower</Name>
@@ -85178,7 +91088,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255360</BitOffs>
+            <BitOffs>1287868352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.iIlluminatorINT</Name>
@@ -85190,7 +91100,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255488</BitOffs>
+            <BitOffs>1287868480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.bGigePower</Name>
@@ -85210,7 +91120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255504</BitOffs>
+            <BitOffs>1287868496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbSetIllPercent.iRaw</Name>
@@ -85223,7 +91133,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291256576</BitOffs>
+            <BitOffs>1287869568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85235,7 +91145,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291259200</BitOffs>
+            <BitOffs>1287872192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -85251,7 +91161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291588960</BitOffs>
+            <BitOffs>1288201952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -85271,7 +91181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297967336</BitOffs>
+            <BitOffs>1294580328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -85291,7 +91201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298491688</BitOffs>
+            <BitOffs>1295104680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -85303,7 +91213,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299030784</BitOffs>
+            <BitOffs>1295643776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -85316,7 +91226,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299039768</BitOffs>
+            <BitOffs>1295652760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85328,7 +91238,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299058240</BitOffs>
+            <BitOffs>1295671232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -85340,7 +91250,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299384128</BitOffs>
+            <BitOffs>1295997120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -85353,7 +91263,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299393112</BitOffs>
+            <BitOffs>1296006104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85365,7 +91275,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299411584</BitOffs>
+            <BitOffs>1296024576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -85377,7 +91287,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299737472</BitOffs>
+            <BitOffs>1296350464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -85390,7 +91300,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299746456</BitOffs>
+            <BitOffs>1296359448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85402,7 +91312,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299764928</BitOffs>
+            <BitOffs>1296377920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -85414,7 +91324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300090816</BitOffs>
+            <BitOffs>1296703808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -85427,7 +91337,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300099800</BitOffs>
+            <BitOffs>1296712792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85439,7 +91349,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300118272</BitOffs>
+            <BitOffs>1296731264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -85451,7 +91361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300444160</BitOffs>
+            <BitOffs>1297057152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -85464,7 +91374,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300453144</BitOffs>
+            <BitOffs>1297066136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -85476,7 +91386,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300470080</BitOffs>
+            <BitOffs>1297083072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -85489,7 +91399,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300479064</BitOffs>
+            <BitOffs>1297092056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -85501,7 +91411,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300496000</BitOffs>
+            <BitOffs>1297108992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -85514,7 +91424,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300504984</BitOffs>
+            <BitOffs>1297117976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -85526,7 +91436,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300521920</BitOffs>
+            <BitOffs>1297134912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -85539,7 +91449,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300530904</BitOffs>
+            <BitOffs>1297143896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -85551,7 +91461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300547840</BitOffs>
+            <BitOffs>1297160832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -85564,7 +91474,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300556824</BitOffs>
+            <BitOffs>1297169816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -85576,7 +91486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300573760</BitOffs>
+            <BitOffs>1297186752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -85589,7 +91499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300582744</BitOffs>
+            <BitOffs>1297195736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -85601,7 +91511,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300599680</BitOffs>
+            <BitOffs>1297212672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -85614,7 +91524,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300608664</BitOffs>
+            <BitOffs>1297221656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -85626,7 +91536,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300625600</BitOffs>
+            <BitOffs>1297238592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -85639,7 +91549,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300634584</BitOffs>
+            <BitOffs>1297247576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85651,7 +91561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300653056</BitOffs>
+            <BitOffs>1297266048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -85663,7 +91573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300978944</BitOffs>
+            <BitOffs>1297591936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -85676,7 +91586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300987928</BitOffs>
+            <BitOffs>1297600920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85688,7 +91598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301006400</BitOffs>
+            <BitOffs>1297619392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -85700,7 +91610,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301332288</BitOffs>
+            <BitOffs>1297945280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -85713,7 +91623,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301341272</BitOffs>
+            <BitOffs>1297954264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85725,7 +91635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301359744</BitOffs>
+            <BitOffs>1297972736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -85737,7 +91647,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301685632</BitOffs>
+            <BitOffs>1298298624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -85750,7 +91660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301694616</BitOffs>
+            <BitOffs>1298307608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85762,7 +91672,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301713088</BitOffs>
+            <BitOffs>1298326080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -85774,7 +91684,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302038976</BitOffs>
+            <BitOffs>1298651968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -85787,7 +91697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302047960</BitOffs>
+            <BitOffs>1298660952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -85799,7 +91709,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302064896</BitOffs>
+            <BitOffs>1298677888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -85812,7 +91722,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302073880</BitOffs>
+            <BitOffs>1298686872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85824,7 +91734,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302092352</BitOffs>
+            <BitOffs>1298705344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -85836,7 +91746,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302418240</BitOffs>
+            <BitOffs>1299031232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -85849,7 +91759,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302427224</BitOffs>
+            <BitOffs>1299040216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -85861,7 +91771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302445696</BitOffs>
+            <BitOffs>1299058688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -85873,7 +91783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302771584</BitOffs>
+            <BitOffs>1299384576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -85886,7 +91796,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302780568</BitOffs>
+            <BitOffs>1299393560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -85898,7 +91808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302797504</BitOffs>
+            <BitOffs>1299410496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -85911,7 +91821,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302806488</BitOffs>
+            <BitOffs>1299419480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -85923,7 +91833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302823424</BitOffs>
+            <BitOffs>1299436416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -85936,7 +91846,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302832408</BitOffs>
+            <BitOffs>1299445400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -85948,7 +91858,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302849344</BitOffs>
+            <BitOffs>1299462336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -85961,7 +91871,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302858328</BitOffs>
+            <BitOffs>1299471320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -85973,7 +91883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302875264</BitOffs>
+            <BitOffs>1299488256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -85986,7 +91896,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302884248</BitOffs>
+            <BitOffs>1299497240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -85998,7 +91908,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302901184</BitOffs>
+            <BitOffs>1299514176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -86011,7 +91921,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302910168</BitOffs>
+            <BitOffs>1299523160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -86023,7 +91933,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302927104</BitOffs>
+            <BitOffs>1299540096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -86036,7 +91946,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302936088</BitOffs>
+            <BitOffs>1299549080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86048,7 +91958,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302954560</BitOffs>
+            <BitOffs>1299567552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -86060,7 +91970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303280448</BitOffs>
+            <BitOffs>1299893440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -86073,7 +91983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303289432</BitOffs>
+            <BitOffs>1299902424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86085,7 +91995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303307904</BitOffs>
+            <BitOffs>1299920896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -86097,7 +92007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303633792</BitOffs>
+            <BitOffs>1300246784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -86110,7 +92020,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303642776</BitOffs>
+            <BitOffs>1300255768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86122,7 +92032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303661248</BitOffs>
+            <BitOffs>1300274240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -86134,7 +92044,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303987136</BitOffs>
+            <BitOffs>1300600128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -86147,7 +92057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303996120</BitOffs>
+            <BitOffs>1300609112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86159,7 +92069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304014592</BitOffs>
+            <BitOffs>1300627584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -86171,7 +92081,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304340480</BitOffs>
+            <BitOffs>1300953472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -86184,7 +92094,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304349464</BitOffs>
+            <BitOffs>1300962456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86196,7 +92106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304367936</BitOffs>
+            <BitOffs>1300980928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -86208,7 +92118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304693824</BitOffs>
+            <BitOffs>1301306816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -86221,7 +92131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304702808</BitOffs>
+            <BitOffs>1301315800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86233,7 +92143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304721280</BitOffs>
+            <BitOffs>1301334272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -86245,7 +92155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305047168</BitOffs>
+            <BitOffs>1301660160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -86258,7 +92168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305056152</BitOffs>
+            <BitOffs>1301669144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86270,7 +92180,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305074624</BitOffs>
+            <BitOffs>1301687616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -86282,7 +92192,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305400512</BitOffs>
+            <BitOffs>1302013504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -86295,7 +92205,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305409496</BitOffs>
+            <BitOffs>1302022488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86307,7 +92217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305427968</BitOffs>
+            <BitOffs>1302040960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -86319,7 +92229,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305753856</BitOffs>
+            <BitOffs>1302366848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -86332,7 +92242,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305762840</BitOffs>
+            <BitOffs>1302375832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86344,7 +92254,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305781312</BitOffs>
+            <BitOffs>1302394304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -86356,7 +92266,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306107200</BitOffs>
+            <BitOffs>1302720192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -86369,7 +92279,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306116184</BitOffs>
+            <BitOffs>1302729176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86381,7 +92291,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306134656</BitOffs>
+            <BitOffs>1302747648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -86393,7 +92303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306460544</BitOffs>
+            <BitOffs>1303073536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -86406,7 +92316,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306469528</BitOffs>
+            <BitOffs>1303082520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86418,7 +92328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306488000</BitOffs>
+            <BitOffs>1303100992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -86430,7 +92340,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306813888</BitOffs>
+            <BitOffs>1303426880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -86443,7 +92353,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306822872</BitOffs>
+            <BitOffs>1303435864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86455,7 +92365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306841344</BitOffs>
+            <BitOffs>1303454336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -86467,7 +92377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307167232</BitOffs>
+            <BitOffs>1303780224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -86480,7 +92390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307176216</BitOffs>
+            <BitOffs>1303789208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -86492,14 +92402,164 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307194688</BitOffs>
+            <BitOffs>1303807680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319258496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319267480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319284416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319293400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319310336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319319320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320799808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320808792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320825728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320834712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320851648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1320860632</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -92299,25 +98359,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>633593344</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
-            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
-            <BitSize>30144</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)DB
-        io: io
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634528960</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Global_Version.stLibVersion_lcls_twincat_motion</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
@@ -92328,11 +98369,11 @@ Emergency Stop for MR1K1</Comment>
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>0</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>8</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -92344,7 +98385,7 @@ Emergency Stop for MR1K1</Comment>
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>4.0.8</String>
+                <String>4.1.1</String>
               </SubItem>
             </Default>
             <Properties>
@@ -93659,35 +99700,54 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264816960</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PiezoSerial.rtInitParams_M1K2</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
+            <BitOffs>1265046656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
+            <Comment>For timeout reset</Comment>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="Tc2_Standard">TON</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.PT</Name>
+                <DateTime>T#2S</DateTime>
+              </SubItem>
+            </Default>
+            <BitOffs>1265046784</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
             <Comment> Temp testing</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1264935648</BitOffs>
+            <BitOffs>1265051744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1264935664</BitOffs>
+            <BitOffs>1265051760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1265711680</BitOffs>
+            <BitOffs>1265827776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265711696</BitOffs>
+            <BitOffs>1265827792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265711704</BitOffs>
+            <BitOffs>1265827800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntYupM1K1</Name>
@@ -93704,26 +99764,7 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265711776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PiezoSerial.rtInitParams_M1K2</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265827520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
-            <Comment>For timeout reset</Comment>
-            <BitSize>256</BitSize>
-            <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.PT</Name>
-                <DateTime>T#2S</DateTime>
-              </SubItem>
-            </Default>
-            <BitOffs>1265827648</BitOffs>
+            <BitOffs>1265827872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -94438,7 +100479,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1281597056</BitOffs>
+            <BitOffs>1281586496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
@@ -94453,19 +100494,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1281620608</BitOffs>
+            <BitOffs>1281610048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282008128</BitOffs>
+            <BitOffs>1281997568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282008192</BitOffs>
+            <BitOffs>1281997632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
@@ -94479,19 +100520,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282008256</BitOffs>
+            <BitOffs>1281997696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282395776</BitOffs>
+            <BitOffs>1282385216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282395840</BitOffs>
+            <BitOffs>1282385280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
@@ -94505,53 +100546,38 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282395904</BitOffs>
+            <BitOffs>1282385344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282783424</BitOffs>
+            <BitOffs>1282772864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282783488</BitOffs>
+            <BitOffs>1282772928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1282783552</BitOffs>
+            <BitOffs>1282772992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1283181440</BitOffs>
+            <BitOffs>1283170880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1283181448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.eStateSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: MR1K2:SWITCH:COATING:STATE:SET
-      io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283181456</BitOffs>
+            <BitOffs>1283170888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYleftM1K2</Name>
@@ -94568,7 +100594,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283181472</BitOffs>
+            <BitOffs>1283170912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -94576,7 +100602,7 @@ M1K1 BEND US ENC CNT</Comment>
  Using stepper only for now</Comment>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283181504</BitOffs>
+            <BitOffs>1283170944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fYRoll_urad</Name>
@@ -94593,7 +100619,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283508928</BitOffs>
+            <BitOffs>1283498368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYrightM1K2</Name>
@@ -94609,7 +100635,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283508992</BitOffs>
+            <BitOffs>1283498432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXupM1K2</Name>
@@ -94625,7 +100651,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509024</BitOffs>
+            <BitOffs>1283498464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXdwnM1K2</Name>
@@ -94641,7 +100667,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509056</BitOffs>
+            <BitOffs>1283498496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntPitchM1K2</Name>
@@ -94657,7 +100683,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509088</BitOffs>
+            <BitOffs>1283498528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYleftM1K2</Name>
@@ -94674,7 +100700,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509120</BitOffs>
+            <BitOffs>1283498560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYrightM1K2</Name>
@@ -94690,7 +100716,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509152</BitOffs>
+            <BitOffs>1283498592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXupM1K2</Name>
@@ -94706,7 +100732,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509184</BitOffs>
+            <BitOffs>1283498624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXdwnM1K2</Name>
@@ -94722,7 +100748,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509216</BitOffs>
+            <BitOffs>1283498656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefPitchM1K2</Name>
@@ -94738,35 +100764,20 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283509248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.eStateGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: MR1K2:SWITCH:COATING:STATE:GET
-      io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283509280</BitOffs>
+            <BitOffs>1283498688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.mcReadParameterPitchM1K2</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1283509312</BitOffs>
+            <BitOffs>1283498752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncRefPitchM1K2_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1283514304</BitOffs>
+            <BitOffs>1283503744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncLeverArm_mm</Name>
@@ -94776,7 +100787,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>391</Value>
             </Default>
-            <BitOffs>1283514368</BitOffs>
+            <BitOffs>1283503808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1</Name>
@@ -94789,7 +100800,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1283514432</BitOffs>
+            <BitOffs>1283503872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1_val</Name>
@@ -94805,7 +100816,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283514944</BitOffs>
+            <BitOffs>1283504384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2</Name>
@@ -94817,7 +100828,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1283515008</BitOffs>
+            <BitOffs>1283504448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2_val</Name>
@@ -94833,7 +100844,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283515520</BitOffs>
+            <BitOffs>1283504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1</Name>
@@ -94845,7 +100856,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1283515584</BitOffs>
+            <BitOffs>1283505024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1_val</Name>
@@ -94861,71 +100872,43 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283516096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbCoatingStates</Name>
-            <BitSize>1541120</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR1K2:SWITCH:COATING</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283516160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbYSetup</Name>
-            <BitSize>92352</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1285057280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.astCoatingStatesY</Name>
-            <BitSize>54720</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>15</Elements>
-            </ArrayInfo>
-            <BitOffs>1285149632</BitOffs>
+            <BitOffs>1283505536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285204672</BitOffs>
+            <BitOffs>1283505920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285532096</BitOffs>
+            <BitOffs>1283833344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285859520</BitOffs>
+            <BitOffs>1284160768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286186944</BitOffs>
+            <BitOffs>1284488192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286514368</BitOffs>
+            <BitOffs>1284815616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286841792</BitOffs>
+            <BitOffs>1285143040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upeurad</Name>
@@ -94940,7 +100923,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287169472</BitOffs>
+            <BitOffs>1285470720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upeurad</Name>
@@ -94955,7 +100938,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287169536</BitOffs>
+            <BitOffs>1285470784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1</Name>
@@ -94978,7 +100961,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169600</BitOffs>
+            <BitOffs>1285470848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2</Name>
@@ -95000,7 +100983,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287169856</BitOffs>
+            <BitOffs>1285471104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3</Name>
@@ -95022,7 +101005,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170112</BitOffs>
+            <BitOffs>1285471360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4</Name>
@@ -95044,7 +101027,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170368</BitOffs>
+            <BitOffs>1285471616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5</Name>
@@ -95066,7 +101049,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170624</BitOffs>
+            <BitOffs>1285471872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6</Name>
@@ -95088,7 +101071,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287170880</BitOffs>
+            <BitOffs>1285472128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7</Name>
@@ -95110,7 +101093,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171136</BitOffs>
+            <BitOffs>1285472384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8</Name>
@@ -95132,7 +101115,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171392</BitOffs>
+            <BitOffs>1285472640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9</Name>
@@ -95154,7 +101137,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171648</BitOffs>
+            <BitOffs>1285472896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10</Name>
@@ -95176,7 +101159,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287171904</BitOffs>
+            <BitOffs>1285473152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11</Name>
@@ -95198,7 +101181,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172160</BitOffs>
+            <BitOffs>1285473408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12</Name>
@@ -95220,7 +101203,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287172416</BitOffs>
+            <BitOffs>1285473664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_read</Name>
@@ -95236,7 +101219,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287172672</BitOffs>
+            <BitOffs>1285473920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_set</Name>
@@ -95251,37 +101234,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287172736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.eStateSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_Grating_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: SP1K1:MONO:GRATING:STATE:SET
-      io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287172832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.eStateGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_Grating_States</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: SP1K1:MONO:GRATING:STATE:GET
-      io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287172848</BitOffs>
+            <BitOffs>1285473984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_FFO</Name>
@@ -95301,7 +101254,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>4368</Value>
               </SubItem>
             </Default>
-            <BitOffs>1287172864</BitOffs>
+            <BitOffs>1285474048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_e_pmps</Name>
@@ -95310,7 +101263,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>74000.29</Value>
             </Default>
-            <BitOffs>1287198784</BitOffs>
+            <BitOffs>1285499968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1</Name>
@@ -95323,7 +101276,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1287198848</BitOffs>
+            <BitOffs>1285500032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1_val</Name>
@@ -95339,7 +101292,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287199360</BitOffs>
+            <BitOffs>1285500544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2</Name>
@@ -95351,7 +101304,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1287199424</BitOffs>
+            <BitOffs>1285500608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2_val</Name>
@@ -95367,7 +101320,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287199936</BitOffs>
+            <BitOffs>1285501120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1</Name>
@@ -95379,7 +101332,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1287200000</BitOffs>
+            <BitOffs>1285501184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1_val</Name>
@@ -95395,71 +101348,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287200512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.stDefaultGH</Name>
-            <BitSize>3648</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fDelta</Name>
-                <Value>2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>875</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fAccel</Name>
-                <Value>6923</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fDecel</Name>
-                <Value>6923</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bMoveOk</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bValid</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bUseRawCounts</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <BitOffs>1287200576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGratingStates</Name>
-            <BitSize>1541120</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: SP1K1:MONO:GRATING</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1287204224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbGHSetup</Name>
-            <BitSize>92352</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1288745344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.astGratingStates</Name>
-            <BitSize>54720</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>15</Elements>
-            </ArrayInfo>
-            <BitOffs>1288837696</BitOffs>
+            <BitOffs>1285501696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -95479,37 +101368,37 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>3664</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288896576</BitOffs>
+            <BitOffs>1285509568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1288922496</BitOffs>
+            <BitOffs>1285535488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1289249920</BitOffs>
+            <BitOffs>1285862912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1289577344</BitOffs>
+            <BitOffs>1286190336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1289904768</BitOffs>
+            <BitOffs>1286517760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1290232192</BitOffs>
+            <BitOffs>1286845184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbStates</Name>
@@ -95524,7 +101413,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1290559616</BitOffs>
+            <BitOffs>1287172608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP</Name>
@@ -95545,7 +101434,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_1]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254336</BitOffs>
+            <BitOffs>1287867328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM</Name>
@@ -95566,7 +101455,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_2]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254592</BitOffs>
+            <BitOffs>1287867584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG</Name>
@@ -95587,7 +101476,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_4]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1291254848</BitOffs>
+            <BitOffs>1287867840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync</Name>
@@ -95608,7 +101497,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_3]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255104</BitOffs>
+            <BitOffs>1287868096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bInit</Name>
@@ -95617,7 +101506,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1291255368</BitOffs>
+            <BitOffs>1287868360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
@@ -95633,7 +101522,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291255376</BitOffs>
+            <BitOffs>1287868368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
@@ -95649,7 +101538,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291255384</BitOffs>
+            <BitOffs>1287868376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.delta</Name>
@@ -95658,7 +101547,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1291255392</BitOffs>
+            <BitOffs>1287868384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige</Name>
@@ -95677,7 +101566,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bGigePower := TIIB[EL2004_SL1K2]^Channel 3^Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291255424</BitOffs>
+            <BitOffs>1287868416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter</Name>
@@ -95707,7 +101596,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3052_SL1K2_FWM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1291256768</BitOffs>
+            <BitOffs>1287869760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fSmallDelta</Name>
@@ -95717,7 +101606,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.01</Value>
             </Default>
-            <BitOffs>1291257280</BitOffs>
+            <BitOffs>1287870272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fBigDelta</Name>
@@ -95726,7 +101615,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>10</Value>
             </Default>
-            <BitOffs>1291257344</BitOffs>
+            <BitOffs>1287870336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fMaxVelocity</Name>
@@ -95735,7 +101624,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.5</Value>
             </Default>
-            <BitOffs>1291257408</BitOffs>
+            <BitOffs>1287870400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fHighAccel</Name>
@@ -95744,7 +101633,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.8</Value>
             </Default>
-            <BitOffs>1291257472</BitOffs>
+            <BitOffs>1287870464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fLowAccel</Name>
@@ -95753,25 +101642,25 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1291257536</BitOffs>
+            <BitOffs>1287870528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1291257600</BitOffs>
+            <BitOffs>1287870592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO</Name>
             <BitSize>145024</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>1291586240</BitOffs>
+            <BitOffs>1288199232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>1291731264</BitOffs>
+            <BitOffs>1288344256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ff2_ff1_link_optics</Name>
@@ -95795,7 +101684,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>65535</Value>
               </SubItem>
             </Default>
-            <BitOffs>1291759616</BitOffs>
+            <BitOffs>1288372608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX01</Name>
@@ -95820,7 +101709,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62729</Value>
               </SubItem>
             </Default>
-            <BitOffs>1291785536</BitOffs>
+            <BitOffs>1288398528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX02</Name>
@@ -95844,7 +101733,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62736</Value>
               </SubItem>
             </Default>
-            <BitOffs>1291811456</BitOffs>
+            <BitOffs>1288424448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX05</Name>
@@ -95868,7 +101757,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62737</Value>
               </SubItem>
             </Default>
-            <BitOffs>1291837376</BitOffs>
+            <BitOffs>1288450368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeam</Name>
@@ -95893,7 +101782,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1291863296</BitOffs>
+            <BitOffs>1288476288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOS_IN</Name>
@@ -95909,7 +101798,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291889216</BitOffs>
+            <BitOffs>1288502208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOB_on_Lower_Stopper</Name>
@@ -95925,7 +101814,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291889224</BitOffs>
+            <BitOffs>1288502216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
@@ -95941,7 +101830,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291889232</BitOffs>
+            <BitOffs>1288502224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
@@ -95957,7 +101846,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291889240</BitOffs>
+            <BitOffs>1288502232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.nMachineMode</Name>
@@ -95975,110 +101864,110 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291889248</BitOffs>
+            <BitOffs>1288502240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889280</BitOffs>
+            <BitOffs>1288502272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889344</BitOffs>
+            <BitOffs>1288502336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889408</BitOffs>
+            <BitOffs>1288502400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889472</BitOffs>
+            <BitOffs>1288502464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.HZos</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889536</BitOffs>
+            <BitOffs>1288502528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889600</BitOffs>
+            <BitOffs>1288502592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889664</BitOffs>
+            <BitOffs>1288502656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889728</BitOffs>
+            <BitOffs>1288502720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889792</BitOffs>
+            <BitOffs>1288502784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889856</BitOffs>
+            <BitOffs>1288502848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889920</BitOffs>
+            <BitOffs>1288502912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hb0m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291889984</BitOffs>
+            <BitOffs>1288502976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm3</Name>
             <Comment>fixed calc</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291890048</BitOffs>
+            <BitOffs>1288503040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hpiv</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291890112</BitOffs>
+            <BitOffs>1288503104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291890176</BitOffs>
+            <BitOffs>1288503168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291890240</BitOffs>
+            <BitOffs>1288503232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291890304</BitOffs>
+            <BitOffs>1288503296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Delta</Name>
@@ -96094,13 +101983,13 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291890368</BitOffs>
+            <BitOffs>1288503360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Ans</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291890432</BitOffs>
+            <BitOffs>1288503424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeamExitSlits</Name>
@@ -96124,7 +102013,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1291890496</BitOffs>
+            <BitOffs>1288503488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hi2</Name>
@@ -96134,7 +102023,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>1.4</Value>
             </Default>
-            <BitOffs>1291916416</BitOffs>
+            <BitOffs>1288529408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zi2</Name>
@@ -96144,7 +102033,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>731.613</Value>
             </Default>
-            <BitOffs>1291916480</BitOffs>
+            <BitOffs>1288529472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta0</Name>
@@ -96153,7 +102042,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>1291916544</BitOffs>
+            <BitOffs>1288529536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zm1</Name>
@@ -96163,7 +102052,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>733.772</Value>
             </Default>
-            <BitOffs>1291916608</BitOffs>
+            <BitOffs>1288529600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zmon</Name>
@@ -96173,7 +102062,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>739.622</Value>
             </Default>
-            <BitOffs>1291916672</BitOffs>
+            <BitOffs>1288529664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zpiv</Name>
@@ -96183,7 +102072,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>739.762</Value>
             </Default>
-            <BitOffs>1291916736</BitOffs>
+            <BitOffs>1288529728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zzos</Name>
@@ -96193,7 +102082,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>741.422</Value>
             </Default>
-            <BitOffs>1291916800</BitOffs>
+            <BitOffs>1288529792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1Offset</Name>
@@ -96202,7 +102091,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>18081.1</Value>
             </Default>
-            <BitOffs>1291916864</BitOffs>
+            <BitOffs>1288529856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2Offset</Name>
@@ -96211,7 +102100,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>-90603</Value>
             </Default>
-            <BitOffs>1291916928</BitOffs>
+            <BitOffs>1288529920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3Offset</Name>
@@ -96221,7 +102110,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>-63300</Value>
             </Default>
-            <BitOffs>1291916992</BitOffs>
+            <BitOffs>1288529984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
@@ -96235,19 +102124,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1291917696</BitOffs>
+            <BitOffs>1288530688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292305216</BitOffs>
+            <BitOffs>1288918208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292305280</BitOffs>
+            <BitOffs>1288918272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
@@ -96260,19 +102149,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1292305344</BitOffs>
+            <BitOffs>1288918336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292692864</BitOffs>
+            <BitOffs>1289305856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292692928</BitOffs>
+            <BitOffs>1289305920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
@@ -96285,19 +102174,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1292692992</BitOffs>
+            <BitOffs>1289305984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293080512</BitOffs>
+            <BitOffs>1289693504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293080576</BitOffs>
+            <BitOffs>1289693568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefXM2K2</Name>
@@ -96315,7 +102204,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080640</BitOffs>
+            <BitOffs>1289693632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefYM2K2</Name>
@@ -96332,7 +102221,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080672</BitOffs>
+            <BitOffs>1289693664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefrXM2K2</Name>
@@ -96349,7 +102238,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080704</BitOffs>
+            <BitOffs>1289693696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntXM2K2</Name>
@@ -96367,7 +102256,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080736</BitOffs>
+            <BitOffs>1289693728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntYM2K2</Name>
@@ -96384,7 +102273,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080768</BitOffs>
+            <BitOffs>1289693760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntrXM2K2</Name>
@@ -96401,7 +102290,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080800</BitOffs>
+            <BitOffs>1289693792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
@@ -96422,7 +102311,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293080832</BitOffs>
+            <BitOffs>1289693824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
@@ -96436,19 +102325,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1293082624</BitOffs>
+            <BitOffs>1289695616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293470144</BitOffs>
+            <BitOffs>1290083136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293470208</BitOffs>
+            <BitOffs>1290083200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
@@ -96461,19 +102350,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1293470272</BitOffs>
+            <BitOffs>1290083264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293857792</BitOffs>
+            <BitOffs>1290470784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293857856</BitOffs>
+            <BitOffs>1290470848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
@@ -96486,19 +102375,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1293857920</BitOffs>
+            <BitOffs>1290470912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294245440</BitOffs>
+            <BitOffs>1290858432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294245504</BitOffs>
+            <BitOffs>1290858496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
@@ -96511,19 +102400,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1294245568</BitOffs>
+            <BitOffs>1290858560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294633088</BitOffs>
+            <BitOffs>1291246080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294633152</BitOffs>
+            <BitOffs>1291246144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
@@ -96536,19 +102425,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1294633216</BitOffs>
+            <BitOffs>1291246208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1295020736</BitOffs>
+            <BitOffs>1291633728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1295020800</BitOffs>
+            <BitOffs>1291633792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefXM3K2</Name>
@@ -96566,7 +102455,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295020864</BitOffs>
+            <BitOffs>1291633856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefYM3K2</Name>
@@ -96583,7 +102472,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295020896</BitOffs>
+            <BitOffs>1291633888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefrYM3K2</Name>
@@ -96600,7 +102489,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295020928</BitOffs>
+            <BitOffs>1291633920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefUSM3K2</Name>
@@ -96617,7 +102506,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295020960</BitOffs>
+            <BitOffs>1291633952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefDSM3K2</Name>
@@ -96634,7 +102523,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295020992</BitOffs>
+            <BitOffs>1291633984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntXM3K2</Name>
@@ -96652,7 +102541,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021024</BitOffs>
+            <BitOffs>1291634016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntYM3K2</Name>
@@ -96669,7 +102558,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021056</BitOffs>
+            <BitOffs>1291634048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntrYM3K2</Name>
@@ -96686,7 +102575,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021088</BitOffs>
+            <BitOffs>1291634080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntUSM3K2</Name>
@@ -96703,7 +102592,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021120</BitOffs>
+            <BitOffs>1291634112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntDSM3K2</Name>
@@ -96720,7 +102609,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021152</BitOffs>
+            <BitOffs>1291634144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_1</Name>
@@ -96739,7 +102628,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021184</BitOffs>
+            <BitOffs>1291634176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_2</Name>
@@ -96756,7 +102645,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021216</BitOffs>
+            <BitOffs>1291634208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
@@ -96773,7 +102662,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021248</BitOffs>
+            <BitOffs>1291634240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
@@ -96791,7 +102680,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021280</BitOffs>
+            <BitOffs>1291634272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
@@ -96808,7 +102697,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021312</BitOffs>
+            <BitOffs>1291634304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -96825,7 +102714,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021344</BitOffs>
+            <BitOffs>1291634336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
@@ -96846,7 +102735,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1295021440</BitOffs>
+            <BitOffs>1291634432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
@@ -96860,19 +102749,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1295022656</BitOffs>
+            <BitOffs>1291635648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1295410176</BitOffs>
+            <BitOffs>1292023168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1295410240</BitOffs>
+            <BitOffs>1292023232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
@@ -96885,19 +102774,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1295410304</BitOffs>
+            <BitOffs>1292023296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1295797824</BitOffs>
+            <BitOffs>1292410816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1295797888</BitOffs>
+            <BitOffs>1292410880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
@@ -96910,19 +102799,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1295797952</BitOffs>
+            <BitOffs>1292410944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1296185472</BitOffs>
+            <BitOffs>1292798464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1296185536</BitOffs>
+            <BitOffs>1292798528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
@@ -96935,19 +102824,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1296185600</BitOffs>
+            <BitOffs>1292798592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1296573120</BitOffs>
+            <BitOffs>1293186112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1296573184</BitOffs>
+            <BitOffs>1293186176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
@@ -96960,19 +102849,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1296573248</BitOffs>
+            <BitOffs>1293186240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1296960768</BitOffs>
+            <BitOffs>1293573760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1296960832</BitOffs>
+            <BitOffs>1293573824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -96990,7 +102879,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296960896</BitOffs>
+            <BitOffs>1293573888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -97007,7 +102896,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296960928</BitOffs>
+            <BitOffs>1293573920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -97024,7 +102913,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296960960</BitOffs>
+            <BitOffs>1293573952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -97041,7 +102930,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296960992</BitOffs>
+            <BitOffs>1293573984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -97058,7 +102947,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961024</BitOffs>
+            <BitOffs>1293574016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -97076,7 +102965,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961056</BitOffs>
+            <BitOffs>1293574048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -97093,7 +102982,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961088</BitOffs>
+            <BitOffs>1293574080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -97110,7 +102999,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961120</BitOffs>
+            <BitOffs>1293574112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -97127,7 +103016,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961152</BitOffs>
+            <BitOffs>1293574144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -97144,7 +103033,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961184</BitOffs>
+            <BitOffs>1293574176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -97163,7 +103052,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961216</BitOffs>
+            <BitOffs>1293574208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -97180,7 +103069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961248</BitOffs>
+            <BitOffs>1293574240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -97197,7 +103086,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961280</BitOffs>
+            <BitOffs>1293574272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -97215,7 +103104,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961312</BitOffs>
+            <BitOffs>1293574304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -97232,7 +103121,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961344</BitOffs>
+            <BitOffs>1293574336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -97249,7 +103138,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961376</BitOffs>
+            <BitOffs>1293574368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -97272,7 +103161,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961408</BitOffs>
+            <BitOffs>1293574400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -97295,7 +103184,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961664</BitOffs>
+            <BitOffs>1293574656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
@@ -97316,7 +103205,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1296961984</BitOffs>
+            <BitOffs>1293574976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -97351,7 +103240,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296968256</BitOffs>
+            <BitOffs>1293581248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -97366,7 +103255,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296970752</BitOffs>
+            <BitOffs>1293583744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -97380,7 +103269,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296970816</BitOffs>
+            <BitOffs>1293583808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -97395,7 +103284,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296970880</BitOffs>
+            <BitOffs>1293583872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -97410,7 +103299,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296970944</BitOffs>
+            <BitOffs>1293583936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -97425,7 +103314,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971008</BitOffs>
+            <BitOffs>1293584000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -97440,7 +103329,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971072</BitOffs>
+            <BitOffs>1293584064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -97456,7 +103345,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971200</BitOffs>
+            <BitOffs>1293584192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -97470,7 +103359,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971264</BitOffs>
+            <BitOffs>1293584256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -97484,7 +103373,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971328</BitOffs>
+            <BitOffs>1293584320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -97498,7 +103387,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296971392</BitOffs>
+            <BitOffs>1293584384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -97513,7 +103402,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296973952</BitOffs>
+            <BitOffs>1293586944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -97528,7 +103417,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974016</BitOffs>
+            <BitOffs>1293587008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -97543,7 +103432,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974080</BitOffs>
+            <BitOffs>1293587072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -97559,7 +103448,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974144</BitOffs>
+            <BitOffs>1293587136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -97573,7 +103462,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974208</BitOffs>
+            <BitOffs>1293587200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -97587,7 +103476,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974272</BitOffs>
+            <BitOffs>1293587264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -97602,7 +103491,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974336</BitOffs>
+            <BitOffs>1293587328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -97617,7 +103506,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974400</BitOffs>
+            <BitOffs>1293587392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -97633,7 +103522,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974592</BitOffs>
+            <BitOffs>1293587584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -97647,7 +103536,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974656</BitOffs>
+            <BitOffs>1293587648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -97661,7 +103550,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974720</BitOffs>
+            <BitOffs>1293587712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -97676,7 +103565,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974784</BitOffs>
+            <BitOffs>1293587776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -97691,7 +103580,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974848</BitOffs>
+            <BitOffs>1293587840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -97706,7 +103595,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974912</BitOffs>
+            <BitOffs>1293587904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -97721,7 +103610,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296974976</BitOffs>
+            <BitOffs>1293587968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -97736,7 +103625,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975040</BitOffs>
+            <BitOffs>1293588032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -97751,7 +103640,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975104</BitOffs>
+            <BitOffs>1293588096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -97767,7 +103656,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975232</BitOffs>
+            <BitOffs>1293588224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -97781,7 +103670,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975296</BitOffs>
+            <BitOffs>1293588288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -97795,7 +103684,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975360</BitOffs>
+            <BitOffs>1293588352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -97809,7 +103698,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975424</BitOffs>
+            <BitOffs>1293588416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -97824,7 +103713,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975488</BitOffs>
+            <BitOffs>1293588480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -97835,7 +103724,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975520</BitOffs>
+            <BitOffs>1293588512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -97853,7 +103742,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296975552</BitOffs>
+            <BitOffs>1293588544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -97871,7 +103760,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297471296</BitOffs>
+            <BitOffs>1294084288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -97900,7 +103789,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297967040</BitOffs>
+            <BitOffs>1294580032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -97929,7 +103818,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298491392</BitOffs>
+            <BitOffs>1295104384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetY</Name>
@@ -97970,7 +103859,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299016128</BitOffs>
+            <BitOffs>1295629120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetX</Name>
@@ -98011,7 +103900,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299019776</BitOffs>
+            <BitOffs>1295632768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBX</Name>
@@ -98052,7 +103941,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299023424</BitOffs>
+            <BitOffs>1295636416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBY</Name>
@@ -98093,7 +103982,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299027072</BitOffs>
+            <BitOffs>1295640064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -98131,7 +104020,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299030720</BitOffs>
+            <BitOffs>1295643712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -98142,7 +104031,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299056640</BitOffs>
+            <BitOffs>1295669632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -98180,7 +104069,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299384064</BitOffs>
+            <BitOffs>1295997056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -98191,7 +104080,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299409984</BitOffs>
+            <BitOffs>1296022976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -98229,7 +104118,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299737408</BitOffs>
+            <BitOffs>1296350400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -98240,7 +104129,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299763328</BitOffs>
+            <BitOffs>1296376320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -98278,7 +104167,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300090752</BitOffs>
+            <BitOffs>1296703744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -98289,7 +104178,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300116672</BitOffs>
+            <BitOffs>1296729664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -98326,7 +104215,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300444096</BitOffs>
+            <BitOffs>1297057088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -98364,7 +104253,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300470016</BitOffs>
+            <BitOffs>1297083008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -98402,7 +104291,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300521856</BitOffs>
+            <BitOffs>1297134848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -98440,7 +104329,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300547776</BitOffs>
+            <BitOffs>1297160768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -98477,7 +104366,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300573696</BitOffs>
+            <BitOffs>1297186688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -98509,7 +104398,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300599616</BitOffs>
+            <BitOffs>1297212608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -98547,7 +104436,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300625536</BitOffs>
+            <BitOffs>1297238528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -98558,7 +104447,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300651456</BitOffs>
+            <BitOffs>1297264448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -98595,7 +104484,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300978880</BitOffs>
+            <BitOffs>1297591872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -98606,7 +104495,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301004800</BitOffs>
+            <BitOffs>1297617792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -98644,7 +104533,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301332224</BitOffs>
+            <BitOffs>1297945216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -98655,7 +104544,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301358144</BitOffs>
+            <BitOffs>1297971136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -98692,7 +104581,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301685568</BitOffs>
+            <BitOffs>1298298560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -98703,7 +104592,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301711488</BitOffs>
+            <BitOffs>1298324480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -98741,7 +104630,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302038912</BitOffs>
+            <BitOffs>1298651904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -98774,7 +104663,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302064832</BitOffs>
+            <BitOffs>1298677824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -98785,7 +104674,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302090752</BitOffs>
+            <BitOffs>1298703744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -98819,7 +104708,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302418176</BitOffs>
+            <BitOffs>1299031168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -98830,7 +104719,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302444096</BitOffs>
+            <BitOffs>1299057088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -98864,7 +104753,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302771520</BitOffs>
+            <BitOffs>1299384512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -98898,7 +104787,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302797440</BitOffs>
+            <BitOffs>1299410432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -98932,7 +104821,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302823360</BitOffs>
+            <BitOffs>1299436352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -98966,7 +104855,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302849280</BitOffs>
+            <BitOffs>1299462272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -99000,7 +104889,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302875200</BitOffs>
+            <BitOffs>1299488192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -99029,7 +104918,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302901120</BitOffs>
+            <BitOffs>1299514112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -99061,7 +104950,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302927040</BitOffs>
+            <BitOffs>1299540032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -99072,7 +104961,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302952960</BitOffs>
+            <BitOffs>1299565952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -99104,7 +104993,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303280384</BitOffs>
+            <BitOffs>1299893376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -99115,7 +105004,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303306304</BitOffs>
+            <BitOffs>1299919296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -99147,7 +105036,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303633728</BitOffs>
+            <BitOffs>1300246720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -99158,7 +105047,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303659648</BitOffs>
+            <BitOffs>1300272640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -99190,7 +105079,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303987072</BitOffs>
+            <BitOffs>1300600064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -99201,7 +105090,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304012992</BitOffs>
+            <BitOffs>1300625984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -99233,7 +105122,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304340416</BitOffs>
+            <BitOffs>1300953408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -99244,7 +105133,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304366336</BitOffs>
+            <BitOffs>1300979328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -99276,7 +105165,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304693760</BitOffs>
+            <BitOffs>1301306752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -99287,7 +105176,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304719680</BitOffs>
+            <BitOffs>1301332672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -99319,7 +105208,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305047104</BitOffs>
+            <BitOffs>1301660096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -99330,7 +105219,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305073024</BitOffs>
+            <BitOffs>1301686016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -99362,7 +105251,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305400448</BitOffs>
+            <BitOffs>1302013440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -99373,7 +105262,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305426368</BitOffs>
+            <BitOffs>1302039360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -99405,7 +105294,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305753792</BitOffs>
+            <BitOffs>1302366784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -99416,7 +105305,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305779712</BitOffs>
+            <BitOffs>1302392704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -99448,7 +105337,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306107136</BitOffs>
+            <BitOffs>1302720128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -99459,7 +105348,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306133056</BitOffs>
+            <BitOffs>1302746048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -99491,7 +105380,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306460480</BitOffs>
+            <BitOffs>1303073472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -99502,7 +105391,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306486400</BitOffs>
+            <BitOffs>1303099392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -99534,7 +105423,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306813824</BitOffs>
+            <BitOffs>1303426816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -99545,7 +105434,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306839744</BitOffs>
+            <BitOffs>1303452736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -99577,7 +105466,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307167168</BitOffs>
+            <BitOffs>1303780160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -99588,7 +105477,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307193088</BitOffs>
+            <BitOffs>1303806080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -99599,7 +105488,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520544</BitOffs>
+            <BitOffs>1304133536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -99614,7 +105503,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520560</BitOffs>
+            <BitOffs>1304133552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -99629,7 +105518,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520568</BitOffs>
+            <BitOffs>1304133560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -99659,7 +105548,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520576</BitOffs>
+            <BitOffs>1304133568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -99689,7 +105578,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520640</BitOffs>
+            <BitOffs>1304133632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -99704,7 +105593,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520704</BitOffs>
+            <BitOffs>1304133696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -99719,7 +105608,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520720</BitOffs>
+            <BitOffs>1304133712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -99734,7 +105623,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520736</BitOffs>
+            <BitOffs>1304133728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -99748,7 +105637,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520744</BitOffs>
+            <BitOffs>1304133736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -99763,7 +105652,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520768</BitOffs>
+            <BitOffs>1304133760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -99778,7 +105667,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520800</BitOffs>
+            <BitOffs>1304133792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -99899,7 +105788,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307520832</BitOffs>
+            <BitOffs>1304133824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -99913,7 +105802,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530304</BitOffs>
+            <BitOffs>1304143296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -99927,7 +105816,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307530336</BitOffs>
+            <BitOffs>1304143328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -99948,7 +105837,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307533952</BitOffs>
+            <BitOffs>1304146944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -100020,7 +105909,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307551872</BitOffs>
+            <BitOffs>1304164864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -100092,7 +105981,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307552000</BitOffs>
+            <BitOffs>1304164992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -100164,7 +106053,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307552128</BitOffs>
+            <BitOffs>1304165120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -100236,7 +106125,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307552256</BitOffs>
+            <BitOffs>1304165248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -100308,7 +106197,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307552384</BitOffs>
+            <BitOffs>1304165376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -100380,7 +106269,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307552512</BitOffs>
+            <BitOffs>1304165504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -100406,14 +106295,420 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307585536</BitOffs>
+            <BitOffs>1304198528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR1K2:SWITCH:COATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1304232480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR1K2:SWITCH:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1304232496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>FB_DynMem_Manager.nInstanceCreations</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarStatic</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309482960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
+            <Comment> CC929187-3970-4CF4-8F39-946BEC12422D</Comment>
+            <BitSize>128</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.Data1</Name>
+                <Value>3432157575</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data2</Name>
+                <Value>14704</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data3</Name>
+                <Value>19700</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[0]</Name>
+                <Value>143</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[1]</Name>
+                <Value>57</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[2]</Name>
+                <Value>148</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[3]</Name>
+                <Value>107</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[4]</Name>
+                <Value>236</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[5]</Name>
+                <Value>18</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[6]</Name>
+                <Value>66</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[7]</Name>
+                <Value>45</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused;ST_TcIPCDiagEventClass</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310898048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
+            <Comment> 20226F4C-54BA-479F-BA48-FBE52D0E9CD5</Comment>
+            <BitSize>128</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000021}">GUID</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.Data1</Name>
+                <Value>539127628</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data2</Name>
+                <Value>21690</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data3</Name>
+                <Value>18335</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[0]</Name>
+                <Value>186</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[1]</Name>
+                <Value>72</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[2]</Name>
+                <Value>251</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[3]</Name>
+                <Value>229</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[4]</Name>
+                <Value>45</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[5]</Name>
+                <Value>14</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[6]</Name>
+                <Value>156</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.Data4[7]</Name>
+                <Value>213</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcTypeSystem</Name>
+              </Property>
+              <Property>
+                <Name>tc_no_symbol</Name>
+                <Value>unused;ST_TcIPCDiagPlcApiEventClass</Value>
+              </Property>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>suppress_warning_0</Name>
+                <Value>C0228</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310900352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc3_IPCDiag</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>12</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>1.0.12.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311509504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc3_DynamicMemory</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>1.0.2.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311618688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_Grating_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: SP1K1:MONO:GRATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311619024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_Grating_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: SP1K1:MONO:GRATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311619040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
+            <BitSize>98368</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)DB
+        io: io
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311930688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbYSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1313955392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.astCoatingStatesY</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1314047744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.stDefaultGH</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>875</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fAccel</Name>
+                <Value>6923</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fDecel</Name>
+                <Value>6923</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bUseRawCounts</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <BitOffs>1314102464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGHSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1315647232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.astGratingStates</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1315739584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates</Name>
+            <BitSize>1541312</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR1K2:SWITCH:COATING</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317959040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates</Name>
+            <BitSize>1541312</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: SP1K1:MONO:GRATING</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1319500352</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164560896</ByteSize>
+          <ByteSize>165216256</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -100485,6 +106780,12 @@ M4K2 KBV X ENC CNT</Comment>
         <EventClass>
           <Type GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">LCLSGeneralEventClass</Type>
         </EventClass>
+        <EventClass>
+          <Type GUID="{CC929187-3970-4CF4-8F39-946BEC12422D}">TcIPCDiagEventClass</Type>
+        </EventClass>
+        <EventClass>
+          <Type GUID="{20226F4C-54BA-479F-BA48-FBE52D0E9CD5}">TcIPCDiagPlcApiEventClass</Type>
+        </EventClass>
       </EventClasses>
       <Properties>
         <Property>
@@ -100493,15 +106794,15 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-09-23T15:15:32</Value>
+          <Value>2024-09-23T15:39:50</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1019904</Value>
+          <Value>1081344</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>163098624</Value>
+          <Value>163110912</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D3536589-6C9E-F8E7-97C3-534B02FC8E7C}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D56FD35A-A82E-BED9-95CE-C5B9B904C156}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10419,31 +10419,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163051576</GetCodeOffs>
+        <GetCodeOffs>163477768</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163051648</GetCodeOffs>
+        <GetCodeOffs>163477840</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163051664</GetCodeOffs>
+        <GetCodeOffs>163477856</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163051624</GetCodeOffs>
+        <GetCodeOffs>163477816</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163051656</GetCodeOffs>
+        <GetCodeOffs>163477848</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11695,15 +11695,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163051448</GetCodeOffs>
-        <SetCodeOffs>163051496</SetCodeOffs>
+        <GetCodeOffs>163477640</GetCodeOffs>
+        <SetCodeOffs>163477688</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163051528</GetCodeOffs>
-        <SetCodeOffs>163051552</SetCodeOffs>
+        <GetCodeOffs>163477720</GetCodeOffs>
+        <SetCodeOffs>163477744</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11944,31 +11944,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>163051760</GetCodeOffs>
+        <GetCodeOffs>163477952</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163051720</GetCodeOffs>
+        <GetCodeOffs>163477912</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163051896</GetCodeOffs>
+        <GetCodeOffs>163478088</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163051904</GetCodeOffs>
+        <GetCodeOffs>163478096</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163051816</GetCodeOffs>
+        <GetCodeOffs>163478008</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11980,7 +11980,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163051912</GetCodeOffs>
+        <GetCodeOffs>163478104</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12573,7 +12573,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163051968</GetCodeOffs>
+        <GetCodeOffs>163478160</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -36985,7 +36985,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>163063608</GetCodeOffs>
+        <GetCodeOffs>163489816</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -38913,31 +38913,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163063008</GetCodeOffs>
+        <GetCodeOffs>163489216</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>163063096</GetCodeOffs>
+        <GetCodeOffs>163489304</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163063024</GetCodeOffs>
+        <GetCodeOffs>163489232</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>163063072</GetCodeOffs>
+        <GetCodeOffs>163489280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>163063112</GetCodeOffs>
+        <GetCodeOffs>163489320</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -54778,142 +54778,34 @@ Use this thing to have a simple indexer with rollover.
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="LCLS_General">FB_TempSensor</Name>
-      <BitSize>256</BitSize>
-      <SubItem>
-        <Name>fResolution</Name>
-        <Type>LREAL</Type>
-        <Comment> Resolution parameter from the Beckhoff docs. Default is 0.1 for 0.1 degree resolution</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0.1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fTemp</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: TEMP
-        io: input
-        field: EGU C
-        field: PREC 2
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bConnected</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: CONN
-        io: input
-        field: ONAM Connected
-        field: ZNAM Disconnected
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: input
-        field: ONAM True
-        field: ZNAM False
-    </Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUnderrange</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>208</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bOverrange</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iRaw</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
+      <Name>E_B4C_Rh_CoatingStates</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>B4C</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Rh</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
       <Properties>
         <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
         </Property>
       </Properties>
     </DataType>
@@ -55136,767 +55028,6 @@ Use this thing to have a simple indexer with rollover.
         <BitSize>2496</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
-      <BitSize>3200</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <Comment> State to move to</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Start move on rising edge, stop move on falling edge</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GO
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> Rising edge error reset</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>enumMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
-        <Comment> Define behavior for when a move is already active</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>208</BitOffs>
-        <Default>
-          <EnumText>E_MotionRequest.WAIT</EnumText>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAtState</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if the motor is at this state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: AT_STATE
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we have an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <Comment> Error code</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Error description</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: input
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we are moving to a state</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> TRUE if we are not moving and we reached a state successfully on our last move</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>944</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: input
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbMotionRequest</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
-        <BitSize>1920</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>2880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>3008</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerExec</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3136</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAllowMove</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLatchAllowErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>3168</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_RawCountConverter</Name>
-      <BitSize>8576</BitSize>
-      <SubItem>
-        <Name>stParameters</Name>
-        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
-        <Comment> Parameters to check against</Comment>
-        <BitSize>8192</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountCheck</Name>
-        <Type>UDINT</Type>
-        <Comment> Optional count to convert to a real position</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosCheck</Name>
-        <Type>LREAL</Type>
-        <Comment> Optional position to convert to encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCountGet</Name>
-        <Type>UDINT</Type>
-        <Comment> If converting position, the number of counts</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>8384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosGet</Name>
-        <Type>LREAL</Type>
-        <Comment> If converting counts, the position</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>8448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> True during a parameter get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> True after a successful get/calc</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8520</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> True if the calculation errored</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateLock</Name>
-      <BitSize>3904</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stCachedPositionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3840</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternal</Name>
-      <BitSize>12672</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbEncConverter</Name>
-        <Type Namespace="lcls_twincat_motion">FB_RawCountConverter</Type>
-        <BitSize>8576</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbLock</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateLock</Type>
-        <BitSize>3904</BitSize>
-        <BitOffs>8768</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
-      <BitSize>256512</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnable</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> On rising edge, reset this FB</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RESET
-        io: io
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, there is an error</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERR
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorId</Name>
-        <Type>UDINT</Type>
-        <Comment> Error ID</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sErrorMessage</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The error that caused bError to flip TRUE</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ERRMSG
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are moving the motor</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>840</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: BUSY
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bDone</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>848</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DONE
-        io: i
-        field: ZNAM False
-        field: ONAM True
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> Pre-allocated array of states</Comment>
-        <BitSize>54720</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv:
-        io: io
-        expand: %.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>setState</Name>
-        <Type>INT</Type>
-        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>goalState</Name>
-        <Type>INT</Type>
-        <Comment> The current position we are trying to reach, or 0</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
-        <Comment> The readback position</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>55648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>55664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stUnknown</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>55680</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoal</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>59328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateMove</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
-        <BitSize>3200</BitSize>
-        <BitOffs>62976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStateInternal</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>190080</BitSize>
-        <BitOffs>66176</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>256256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bNewGoal</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256272</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerExec</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInnerReset</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReset</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>256320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveRequested</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256448</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>StateHandler</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionState1D instead</Value>
-        </Property>
-      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="PMPS">I_HigherAuthority</Name>
@@ -57220,8 +56351,514 @@ ELSE:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</Name>
-      <BitSize>20096</BitSize>
+      <Name Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>nSetValue</Name>
+        <Type>UINT</Type>
+        <Comment> For internal use only. This holds new goal positions as an integer, else it is 0 if there is no new state move request. It is written to from the user's input enum.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to acknowledge and clear an error.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Name>
+      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>bArbiterEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> User setting: TRUE to enable the arbiter, FALSE to disable it.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:ARB:ENABLE
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <Comment> User setting: TRUE to enable maintenance mode (Fast fault, free motion), FALSE to disable it.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:MAINT
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Name>
+      <BitSize>768</BitSize>
+      <SubItem>
+        <Name>nGetValue</Name>
+        <Type>UINT</Type>
+        <Comment> For internal use only. This holds the current position index as an integer, else it is 0 if we are changing states or not at any particular state.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE when we are in an active state move and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE after a move completes and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be TRUE if the most recent move had an error and FALSE otherwise.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> This will be set to an NC error code during an error if one exists or left at 0 otherwise.</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMsg</Name>
+        <Type>STRING(80)</Type>
+        <Comment> This will be set to an appropriate error message during an error if one exists or left as an empty string otherwise.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Name>
+      <BitSize>2496</BitSize>
+      <SubItem>
+        <Name>stTransitionDb</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The database entry for the transition state. This should always be present.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: PMPS:TRANS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatesInputHandler</Name>
+      <BitSize>384</BitSize>
+      <SubItem>
+        <Name>stUserInput</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> The user's inputs from EPICS. This is an IN_OUT variable because we will write values back to this to help us detect when the same value is re-caput</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> The bBusy boolean from the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nStartingState</Name>
+        <Type>UINT</Type>
+        <Comment> The starting state number to seed nCurrGoal with</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have a move error, to prevent moves</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The goal index to input to the motion FB. This will be clamped to the range 0..GeneralConstants.MAX_STATES</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>176</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecMove</Name>
+        <Type>BOOL</Type>
+        <Comment> The bExecute boolean to input to the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetMove</Name>
+        <Type>BOOL</Type>
+        <Comment> The bReset boolean to input to the motion FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nState</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nQueuedGoal</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>240</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCachedStart</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>IDLE</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>288</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>GOING</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>304</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>WAIT_STOP</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>2</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_RawCountConverter</Name>
+      <BitSize>8576</BitSize>
+      <SubItem>
+        <Name>stParameters</Name>
+        <Type Namespace="Tc2_MC2">ST_AxisParameterSet</Type>
+        <Comment> Parameters to check against</Comment>
+        <BitSize>8192</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCountCheck</Name>
+        <Type>UDINT</Type>
+        <Comment> Optional count to convert to a real position</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosCheck</Name>
+        <Type>LREAL</Type>
+        <Comment> Optional position to convert to encoder counts</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>8320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCountGet</Name>
+        <Type>UDINT</Type>
+        <Comment> If converting position, the number of counts</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>8384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosGet</Name>
+        <Type>LREAL</Type>
+        <Comment> If converting counts, the position</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>8448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> True during a parameter get/calc</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> True after a successful get/calc</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8520</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> True if the calculation errored</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8528</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateLock</Name>
+      <BitSize>3904</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCachedPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3840</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternal</Name>
+      <BitSize>12672</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -57235,12 +56872,8 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>arrStates</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
         <BitSize>64</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
@@ -57251,23 +56884,160 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bArbiterEnabled</Name>
+        <Name>fbEncConverter</Name>
+        <Type Namespace="lcls_twincat_motion">FB_RawCountConverter</Type>
+        <BitSize>8576</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLock</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateLock</Type>
+        <BitSize>3904</BitSize>
+        <BitOffs>8768</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Name>
+      <BitSize>570496</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All the motors to apply the standard routines to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbStateInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> The individual instantiated internal FBs. Must have the same bounds as astPositionState.</Comment>
+        <BitSize>570240</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotors</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>570432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterStates</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>570464</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateMove</Name>
+      <BitSize>3200</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <Comment> State to move to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
         <Type>BOOL</Type>
+        <Comment> Start move on rising edge, stop move on falling edge</Comment>
         <BitSize>8</BitSize>
         <BitOffs>192</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
         <Properties>
           <Property>
             <Name>ItemType</Name>
             <Value>Input</Value>
           </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GO
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bMaintMode</Name>
+        <Name>bReset</Name>
         <Type>BOOL</Type>
+        <Comment> Rising edge error reset</Comment>
         <BitSize>8</BitSize>
         <BitOffs>200</BitOffs>
         <Properties>
@@ -57278,15 +57048,255 @@ ELSE:
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: MAINT
+        pv: RESET
         io: io
+        field: ZNAM False
+        field: ONAM True
     </Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bRequestTransition</Name>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when a move is already active</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
         <Type>BOOL</Type>
+        <Comment> TRUE if the motor is at this state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: AT_STATE
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we have an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> Error code</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Error description</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: input
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we are moving to a state</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>936</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we are not moving and we reached a state successfully on our last move</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>944</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: input
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionRequest</Type>
+        <BitSize>1920</BitSize>
+        <BitOffs>960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>2880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>3008</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerExec</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3136</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAllowMove</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLatchAllowErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>3168</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Name>
+      <BitSize>10752</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Array of motors to move together</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> 1D Position states: the current position to send each axis to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Start all moves on rising edge, stop all moves on falling edge</Comment>
         <BitSize>8</BitSize>
         <BitOffs>208</BitOffs>
         <Properties>
@@ -57297,10 +57307,11 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>setState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>224</BitOffs>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> Reset any errors</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -57309,67 +57320,118 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>getState</Name>
-        <Type>INT</Type>
+        <Name>enumMotionRequest</Name>
+        <Type Namespace="lcls_twincat_motion">E_MotionRequest</Type>
+        <Comment> Define behavior for when a move request is interrupted with a new request</Comment>
         <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Default>
+          <EnumText>E_MotionRequest.WAIT</EnumText>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ALL of the motors are at their goal states</Comment>
+        <BitSize>8</BitSize>
         <BitOffs>240</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
+            <Value>Output</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>fStateBoundaryDeadband</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ANY of this FB's moves are in progress</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>248</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
+            <Value>Output</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>tArbiterTimeout</Name>
-        <Type>TIME</Type>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ALL motors have completed the last move request from this FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if ANY of this FB's moves had an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>264</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorCount</Name>
+        <Type>UINT</Type>
+        <Comment> How many FBs are erroring</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nShownError</Name>
+        <Type>DINT</Type>
+        <Comment> Which component is the source of the example/summarized error</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorID</Name>
+        <Type>UDINT</Type>
+        <Comment> One of the error ids</Comment>
         <BitSize>32</BitSize>
         <BitOffs>320</BitOffs>
-        <Default>
-          <DateTime>T#1s</DateTime>
-        </Default>
         <Properties>
           <Property>
             <Name>ItemType</Name>
-            <Value>Input</Value>
+            <Value>Output</Value>
           </Property>
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bMoveOnArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The error error message matching the ID</Comment>
+        <BitSize>648</BitSize>
         <BitOffs>352</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bTransitionAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>360</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -57378,276 +57440,515 @@ ELSE:
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bForwardAuthorized</Name>
+        <Name>afbPositionStateMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> 1D State movers: FBs to move the motors</Comment>
+        <BitSize>9600</BitSize>
+        <BitOffs>1024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>368</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
+        <BitOffs>10656</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bBackwardAuthorized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>376</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
+        <Name>nLowerBound</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10688</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>bArbiterTimeout</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionDb</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <BitSize>2496</BitSize>
-        <BitOffs>416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: TRANS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionBeam</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>2912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stTransitionState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>4672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8320</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bTransDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8328</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTransReq</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBPTMDone</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtBPTMDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftMotorExec</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTransDone</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtDoLateFinish</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>8960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonDone</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>9088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stStateReq</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>9344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>mcPower</Name>
-        <Type Namespace="Tc2_MC2">MC_Power</Type>
-        <BitSize>960</BitSize>
-        <BitOffs>12992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fUpperBound</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>13952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fLowerBound</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>14016</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nGoalState</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>14080</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stGoalState</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>14144</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fActPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>17792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fReqPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>17856</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInTransition</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>17920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stBeamNeeded</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>17952</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFwdOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBwdOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>19720</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tonArbiter</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>256</BitSize>
-        <BitOffs>19776</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLateFinish</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20032</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInternalAuth</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20040</BitOffs>
+        <Name>nUpperBound</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>10720</BitOffs>
       </SubItem>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>DoStateMoves</Name>
       </Action>
       <Action>
-        <Name>HandleBPTM</Name>
+        <Name>CheckCount</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
+        <Name>CombineOutputs</Name>
       </Action>
-      <Action>
-        <Name>ClearAsserts</Name>
-      </Action>
-      <Action>
-        <Name>Exec</Name>
-      </Action>
-      <Action>
-        <Name>HandlePmpsDb</Name>
-      </Action>
-      <Method>
-        <Name>GetBeamFromState</Name>
-        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
-        <ReturnBitSize>1760</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Local>
-          <Name>stState</Name>
-          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-          <BitSize>3648</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetStateCode</Name>
-        <ReturnType>INT</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetStateStruct</Name>
-        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
-        <ReturnBitSize>3648</ReturnBitSize>
-        <Parameter>
-          <Name>nState</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateRead</Name>
+      <BitSize>4096</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to check the state of</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> The allowed states for this motor</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're standing still at a known state, or moving within the bounds of a state to another location in the bounds.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMovingState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're moving to some other state or to another non-state position.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nPositionIndex</Name>
+        <Type>UINT</Type>
+        <Comment> If we're at a known state, this will be the index in the astPositionState array that matches the state. Otherwise, this will be 0, which is below the bounds of the array, so it cannot be confused with a valid output.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentPosition</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <Comment> A copy of the details of the current position state, for convenience. This may be a moving state or an unknown state as a placeholder if we are not at a known state.</Comment>
+        <BitSize>3648</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abAtPosition</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> A full description of whether we're at each of our states. This is used in 2D, 3D, etc. to clarify cases where states may overlap in 1D.</Comment>
+        <BitSize>120</BitSize>
+        <BitOffs>3904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>4032</BitOffs>
+      </SubItem>
+      <Properties>
         <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateReadND</Name>
+      <BitSize>12736</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The motors with a combined N-dimensional state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're standing still at a known state.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMovingState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're moving, there can be no valid state if we are moving.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nPositionIndex</Name>
+        <Type>UINT</Type>
+        <Comment> If we're at a known state, this will be the state index along the enclosed states arrays. Otherwise, it will be zero, which is below the bounds of the states array.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if the active motor count was invalid</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abAtPosition</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> A full description of whether we're at each of our states. This is used to clarify cases where states may overlap.</Comment>
+        <BitSize>120</BitSize>
+        <BitOffs>248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbPositionStateRead</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateRead</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The individual position state reader function blocks</Comment>
+        <BitSize>12288</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter2</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>12688</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>DoStateReads</Name>
+      </Action>
+      <Action>
+        <Name>CombineOutputs</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Name>
+      <BitSize>609536</BitSize>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All position states for all motors, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbInput</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatesInputHandler</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternalND</Type>
+        <BitSize>570496</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMoveND</Type>
+        <BitSize>10752</BitSize>
+        <BitOffs>571392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbRead</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateReadND</Type>
+        <BitSize>12736</BitSize>
+        <BitOffs>582144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMoveGoals</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>10944</BitSize>
+        <BitOffs>594880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stInvalidPos</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>605824</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotor</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>609472</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -57964,6 +58265,246 @@ ELSE:
           <BitSize>16</BitSize>
         </Local>
       </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Name>
+      <BitSize>205632</BitSize>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction. These will not be modified.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The database lookup key for the transition state. This has no corresponding ST_PositionState.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to use for fast faults, etc.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>840</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadNow</Name>
+        <Type>BOOL</Type>
+        <Comment> For debug: set this to TRUE in online mode to read the database immediately.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1488</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> The raw lookup results from this FB. Index 0 is the transition beam, the rest of the indices match the state positions.</Comment>
+        <BitSize>39936</BitSize>
+        <BitOffs>1504</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstReadDone</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we've had at least one successful read.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>41440</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> This will be set to TRUE if there was an error reading from the database.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>41448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ffError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>41472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadPmpsDb</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>115008</BitSize>
+        <BitOffs>67392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftDbBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>182400</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftRead</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>182528</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>182656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterMotor</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>182688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterState</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>182720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIterState2</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>182752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sLoopNewKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>182784</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sLoopPrevKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>183432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>abStateError</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>128</BitSize>
+        <BitOffs>184080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>asLookupKeys</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>10368</BitSize>
+        <BitOffs>184208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>asPrevLookupKeys</Name>
+        <Type>STRING(80)</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>10368</BitSize>
+        <BitOffs>194576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewKeys</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>204944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sTempBackfill</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>204952</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>SelectLookupKeys</Name>
+      </Action>
+      <Action>
+        <Name>BackfillInfo</Name>
+      </Action>
+      <Action>
+        <Name>ReadDatabase</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -58543,14 +59084,31 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Name>
-      <BitSize>396032</BitSize>
-      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</ExtendsType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionBPTM</Name>
+      <BitSize>115072</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Array of motors that will move for this beam transition</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
       <SubItem>
         <Name>fbArbiter</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam states from</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>20096</BitOffs>
+        <BitOffs>128</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -58561,8 +59119,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       <SubItem>
         <Name>fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>20160</BitOffs>
+        <BitOffs>192</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -58571,46 +59130,37 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPmpsDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>20232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>20880</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPmpsDoc</Name>
-        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <Name>stGoalParams</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
+        <Comment> The parameters we want to transition to</Comment>
         <BitSize>64</BitSize>
-        <BitOffs>21568</BitOffs>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransParams</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">ST_DbStateParams</Type>
+        <Comment> The parameters we want to use during the transition</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>384</BitOffs>
         <Properties>
           <Property>
             <Name>ItemType</Name>
@@ -58619,24 +59169,52 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>stHighBeamThreshold</Name>
-        <Type Namespace="PMPS">ST_BeamParams</Type>
-        <BitSize>1760</BitSize>
-        <BitOffs>21632</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBPOKAutoReset</Name>
+        <Name>bEnable</Name>
         <Type>BOOL</Type>
+        <Comment> Set to TRUE to use the BPTM, FALSE to stop using the BPTM.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>23392</BitOffs>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAtState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're at the physical state that matches the goal parameters</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A device name to use in the GUI</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> How long to wait for parameters before timing out</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1088</BitOffs>
         <Default>
-          <Bool>false</Bool>
+          <DateTime>T#1s</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -58646,140 +59224,884 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>arrPMPS</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>16</Elements>
-        </ArrayInfo>
-        <BitSize>39936</BitSize>
-        <BitOffs>23424</BitOffs>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether to fault and move on timeout (TRUE) or to wait (FALSE)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1120</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nBPIndex</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>63360</BitOffs>
+        <Name>bResetBPTMTimeout</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE when it is safe to reset the BPTM timeout fast fault, to reset it early.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nTransitionAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>63392</BitOffs>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> This becomes TRUE when the motors are allowed to move to their destinations.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>nLastReqAssertionID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>63424</BitOffs>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> This becomes TRUE once the full beam transition is done.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
-        <Name>fbReadPmpsDb</Name>
-        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
-        <BitSize>115008</BitSize>
-        <BitOffs>63488</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftDbBusy</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>178496</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtReadDBExec</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>178624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftRead</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>178752</BitOffs>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're using a bad motor count</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
       </SubItem>
       <SubItem>
         <Name>bptm</Name>
         <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
         <BitSize>61568</BitSize>
-        <BitOffs>178880</BitOffs>
+        <BitOffs>1216</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>ffBeamParamsOk</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>240448</BitOffs>
+        <Name>bDoneMoving</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>62784</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>ffZeroRate</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>266368</BitOffs>
+        <Name>nPrevID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>62816</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>62848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInternalAuth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>62880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bDoneResetQueued</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>62888</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonArbiter</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>62912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>63168</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffBPTMTimeoutAndMove</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>292288</BitOffs>
+        <BitOffs>63232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffBPTMError</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25920</BitSize>
-        <BitOffs>318208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffMaint</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>344128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ffUnknown</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25920</BitSize>
-        <BitOffs>370048</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bFFOxOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>395968</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bAtSafeState</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>395976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIter</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>395984</BitOffs>
+        <BitOffs>89152</BitOffs>
       </SubItem>
       <Action>
-        <Name>HandlePmpsDb</Name>
+        <Name>HandleTimeout</Name>
       </Action>
       <Action>
-        <Name>HandleFFO</Name>
+        <Name>SetDoneMoving</Name>
       </Action>
       <Action>
-        <Name>AssertHere</Name>
+        <Name>CheckCount</Name>
       </Action>
       <Action>
-        <Name>ClearAsserts</Name>
-      </Action>
-      <Action>
-        <Name>HandleBPTM</Name>
+        <Name>RunBPTM</Name>
       </Action>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
         </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Name>
+      <BitSize>448</BitSize>
+      <SubItem>
+        <Name>astDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <Comment> All states to deactivate: transition + the static position states</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter who made the PMPS assert requests</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Clear asserts on rising edge</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <Properties>
         <Property>
-          <Name>obsolete</Name>
-          <Value>Use FB_PositionStatePMPS1D instead</Value>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">E_StatePMPSStatus</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>UNKNOWN</Text>
+        <Enum>0</Enum>
+        <Comment> No other enum state describes it</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TRANSITION</Text>
+        <Enum>1</Enum>
+        <Comment> Moving toward a known state</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>AT_STATE</Text>
+        <Enum>2</Enum>
+        <Comment> Within a known state, not trying to leave</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>DISABLED</Text>
+        <Enum>3</Enum>
+        <Comment> PMPS is in some way disabled, either with maint mode or arbiter disable</Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Name>
+      <BitSize>27456</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor with a position state.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for this motor.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, do the limits as normal. If FALSE, allow all moves regardless of the limits defined here.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalStateIndex</Name>
+        <Type>UINT</Type>
+        <Comment> The state that the motor is moving to.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <Comment> The overal PMPS FB state</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect to the BPTM</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>312</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForwardEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBackwardEnabled</Name>
+        <Type>BOOL</Type>
+        <Comment> The backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValidGoal</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>mc_power</Name>
+        <Type Namespace="Tc2_MC2">MC_Power</Type>
+        <BitSize>960</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nPrevStateIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLowerPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fUpperPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffNoGoal</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>1536</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>SetEnables</Name>
+      </Action>
+      <Action>
+        <Name>ApplyEnables</Name>
+      </Action>
+      <Action>
+        <Name>GetBounds</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Name>
+      <BitSize>135360</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The motors with a combined N-dimensional state</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Each motor's respective position states along its direction</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Hardware output to fault to if there is a problem.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether or not to do anything</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalStateIndex</Name>
+        <Type>UINT</Type>
+        <Comment> The state that the motors are moving to, along dimension 2 of the position state array. This may be the same as the current state.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to use for this state mover in the case of fast faults.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE to put motors into maintenance mode. This allows us to freely move the motors at the cost of a fast fault.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <Comment> The overal PMPS FB state</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <Comment> Connect from bptm bTransitionAuthorized</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>976</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor enable state we send to MC_Power. This is a pass-through from stMotionStage.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>984</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abForwardEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor forward enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>1008</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abBackwardEnabled</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor backwards enable state we send to MC_Power. This may be a pass-through or an override to FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>1032</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>abValidGoal</Name>
+        <Type>BOOL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> Per-motor TRUE if there is a valid goal position and FALSE otherwise. This makes a fast fault if FALSE.</Comment>
+        <BitSize>24</BitSize>
+        <BitOffs>1056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE if the arrays have mismatched sizing. For this FB, this means the motor won't ever get an enable.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1080</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbStateEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnables</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> The individual state limit function blocks</Comment>
+        <BitSize>82368</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffMaint</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>83456</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffProgrammerError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>109376</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>135296</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>DoLimits</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Action>
+        <Name>RunFastFaults</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Name>
+      <BitSize>106944</BitSize>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam states from</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> A name to link to these fast faults</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stCurrentBeamReq</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <Comment> Current requested beam details: either a known state or the transition beam</Comment>
+        <BitSize>1760</BitSize>
+        <BitOffs>864</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bKnownState</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE if we're at a known state (doesn't matter which)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTransitionID</Name>
+        <Type>DWORD</Type>
+        <Comment> Lookup ID of the transition beam</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2656</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMaxTrips</Name>
+        <Type>UINT</Type>
+        <Comment> Number of consecutive trips before we debounce</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2688</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>tTripReset</Name>
+        <Type>TIME</Type>
+        <Comment> Decrease trip count by 1 after this much time has passed</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>2720</BitOffs>
+        <Default>
+          <DateTime>T#1s</DateTime>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ffBeamParamsOk</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> If the beam parameters are wrong, it is a fault! This encompasses all unknown arbiter-related errors.</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>2752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffZeroRate</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> If we asked for zero rate (NC or SC) then we can cut the beam early. This is somewhat redundant.</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>28672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffUnknown</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Trip the beam for unknown state</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>54592</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffDebounce</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <Comment> Trip the beam (no autoreset) if ffBeamParamsOK faults/resets multiple times too quickly.</Comment>
+        <BitSize>25920</BitSize>
+        <BitOffs>80512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTripCount</Name>
+        <Type>UINT</Type>
+        <Comment> Number of consecutive trips so far</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>106432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftTripCount</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <Comment> Increase by 1 whenever there is a fault (rising edge)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>106496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonTripCount</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <Comment> Decrease trip count by 1 each timeout</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>106624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCycle</Name>
+        <Type>BOOL</Type>
+        <Comment> TRUE on only the first cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>106880</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
         </Property>
       </Properties>
     </DataType>
@@ -59035,6 +60357,2046 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Name>
+      <BitSize>114048</BitSize>
+      <SubItem>
+        <Name>astMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors associated with the state mover.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> Fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> The number of motors we're actually using</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Identifying name to use in group fast faults</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMotorCountError</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE if the arrays don't have the same bounds. In this FB, that's an automatic fault.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>afbEncError</Name>
+        <Type Namespace="lcls_twincat_motion">FB_EncErrorFFO</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>87168</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffProgrammerError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>88064</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>113984</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>HandleLoops</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>CheckCount</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Name>
+      <BitSize>682048</BitSize>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <Comment> All motors to be used in the states move, including blank/uninitialized structs.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0" ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All position states for all motors, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>584</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nActiveMotorCount</Name>
+        <Type>UINT</Type>
+        <Comment> Set this to the number of motors to be included in astMotionStageMax</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGoal</Name>
+        <Type>UINT</Type>
+        <Comment> The current position index goal, where the motors are supposed to be moving towards.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1920</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>1952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionReadPMPSDB</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionReadPMPSDBND</Type>
+        <BitSize>205632</BitSize>
+        <BitOffs>4480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionBPTM</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionBPTM</Type>
+        <BitSize>115072</BitSize>
+        <BitOffs>210112</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMotionClearAsserts</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MotionClearAsserts</Type>
+        <BitSize>448</BitSize>
+        <BitOffs>325184</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStatePMPSEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_StatePMPSEnablesND</Type>
+        <BitSize>135360</BitSize>
+        <BitOffs>325632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMiscStatesErrorFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_MiscStatesErrorFFO</Type>
+        <BitSize>106944</BitSize>
+        <BitOffs>460992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPerMotorFFO</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PerMotorFFOND</Type>
+        <BitSize>114048</BitSize>
+        <BitOffs>567936</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eStatePMPSStatus</Name>
+        <Type Namespace="lcls_twincat_motion">E_StatePMPSStatus</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>681984</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
+      <BitSize>1541120</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The motor to move.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1776</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
+        <Comment> PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1808</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1824</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>1856</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>2624</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>5120</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
+        <BitSize>609536</BitSize>
+        <BitOffs>7616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPMPSCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
+        <BitSize>682048</BitSize>
+        <BitOffs>617152</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>77760</BitSize>
+        <BitOffs>1299200</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>164160</BitSize>
+        <BitOffs>1376960</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
+      <BitSize>92352</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSetDefault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForceUpdate</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDecel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bLocked</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUseRawCounts</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPmpsState</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDefault</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbWarning</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>86080</BitSize>
+        <BitOffs>5568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHasDefault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>91648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHasWarned</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>91656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sJson</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>91664</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_TempSensor</Name>
+      <BitSize>256</BitSize>
+      <SubItem>
+        <Name>fResolution</Name>
+        <Type>LREAL</Type>
+        <Comment> Resolution parameter from the Beckhoff docs. Default is 0.1 for 0.1 degree resolution</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0.1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fTemp</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TEMP
+        io: input
+        field: EGU C
+        field: PREC 2
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bConnected</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: CONN
+        io: input
+        field: ONAM Connected
+        field: ZNAM Disconnected
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUnderrange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bOverrange</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iRaw</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>E_Grating_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>LRG</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Unruled</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>YAG</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MEG</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>HEG</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>LEG</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStateBase</Name>
+      <BitSize>256512</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnable</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, start a move when setState transitions to a nonzero number</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> On rising edge, reset this FB</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RESET
+        io: io
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, there is an error</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERR
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nErrorId</Name>
+        <Type>UDINT</Type>
+        <Comment> Error ID</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sErrorMessage</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The error that caused bError to flip TRUE</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ERRMSG
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are moving the motor</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>840</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: BUSY
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bDone</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we are not moving the motor and the last move completed successfully</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>848</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DONE
+        io: i
+        field: ZNAM False
+        field: ONAM True
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrStates</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> Pre-allocated array of states</Comment>
+        <BitSize>54720</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv:
+        io: io
+        expand: %.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>setState</Name>
+        <Type>INT</Type>
+        <Comment> Corresponding arrStates index to move to, or 0 if no move selected</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55616</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>goalState</Name>
+        <Type>INT</Type>
+        <Comment> The current position we are trying to reach, or 0</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55632</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>getState</Name>
+        <Type>INT</Type>
+        <Comment> The readback position</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>55648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>55664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stUnknown</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>55680</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stGoal</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>59328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateMove</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateMove</Type>
+        <BitSize>3200</BitSize>
+        <BitOffs>62976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStateInternal</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateInternal</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>190080</BitSize>
+        <BitOffs>66176</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>256256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bNewGoal</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256272</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerExec</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInnerReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReset</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>256320</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveRequested</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>256448</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>StateHandler</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionState1D instead</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</Name>
+      <BitSize>20096</BitSize>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrStates</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterEnabled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMaintMode</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>200</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MAINT
+        io: io
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bRequestTransition</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>208</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>setState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>getState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fStateBoundaryDeadband</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>tArbiterTimeout</Name>
+        <Type>TIME</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <DateTime>T#1s</DateTime>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOnArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>352</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bTransitionAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>360</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForwardAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>368</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBackwardAuthorized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>376</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bArbiterTimeout</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionDb</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <BitSize>2496</BitSize>
+        <BitOffs>416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: TRANS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionBeam</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>2912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stTransitionState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>4672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8320</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bTransDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8328</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTransReq</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBPTMDone</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>8512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtBPTMDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftMotorExec</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTransDone</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8832</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtDoLateFinish</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>8960</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonDone</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>9088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stStateReq</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>9344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>mcPower</Name>
+        <Type Namespace="Tc2_MC2">MC_Power</Type>
+        <BitSize>960</BitSize>
+        <BitOffs>12992</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fUpperBound</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>13952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fLowerBound</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>14016</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nGoalState</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>14080</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stGoalState</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>14144</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fActPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>17792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fReqPos</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>17856</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInTransition</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>17920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>stBeamNeeded</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>17952</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFwdOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19712</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBwdOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>19720</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tonArbiter</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>256</BitSize>
+        <BitOffs>19776</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLateFinish</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20032</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInternalAuth</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20040</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>AssertHere</Name>
+      </Action>
+      <Action>
+        <Name>HandleBPTM</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>ClearAsserts</Name>
+      </Action>
+      <Action>
+        <Name>Exec</Name>
+      </Action>
+      <Action>
+        <Name>HandlePmpsDb</Name>
+      </Action>
+      <Method>
+        <Name>GetBeamFromState</Name>
+        <ReturnType Namespace="PMPS">ST_BeamParams</ReturnType>
+        <ReturnBitSize>1760</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Local>
+          <Name>stState</Name>
+          <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+          <BitSize>3648</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetStateCode</Name>
+        <ReturnType>INT</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetStateStruct</Name>
+        <ReturnType Namespace="lcls_twincat_motion">ST_PositionState</ReturnType>
+        <ReturnBitSize>3648</ReturnBitSize>
+        <Parameter>
+          <Name>nState</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS</Name>
+      <BitSize>396032</BitSize>
+      <ExtendsType Namespace="lcls_twincat_motion">FB_PositionStatePMPS_Base</ExtendsType>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>20096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>20160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPmpsDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>20232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>20880</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPmpsDoc</Name>
+        <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>21568</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stHighBeamThreshold</Name>
+        <Type Namespace="PMPS">ST_BeamParams</Type>
+        <BitSize>1760</BitSize>
+        <BitOffs>21632</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bBPOKAutoReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>23392</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrPMPS</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>16</Elements>
+        </ArrayInfo>
+        <BitSize>39936</BitSize>
+        <BitOffs>23424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nBPIndex</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>63360</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nTransitionAssertionID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>63392</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nLastReqAssertionID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>63424</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbReadPmpsDb</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>115008</BitSize>
+        <BitOffs>63488</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftDbBusy</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>178496</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtReadDBExec</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>178624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftRead</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>178752</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bptm</Name>
+        <Type Namespace="PMPS">BeamParameterTransitionManager</Type>
+        <BitSize>61568</BitSize>
+        <BitOffs>178880</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBeamParamsOk</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>240448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffZeroRate</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>266368</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBPTMTimeoutAndMove</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>292288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffBPTMError</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>318208</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffMaint</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>344128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffUnknown</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25920</BitSize>
+        <BitOffs>370048</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bFFOxOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>395968</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bAtSafeState</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>395976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIter</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>395984</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>HandlePmpsDb</Name>
+      </Action>
+      <Action>
+        <Name>HandleFFO</Name>
+      </Action>
+      <Action>
+        <Name>AssertHere</Name>
+      </Action>
+      <Action>
+        <Name>ClearAsserts</Name>
+      </Action>
+      <Action>
+        <Name>HandleBPTM</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>Use FB_PositionStatePMPS1D instead</Value>
         </Property>
       </Properties>
     </DataType>
@@ -72475,7 +75837,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -72491,14 +75853,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295628736</BitOffs>
+            <BitOffs>1299015744</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -72512,14 +75874,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295628928</BitOffs>
+            <BitOffs>1299015936</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -72536,7 +75898,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293576192</BitOffs>
+            <BitOffs>1296963200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -72547,7 +75909,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293578704</BitOffs>
+            <BitOffs>1296965712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -72561,7 +75923,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304121280</BitOffs>
+            <BitOffs>1307522880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -72575,7 +75937,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128448</BitOffs>
+            <BitOffs>1307530048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -72589,7 +75951,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128480</BitOffs>
+            <BitOffs>1307530080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -72610,14 +75972,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128768</BitOffs>
+            <BitOffs>1307530368</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -72628,14 +75990,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297095424</BitOffs>
+            <BitOffs>1300497024</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -72737,7 +76099,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297094336</BitOffs>
+            <BitOffs>1300495936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -72751,7 +76113,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128512</BitOffs>
+            <BitOffs>1307530112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -72765,7 +76127,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128544</BitOffs>
+            <BitOffs>1307530144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -72786,20 +76148,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304129664</BitOffs>
+            <BitOffs>1307531264</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1264934016</BitOffs>
+            <BitOffs>1265714880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -72834,7 +76196,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584448</BitOffs>
+            <BitOffs>1296971456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -72848,7 +76210,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128576</BitOffs>
+            <BitOffs>1307530176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -72862,7 +76224,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128608</BitOffs>
+            <BitOffs>1307530208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -72883,14 +76245,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304130560</BitOffs>
+            <BitOffs>1307532160</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -72906,7 +76268,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265050816</BitOffs>
+            <BitOffs>1264934720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -72922,7 +76284,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265050880</BitOffs>
+            <BitOffs>1264934784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -72938,14 +76300,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265050944</BitOffs>
+            <BitOffs>1264934848</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -73070,7 +76432,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265051008</BitOffs>
+            <BitOffs>1264934912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bSendToTest</Name>
@@ -73079,7 +76441,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265051016</BitOffs>
+            <BitOffs>1264934920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.sTestHost</Name>
@@ -73089,7 +76451,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265051024</BitOffs>
+            <BitOffs>1264934928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -73098,7 +76460,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265051672</BitOffs>
+            <BitOffs>1264935576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -73107,14 +76469,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265051680</BitOffs>
+            <BitOffs>1264935584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265051688</BitOffs>
+            <BitOffs>1264935592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -73129,7 +76491,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265051696</BitOffs>
+            <BitOffs>1264935600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -73138,20 +76500,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265051712</BitOffs>
+            <BitOffs>1264935616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265051776</BitOffs>
+            <BitOffs>1264935680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265051840</BitOffs>
+            <BitOffs>1264935744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -73160,19 +76522,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265051904</BitOffs>
+            <BitOffs>1264935808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265051968</BitOffs>
+            <BitOffs>1264935872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052032</BitOffs>
+            <BitOffs>1264935936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -73187,25 +76549,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265052096</BitOffs>
+            <BitOffs>1264936000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265052160</BitOffs>
+            <BitOffs>1264936064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052416</BitOffs>
+            <BitOffs>1264936320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265052480</BitOffs>
+            <BitOffs>1264936384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -73214,79 +76576,79 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265052544</BitOffs>
+            <BitOffs>1264936448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052608</BitOffs>
+            <BitOffs>1264936512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265052672</BitOffs>
+            <BitOffs>1264936576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265052736</BitOffs>
+            <BitOffs>1264936640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265053760</BitOffs>
+            <BitOffs>1264937664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265053824</BitOffs>
+            <BitOffs>1264937728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265053888</BitOffs>
+            <BitOffs>1264937792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265053952</BitOffs>
+            <BitOffs>1264937856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265054016</BitOffs>
+            <BitOffs>1264937920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265164608</BitOffs>
+            <BitOffs>1265048512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265439808</BitOffs>
+            <BitOffs>1265323712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265550400</BitOffs>
+            <BitOffs>1265434304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265825600</BitOffs>
+            <BitOffs>1265709504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -73298,7 +76660,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265826112</BitOffs>
+            <BitOffs>1265710016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -73310,14 +76672,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265826688</BitOffs>
+            <BitOffs>1265710592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265827520</BitOffs>
+            <BitOffs>1265711424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -73333,7 +76695,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265827808</BitOffs>
+            <BitOffs>1265711712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -73348,7 +76710,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265827840</BitOffs>
+            <BitOffs>1265711744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -73366,7 +76728,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304123328</BitOffs>
+            <BitOffs>1307524928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -73380,7 +76742,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128640</BitOffs>
+            <BitOffs>1307530240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -73394,7 +76756,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128672</BitOffs>
+            <BitOffs>1307530272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -73415,14 +76777,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304131456</BitOffs>
+            <BitOffs>1307533056</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -73775,7 +77137,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281587712</BitOffs>
+            <BitOffs>1281598272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
@@ -73787,7 +77149,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281587720</BitOffs>
+            <BitOffs>1281598280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
@@ -73800,7 +77162,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281587776</BitOffs>
+            <BitOffs>1281598336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
@@ -73812,7 +77174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281587904</BitOffs>
+            <BitOffs>1281598464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
@@ -73824,7 +77186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281588032</BitOffs>
+            <BitOffs>1281598592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
@@ -73836,7 +77198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281588160</BitOffs>
+            <BitOffs>1281598720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -73849,7 +77211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281588928</BitOffs>
+            <BitOffs>1281599488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -73862,7 +77224,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281589056</BitOffs>
+            <BitOffs>1281599616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -73875,7 +77237,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281599680</BitOffs>
+            <BitOffs>1281610240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -73888,7 +77250,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1281599808</BitOffs>
+            <BitOffs>1281610368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73900,7 +77262,19 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1282838528</BitOffs>
+            <BitOffs>1282849088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283184128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
@@ -73917,7 +77291,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283170896</BitOffs>
+            <BitOffs>1283509296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
@@ -73933,19 +77307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283170904</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-            <BitSize>2048</BitSize>
-            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1283173568</BitOffs>
+            <BitOffs>1283509304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
@@ -73958,7 +77320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283503936</BitOffs>
+            <BitOffs>1283514496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2.iRaw</Name>
@@ -73971,7 +77333,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283504512</BitOffs>
+            <BitOffs>1283515072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
@@ -73984,7 +77346,346 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283505088</BitOffs>
+            <BitOffs>1283515648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284816448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284842368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284868288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -73996,7 +77697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283508544</BitOffs>
+            <BitOffs>1285207296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74008,7 +77709,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283835968</BitOffs>
+            <BitOffs>1285534720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74020,7 +77721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284163392</BitOffs>
+            <BitOffs>1285862144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74032,7 +77733,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284490816</BitOffs>
+            <BitOffs>1286189568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74044,7 +77745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284818240</BitOffs>
+            <BitOffs>1286516992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74056,7 +77757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285145664</BitOffs>
+            <BitOffs>1286844416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upe</Name>
@@ -74078,7 +77779,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285470464</BitOffs>
+            <BitOffs>1287169216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upe</Name>
@@ -74100,7 +77801,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285470592</BitOffs>
+            <BitOffs>1287169344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bError</Name>
@@ -74124,7 +77825,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471048</BitOffs>
+            <BitOffs>1287169800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bUnderrange</Name>
@@ -74136,7 +77837,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471056</BitOffs>
+            <BitOffs>1287169808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bOverrange</Name>
@@ -74148,7 +77849,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471064</BitOffs>
+            <BitOffs>1287169816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.iRaw</Name>
@@ -74160,7 +77861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471072</BitOffs>
+            <BitOffs>1287169824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bError</Name>
@@ -74184,7 +77885,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471304</BitOffs>
+            <BitOffs>1287170056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bUnderrange</Name>
@@ -74196,7 +77897,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471312</BitOffs>
+            <BitOffs>1287170064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bOverrange</Name>
@@ -74208,7 +77909,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471320</BitOffs>
+            <BitOffs>1287170072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.iRaw</Name>
@@ -74220,7 +77921,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471328</BitOffs>
+            <BitOffs>1287170080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bError</Name>
@@ -74244,7 +77945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471560</BitOffs>
+            <BitOffs>1287170312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bUnderrange</Name>
@@ -74256,7 +77957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471568</BitOffs>
+            <BitOffs>1287170320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bOverrange</Name>
@@ -74268,7 +77969,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471576</BitOffs>
+            <BitOffs>1287170328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.iRaw</Name>
@@ -74280,7 +77981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471584</BitOffs>
+            <BitOffs>1287170336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bError</Name>
@@ -74304,7 +78005,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471816</BitOffs>
+            <BitOffs>1287170568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bUnderrange</Name>
@@ -74316,7 +78017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471824</BitOffs>
+            <BitOffs>1287170576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bOverrange</Name>
@@ -74328,7 +78029,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471832</BitOffs>
+            <BitOffs>1287170584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.iRaw</Name>
@@ -74340,7 +78041,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471840</BitOffs>
+            <BitOffs>1287170592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bError</Name>
@@ -74364,7 +78065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472072</BitOffs>
+            <BitOffs>1287170824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bUnderrange</Name>
@@ -74376,7 +78077,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472080</BitOffs>
+            <BitOffs>1287170832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bOverrange</Name>
@@ -74388,7 +78089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472088</BitOffs>
+            <BitOffs>1287170840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.iRaw</Name>
@@ -74400,7 +78101,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472096</BitOffs>
+            <BitOffs>1287170848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bError</Name>
@@ -74424,7 +78125,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472328</BitOffs>
+            <BitOffs>1287171080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bUnderrange</Name>
@@ -74436,7 +78137,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472336</BitOffs>
+            <BitOffs>1287171088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bOverrange</Name>
@@ -74448,7 +78149,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472344</BitOffs>
+            <BitOffs>1287171096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.iRaw</Name>
@@ -74460,7 +78161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472352</BitOffs>
+            <BitOffs>1287171104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bError</Name>
@@ -74484,7 +78185,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472584</BitOffs>
+            <BitOffs>1287171336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bUnderrange</Name>
@@ -74496,7 +78197,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472592</BitOffs>
+            <BitOffs>1287171344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bOverrange</Name>
@@ -74508,7 +78209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472600</BitOffs>
+            <BitOffs>1287171352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.iRaw</Name>
@@ -74520,7 +78221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472608</BitOffs>
+            <BitOffs>1287171360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bError</Name>
@@ -74544,7 +78245,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472840</BitOffs>
+            <BitOffs>1287171592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bUnderrange</Name>
@@ -74556,7 +78257,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472848</BitOffs>
+            <BitOffs>1287171600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bOverrange</Name>
@@ -74568,7 +78269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472856</BitOffs>
+            <BitOffs>1287171608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.iRaw</Name>
@@ -74580,7 +78281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472864</BitOffs>
+            <BitOffs>1287171616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bError</Name>
@@ -74604,7 +78305,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473096</BitOffs>
+            <BitOffs>1287171848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bUnderrange</Name>
@@ -74616,7 +78317,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473104</BitOffs>
+            <BitOffs>1287171856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bOverrange</Name>
@@ -74628,7 +78329,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473112</BitOffs>
+            <BitOffs>1287171864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.iRaw</Name>
@@ -74640,7 +78341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473120</BitOffs>
+            <BitOffs>1287171872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bError</Name>
@@ -74664,7 +78365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473352</BitOffs>
+            <BitOffs>1287172104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bUnderrange</Name>
@@ -74676,7 +78377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473360</BitOffs>
+            <BitOffs>1287172112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bOverrange</Name>
@@ -74688,7 +78389,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473368</BitOffs>
+            <BitOffs>1287172120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.iRaw</Name>
@@ -74700,7 +78401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473376</BitOffs>
+            <BitOffs>1287172128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bError</Name>
@@ -74724,7 +78425,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473608</BitOffs>
+            <BitOffs>1287172360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bUnderrange</Name>
@@ -74736,7 +78437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473616</BitOffs>
+            <BitOffs>1287172368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bOverrange</Name>
@@ -74748,7 +78449,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473624</BitOffs>
+            <BitOffs>1287172376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.iRaw</Name>
@@ -74760,7 +78461,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473632</BitOffs>
+            <BitOffs>1287172384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bError</Name>
@@ -74784,7 +78485,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473864</BitOffs>
+            <BitOffs>1287172616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bUnderrange</Name>
@@ -74796,7 +78497,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473872</BitOffs>
+            <BitOffs>1287172624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bOverrange</Name>
@@ -74808,7 +78509,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473880</BitOffs>
+            <BitOffs>1287172632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.iRaw</Name>
@@ -74820,7 +78521,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473888</BitOffs>
+            <BitOffs>1287172640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw</Name>
@@ -74833,7 +78534,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285500096</BitOffs>
+            <BitOffs>1287198912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2.iRaw</Name>
@@ -74846,7 +78547,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285500672</BitOffs>
+            <BitOffs>1287199488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
@@ -74859,7 +78560,346 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285501248</BitOffs>
+            <BitOffs>1287200064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288504512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288530432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288556352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288564432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74871,7 +78911,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285538112</BitOffs>
+            <BitOffs>1288925120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74883,7 +78923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285865536</BitOffs>
+            <BitOffs>1289252544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74895,7 +78935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286192960</BitOffs>
+            <BitOffs>1289579968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74907,7 +78947,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286520384</BitOffs>
+            <BitOffs>1289907392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -74919,7 +78959,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286847808</BitOffs>
+            <BitOffs>1290234816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bError</Name>
@@ -74943,7 +78983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867528</BitOffs>
+            <BitOffs>1291254536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bUnderrange</Name>
@@ -74955,7 +78995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867536</BitOffs>
+            <BitOffs>1291254544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bOverrange</Name>
@@ -74967,7 +79007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867544</BitOffs>
+            <BitOffs>1291254552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.iRaw</Name>
@@ -74979,7 +79019,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867552</BitOffs>
+            <BitOffs>1291254560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bError</Name>
@@ -75003,7 +79043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867784</BitOffs>
+            <BitOffs>1291254792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bUnderrange</Name>
@@ -75015,7 +79055,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867792</BitOffs>
+            <BitOffs>1291254800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bOverrange</Name>
@@ -75027,7 +79067,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867800</BitOffs>
+            <BitOffs>1291254808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.iRaw</Name>
@@ -75039,7 +79079,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867808</BitOffs>
+            <BitOffs>1291254816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bError</Name>
@@ -75063,7 +79103,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868040</BitOffs>
+            <BitOffs>1291255048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bUnderrange</Name>
@@ -75075,7 +79115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868048</BitOffs>
+            <BitOffs>1291255056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bOverrange</Name>
@@ -75087,7 +79127,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868056</BitOffs>
+            <BitOffs>1291255064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.iRaw</Name>
@@ -75099,7 +79139,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868064</BitOffs>
+            <BitOffs>1291255072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bError</Name>
@@ -75123,7 +79163,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868296</BitOffs>
+            <BitOffs>1291255304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bUnderrange</Name>
@@ -75135,7 +79175,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868304</BitOffs>
+            <BitOffs>1291255312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bOverrange</Name>
@@ -75147,7 +79187,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868312</BitOffs>
+            <BitOffs>1291255320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.iRaw</Name>
@@ -75159,7 +79199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868320</BitOffs>
+            <BitOffs>1291255328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbGetIllPercent.iRaw</Name>
@@ -75172,7 +79212,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868672</BitOffs>
+            <BitOffs>1291255680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter.iRaw</Name>
@@ -75185,7 +79225,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287869824</BitOffs>
+            <BitOffs>1291256832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -75197,7 +79237,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287873216</BitOffs>
+            <BitOffs>1291260224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -75213,7 +79253,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288200192</BitOffs>
+            <BitOffs>1291587200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -75234,7 +79274,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288203712</BitOffs>
+            <BitOffs>1291590720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -75255,7 +79295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288203713</BitOffs>
+            <BitOffs>1291590721</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable1</Name>
@@ -75272,7 +79312,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288502256</BitOffs>
+            <BitOffs>1291889264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2</Name>
@@ -75288,7 +79328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288502264</BitOffs>
+            <BitOffs>1291889272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -75301,7 +79341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289694080</BitOffs>
+            <BitOffs>1293081088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -75314,7 +79354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289694592</BitOffs>
+            <BitOffs>1293081600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
@@ -75327,7 +79367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289695168</BitOffs>
+            <BitOffs>1293082176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
@@ -75340,7 +79380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634368</BitOffs>
+            <BitOffs>1295021376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
@@ -75352,7 +79392,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634376</BitOffs>
+            <BitOffs>1295021384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
@@ -75364,7 +79404,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634384</BitOffs>
+            <BitOffs>1295021392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
@@ -75376,7 +79416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634392</BitOffs>
+            <BitOffs>1295021400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
@@ -75388,7 +79428,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634400</BitOffs>
+            <BitOffs>1295021408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -75400,7 +79440,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634408</BitOffs>
+            <BitOffs>1295021416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -75417,7 +79457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634416</BitOffs>
+            <BitOffs>1295021424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -75433,7 +79473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634424</BitOffs>
+            <BitOffs>1295021432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -75446,7 +79486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291634688</BitOffs>
+            <BitOffs>1295021696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -75459,7 +79499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291635200</BitOffs>
+            <BitOffs>1295022208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
@@ -75483,7 +79523,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574600</BitOffs>
+            <BitOffs>1296961608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -75495,7 +79535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574608</BitOffs>
+            <BitOffs>1296961616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -75507,7 +79547,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574616</BitOffs>
+            <BitOffs>1296961624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
@@ -75519,7 +79559,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574624</BitOffs>
+            <BitOffs>1296961632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
@@ -75543,7 +79583,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574856</BitOffs>
+            <BitOffs>1296961864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -75555,7 +79595,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574864</BitOffs>
+            <BitOffs>1296961872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -75567,7 +79607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574872</BitOffs>
+            <BitOffs>1296961880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
@@ -75579,7 +79619,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574880</BitOffs>
+            <BitOffs>1296961888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -75592,7 +79632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574912</BitOffs>
+            <BitOffs>1296961920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -75604,7 +79644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574920</BitOffs>
+            <BitOffs>1296961928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -75616,7 +79656,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574928</BitOffs>
+            <BitOffs>1296961936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -75628,7 +79668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574936</BitOffs>
+            <BitOffs>1296961944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -75640,7 +79680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574944</BitOffs>
+            <BitOffs>1296961952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -75652,7 +79692,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574952</BitOffs>
+            <BitOffs>1296961960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -75669,7 +79709,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574960</BitOffs>
+            <BitOffs>1296961968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -75685,7 +79725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293574968</BitOffs>
+            <BitOffs>1296961976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -75698,7 +79738,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293575232</BitOffs>
+            <BitOffs>1296962240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -75711,7 +79751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293575744</BitOffs>
+            <BitOffs>1296962752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -75731,7 +79771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293581216</BitOffs>
+            <BitOffs>1296968224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -75750,7 +79790,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293581232</BitOffs>
+            <BitOffs>1296968240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
@@ -75763,7 +79803,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293583680</BitOffs>
+            <BitOffs>1296970688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -75782,7 +79822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584128</BitOffs>
+            <BitOffs>1296971136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -75802,7 +79842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584144</BitOffs>
+            <BitOffs>1296971152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -75821,7 +79861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584160</BitOffs>
+            <BitOffs>1296971168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -75840,7 +79880,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584176</BitOffs>
+            <BitOffs>1296971184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
@@ -75853,7 +79893,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293586880</BitOffs>
+            <BitOffs>1296973888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -75873,7 +79913,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587456</BitOffs>
+            <BitOffs>1296974464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -75892,7 +79932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587472</BitOffs>
+            <BitOffs>1296974480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
@@ -75911,7 +79951,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587488</BitOffs>
+            <BitOffs>1296974496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -75931,7 +79971,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587504</BitOffs>
+            <BitOffs>1296974512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
@@ -75950,7 +79990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587520</BitOffs>
+            <BitOffs>1296974528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -75969,7 +80009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587536</BitOffs>
+            <BitOffs>1296974544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -75989,7 +80029,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587552</BitOffs>
+            <BitOffs>1296974560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -76008,7 +80048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587568</BitOffs>
+            <BitOffs>1296974576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -76027,7 +80067,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588160</BitOffs>
+            <BitOffs>1296975168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -76047,7 +80087,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588176</BitOffs>
+            <BitOffs>1296975184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
@@ -76066,7 +80106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588192</BitOffs>
+            <BitOffs>1296975200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
@@ -76085,7 +80125,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588208</BitOffs>
+            <BitOffs>1296975216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -76097,7 +80137,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295630208</BitOffs>
+            <BitOffs>1299031808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -76110,7 +80150,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638144</BitOffs>
+            <BitOffs>1299039744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -76123,7 +80163,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638152</BitOffs>
+            <BitOffs>1299039752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -76136,7 +80176,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638160</BitOffs>
+            <BitOffs>1299039760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -76159,7 +80199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638176</BitOffs>
+            <BitOffs>1299039776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -76172,7 +80212,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638208</BitOffs>
+            <BitOffs>1299039808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -76185,7 +80225,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638272</BitOffs>
+            <BitOffs>1299039872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -76198,7 +80238,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638288</BitOffs>
+            <BitOffs>1299039888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76210,7 +80250,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295657664</BitOffs>
+            <BitOffs>1299059264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -76222,7 +80262,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295983552</BitOffs>
+            <BitOffs>1299385152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -76235,7 +80275,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991488</BitOffs>
+            <BitOffs>1299393088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -76248,7 +80288,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991496</BitOffs>
+            <BitOffs>1299393096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -76261,7 +80301,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991504</BitOffs>
+            <BitOffs>1299393104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -76284,7 +80324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991520</BitOffs>
+            <BitOffs>1299393120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -76297,7 +80337,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991552</BitOffs>
+            <BitOffs>1299393152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -76310,7 +80350,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991616</BitOffs>
+            <BitOffs>1299393216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -76323,7 +80363,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991632</BitOffs>
+            <BitOffs>1299393232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76335,7 +80375,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296011008</BitOffs>
+            <BitOffs>1299412608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -76347,7 +80387,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336896</BitOffs>
+            <BitOffs>1299738496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -76360,7 +80400,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344832</BitOffs>
+            <BitOffs>1299746432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -76373,7 +80413,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344840</BitOffs>
+            <BitOffs>1299746440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -76386,7 +80426,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344848</BitOffs>
+            <BitOffs>1299746448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -76409,7 +80449,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344864</BitOffs>
+            <BitOffs>1299746464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -76422,7 +80462,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344896</BitOffs>
+            <BitOffs>1299746496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -76435,7 +80475,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344960</BitOffs>
+            <BitOffs>1299746560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -76448,7 +80488,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344976</BitOffs>
+            <BitOffs>1299746576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76460,7 +80500,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296364352</BitOffs>
+            <BitOffs>1299765952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -76472,7 +80512,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296690240</BitOffs>
+            <BitOffs>1300091840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -76485,7 +80525,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698176</BitOffs>
+            <BitOffs>1300099776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -76498,7 +80538,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698184</BitOffs>
+            <BitOffs>1300099784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -76511,7 +80551,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698192</BitOffs>
+            <BitOffs>1300099792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -76534,7 +80574,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698208</BitOffs>
+            <BitOffs>1300099808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -76547,7 +80587,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698240</BitOffs>
+            <BitOffs>1300099840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -76560,7 +80600,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698304</BitOffs>
+            <BitOffs>1300099904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -76573,7 +80613,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698320</BitOffs>
+            <BitOffs>1300099920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -76585,7 +80625,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296717696</BitOffs>
+            <BitOffs>1300119296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -76597,7 +80637,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297043584</BitOffs>
+            <BitOffs>1300445184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -76610,7 +80650,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051520</BitOffs>
+            <BitOffs>1300453120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -76623,7 +80663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051528</BitOffs>
+            <BitOffs>1300453128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -76636,7 +80676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051536</BitOffs>
+            <BitOffs>1300453136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -76659,7 +80699,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051552</BitOffs>
+            <BitOffs>1300453152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -76672,7 +80712,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051584</BitOffs>
+            <BitOffs>1300453184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -76685,7 +80725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051648</BitOffs>
+            <BitOffs>1300453248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -76698,7 +80738,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051664</BitOffs>
+            <BitOffs>1300453264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -76710,7 +80750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297069504</BitOffs>
+            <BitOffs>1300471104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -76723,7 +80763,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077440</BitOffs>
+            <BitOffs>1300479040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -76736,7 +80776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077448</BitOffs>
+            <BitOffs>1300479048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -76749,7 +80789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077456</BitOffs>
+            <BitOffs>1300479056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -76772,7 +80812,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077472</BitOffs>
+            <BitOffs>1300479072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -76785,7 +80825,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077504</BitOffs>
+            <BitOffs>1300479104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -76798,7 +80838,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077568</BitOffs>
+            <BitOffs>1300479168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -76811,7 +80851,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077584</BitOffs>
+            <BitOffs>1300479184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -76824,7 +80864,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103360</BitOffs>
+            <BitOffs>1300504960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -76837,7 +80877,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103368</BitOffs>
+            <BitOffs>1300504968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -76850,7 +80890,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103376</BitOffs>
+            <BitOffs>1300504976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -76873,7 +80913,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103392</BitOffs>
+            <BitOffs>1300504992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -76886,7 +80926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103424</BitOffs>
+            <BitOffs>1300505024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -76899,7 +80939,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103488</BitOffs>
+            <BitOffs>1300505088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -76912,7 +80952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103504</BitOffs>
+            <BitOffs>1300505104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -76924,7 +80964,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297121344</BitOffs>
+            <BitOffs>1300522944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -76937,7 +80977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129280</BitOffs>
+            <BitOffs>1300530880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -76950,7 +80990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129288</BitOffs>
+            <BitOffs>1300530888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -76963,7 +81003,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129296</BitOffs>
+            <BitOffs>1300530896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -76986,7 +81026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129312</BitOffs>
+            <BitOffs>1300530912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -76999,7 +81039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129344</BitOffs>
+            <BitOffs>1300530944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -77012,7 +81052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129408</BitOffs>
+            <BitOffs>1300531008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -77025,7 +81065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129424</BitOffs>
+            <BitOffs>1300531024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -77037,7 +81077,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297147264</BitOffs>
+            <BitOffs>1300548864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -77050,7 +81090,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155200</BitOffs>
+            <BitOffs>1300556800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -77063,7 +81103,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155208</BitOffs>
+            <BitOffs>1300556808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -77076,7 +81116,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155216</BitOffs>
+            <BitOffs>1300556816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -77099,7 +81139,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155232</BitOffs>
+            <BitOffs>1300556832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -77112,7 +81152,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155264</BitOffs>
+            <BitOffs>1300556864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -77125,7 +81165,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155328</BitOffs>
+            <BitOffs>1300556928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -77138,7 +81178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155344</BitOffs>
+            <BitOffs>1300556944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -77150,7 +81190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297173184</BitOffs>
+            <BitOffs>1300574784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -77163,7 +81203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181120</BitOffs>
+            <BitOffs>1300582720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -77176,7 +81216,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181128</BitOffs>
+            <BitOffs>1300582728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -77189,7 +81229,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181136</BitOffs>
+            <BitOffs>1300582736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -77212,7 +81252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181152</BitOffs>
+            <BitOffs>1300582752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -77225,7 +81265,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181184</BitOffs>
+            <BitOffs>1300582784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -77238,7 +81278,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181248</BitOffs>
+            <BitOffs>1300582848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -77251,7 +81291,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181264</BitOffs>
+            <BitOffs>1300582864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -77263,7 +81303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297199104</BitOffs>
+            <BitOffs>1300600704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -77276,7 +81316,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207040</BitOffs>
+            <BitOffs>1300608640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -77289,7 +81329,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207048</BitOffs>
+            <BitOffs>1300608648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -77302,7 +81342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207056</BitOffs>
+            <BitOffs>1300608656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -77325,7 +81365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207072</BitOffs>
+            <BitOffs>1300608672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -77338,7 +81378,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207104</BitOffs>
+            <BitOffs>1300608704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -77351,7 +81391,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207168</BitOffs>
+            <BitOffs>1300608768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -77364,7 +81404,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207184</BitOffs>
+            <BitOffs>1300608784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -77376,7 +81416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297225024</BitOffs>
+            <BitOffs>1300626624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -77389,7 +81429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297232960</BitOffs>
+            <BitOffs>1300634560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -77402,7 +81442,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297232968</BitOffs>
+            <BitOffs>1300634568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -77415,7 +81455,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297232976</BitOffs>
+            <BitOffs>1300634576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -77438,7 +81478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297232992</BitOffs>
+            <BitOffs>1300634592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -77451,7 +81491,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297233024</BitOffs>
+            <BitOffs>1300634624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -77464,7 +81504,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297233088</BitOffs>
+            <BitOffs>1300634688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -77477,7 +81517,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297233104</BitOffs>
+            <BitOffs>1300634704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77489,7 +81529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297252480</BitOffs>
+            <BitOffs>1300654080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -77501,7 +81541,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297578368</BitOffs>
+            <BitOffs>1300979968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -77514,7 +81554,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586304</BitOffs>
+            <BitOffs>1300987904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -77527,7 +81567,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586312</BitOffs>
+            <BitOffs>1300987912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -77540,7 +81580,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586320</BitOffs>
+            <BitOffs>1300987920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -77563,7 +81603,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586336</BitOffs>
+            <BitOffs>1300987936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -77576,7 +81616,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586368</BitOffs>
+            <BitOffs>1300987968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -77589,7 +81629,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586432</BitOffs>
+            <BitOffs>1300988032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -77602,7 +81642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586448</BitOffs>
+            <BitOffs>1300988048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77614,7 +81654,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297605824</BitOffs>
+            <BitOffs>1301007424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -77626,7 +81666,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297931712</BitOffs>
+            <BitOffs>1301333312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -77639,7 +81679,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939648</BitOffs>
+            <BitOffs>1301341248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -77652,7 +81692,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939656</BitOffs>
+            <BitOffs>1301341256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -77665,7 +81705,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939664</BitOffs>
+            <BitOffs>1301341264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -77688,7 +81728,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939680</BitOffs>
+            <BitOffs>1301341280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -77701,7 +81741,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939712</BitOffs>
+            <BitOffs>1301341312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -77714,7 +81754,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939776</BitOffs>
+            <BitOffs>1301341376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -77727,7 +81767,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939792</BitOffs>
+            <BitOffs>1301341392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77739,7 +81779,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1297959168</BitOffs>
+            <BitOffs>1301360768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -77751,7 +81791,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298285056</BitOffs>
+            <BitOffs>1301686656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -77764,7 +81804,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298292992</BitOffs>
+            <BitOffs>1301694592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -77777,7 +81817,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293000</BitOffs>
+            <BitOffs>1301694600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -77790,7 +81830,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293008</BitOffs>
+            <BitOffs>1301694608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -77813,7 +81853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293024</BitOffs>
+            <BitOffs>1301694624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -77826,7 +81866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293056</BitOffs>
+            <BitOffs>1301694656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -77839,7 +81879,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293120</BitOffs>
+            <BitOffs>1301694720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -77852,7 +81892,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293136</BitOffs>
+            <BitOffs>1301694736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -77864,7 +81904,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298312512</BitOffs>
+            <BitOffs>1301714112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -77876,7 +81916,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298638400</BitOffs>
+            <BitOffs>1302040000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -77889,7 +81929,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646336</BitOffs>
+            <BitOffs>1302047936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -77902,7 +81942,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646344</BitOffs>
+            <BitOffs>1302047944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -77915,7 +81955,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646352</BitOffs>
+            <BitOffs>1302047952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -77938,7 +81978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646368</BitOffs>
+            <BitOffs>1302047968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -77951,7 +81991,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646400</BitOffs>
+            <BitOffs>1302048000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -77964,7 +82004,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646464</BitOffs>
+            <BitOffs>1302048064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -77977,7 +82017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646480</BitOffs>
+            <BitOffs>1302048080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -77989,7 +82029,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298664320</BitOffs>
+            <BitOffs>1302065920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -78002,7 +82042,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672256</BitOffs>
+            <BitOffs>1302073856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -78015,7 +82055,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672264</BitOffs>
+            <BitOffs>1302073864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -78028,7 +82068,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672272</BitOffs>
+            <BitOffs>1302073872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -78051,7 +82091,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672288</BitOffs>
+            <BitOffs>1302073888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -78064,7 +82104,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672320</BitOffs>
+            <BitOffs>1302073920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -78077,7 +82117,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672384</BitOffs>
+            <BitOffs>1302073984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -78090,7 +82130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672400</BitOffs>
+            <BitOffs>1302074000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78102,7 +82142,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298691776</BitOffs>
+            <BitOffs>1302093376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -78114,7 +82154,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299017664</BitOffs>
+            <BitOffs>1302419264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -78127,7 +82167,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025600</BitOffs>
+            <BitOffs>1302427200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -78140,7 +82180,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025608</BitOffs>
+            <BitOffs>1302427208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -78153,7 +82193,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025616</BitOffs>
+            <BitOffs>1302427216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -78176,7 +82216,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025632</BitOffs>
+            <BitOffs>1302427232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -78189,7 +82229,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025664</BitOffs>
+            <BitOffs>1302427264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -78202,7 +82242,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025728</BitOffs>
+            <BitOffs>1302427328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -78215,7 +82255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025744</BitOffs>
+            <BitOffs>1302427344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -78227,7 +82267,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299045120</BitOffs>
+            <BitOffs>1302446720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -78239,7 +82279,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299371008</BitOffs>
+            <BitOffs>1302772608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -78252,7 +82292,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299378944</BitOffs>
+            <BitOffs>1302780544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -78265,7 +82305,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299378952</BitOffs>
+            <BitOffs>1302780552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -78278,7 +82318,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299378960</BitOffs>
+            <BitOffs>1302780560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -78301,7 +82341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299378976</BitOffs>
+            <BitOffs>1302780576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -78314,7 +82354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299379008</BitOffs>
+            <BitOffs>1302780608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -78327,7 +82367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299379072</BitOffs>
+            <BitOffs>1302780672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -78340,7 +82380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299379088</BitOffs>
+            <BitOffs>1302780688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -78352,7 +82392,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299396928</BitOffs>
+            <BitOffs>1302798528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -78365,7 +82405,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404864</BitOffs>
+            <BitOffs>1302806464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -78378,7 +82418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404872</BitOffs>
+            <BitOffs>1302806472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -78391,7 +82431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404880</BitOffs>
+            <BitOffs>1302806480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -78414,7 +82454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404896</BitOffs>
+            <BitOffs>1302806496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -78427,7 +82467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404928</BitOffs>
+            <BitOffs>1302806528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -78440,7 +82480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404992</BitOffs>
+            <BitOffs>1302806592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -78453,7 +82493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299405008</BitOffs>
+            <BitOffs>1302806608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -78465,7 +82505,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299422848</BitOffs>
+            <BitOffs>1302824448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -78478,7 +82518,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430784</BitOffs>
+            <BitOffs>1302832384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -78491,7 +82531,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430792</BitOffs>
+            <BitOffs>1302832392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -78504,7 +82544,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430800</BitOffs>
+            <BitOffs>1302832400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -78527,7 +82567,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430816</BitOffs>
+            <BitOffs>1302832416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -78540,7 +82580,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430848</BitOffs>
+            <BitOffs>1302832448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -78553,7 +82593,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430912</BitOffs>
+            <BitOffs>1302832512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -78566,7 +82606,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430928</BitOffs>
+            <BitOffs>1302832528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -78578,7 +82618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299448768</BitOffs>
+            <BitOffs>1302850368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -78591,7 +82631,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456704</BitOffs>
+            <BitOffs>1302858304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -78604,7 +82644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456712</BitOffs>
+            <BitOffs>1302858312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -78617,7 +82657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456720</BitOffs>
+            <BitOffs>1302858320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -78640,7 +82680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456736</BitOffs>
+            <BitOffs>1302858336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -78653,7 +82693,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456768</BitOffs>
+            <BitOffs>1302858368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -78666,7 +82706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456832</BitOffs>
+            <BitOffs>1302858432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -78679,7 +82719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456848</BitOffs>
+            <BitOffs>1302858448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -78691,7 +82731,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299474688</BitOffs>
+            <BitOffs>1302876288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -78704,7 +82744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482624</BitOffs>
+            <BitOffs>1302884224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -78717,7 +82757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482632</BitOffs>
+            <BitOffs>1302884232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -78730,7 +82770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482640</BitOffs>
+            <BitOffs>1302884240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -78753,7 +82793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482656</BitOffs>
+            <BitOffs>1302884256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -78766,7 +82806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482688</BitOffs>
+            <BitOffs>1302884288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -78779,7 +82819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482752</BitOffs>
+            <BitOffs>1302884352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -78792,7 +82832,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482768</BitOffs>
+            <BitOffs>1302884368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -78804,7 +82844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299500608</BitOffs>
+            <BitOffs>1302902208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -78817,7 +82857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508544</BitOffs>
+            <BitOffs>1302910144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -78830,7 +82870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508552</BitOffs>
+            <BitOffs>1302910152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -78843,7 +82883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508560</BitOffs>
+            <BitOffs>1302910160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -78866,7 +82906,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508576</BitOffs>
+            <BitOffs>1302910176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -78879,7 +82919,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508608</BitOffs>
+            <BitOffs>1302910208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -78892,7 +82932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508672</BitOffs>
+            <BitOffs>1302910272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -78905,7 +82945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508688</BitOffs>
+            <BitOffs>1302910288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -78917,7 +82957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299526528</BitOffs>
+            <BitOffs>1302928128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -78930,7 +82970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534464</BitOffs>
+            <BitOffs>1302936064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -78943,7 +82983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534472</BitOffs>
+            <BitOffs>1302936072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -78956,7 +82996,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534480</BitOffs>
+            <BitOffs>1302936080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -78979,7 +83019,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534496</BitOffs>
+            <BitOffs>1302936096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -78992,7 +83032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534528</BitOffs>
+            <BitOffs>1302936128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -79005,7 +83045,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534592</BitOffs>
+            <BitOffs>1302936192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -79018,7 +83058,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534608</BitOffs>
+            <BitOffs>1302936208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79030,7 +83070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299553984</BitOffs>
+            <BitOffs>1302955584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -79042,7 +83082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299879872</BitOffs>
+            <BitOffs>1303281472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -79055,7 +83095,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887808</BitOffs>
+            <BitOffs>1303289408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -79068,7 +83108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887816</BitOffs>
+            <BitOffs>1303289416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -79081,7 +83121,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887824</BitOffs>
+            <BitOffs>1303289424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -79104,7 +83144,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887840</BitOffs>
+            <BitOffs>1303289440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -79117,7 +83157,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887872</BitOffs>
+            <BitOffs>1303289472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -79130,7 +83170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887936</BitOffs>
+            <BitOffs>1303289536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -79143,7 +83183,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887952</BitOffs>
+            <BitOffs>1303289552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79155,7 +83195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299907328</BitOffs>
+            <BitOffs>1303308928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -79167,7 +83207,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300233216</BitOffs>
+            <BitOffs>1303634816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -79180,7 +83220,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241152</BitOffs>
+            <BitOffs>1303642752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -79193,7 +83233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241160</BitOffs>
+            <BitOffs>1303642760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -79206,7 +83246,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241168</BitOffs>
+            <BitOffs>1303642768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -79229,7 +83269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241184</BitOffs>
+            <BitOffs>1303642784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -79242,7 +83282,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241216</BitOffs>
+            <BitOffs>1303642816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -79255,7 +83295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241280</BitOffs>
+            <BitOffs>1303642880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -79268,7 +83308,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241296</BitOffs>
+            <BitOffs>1303642896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79280,7 +83320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300260672</BitOffs>
+            <BitOffs>1303662272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -79292,7 +83332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300586560</BitOffs>
+            <BitOffs>1303988160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -79305,7 +83345,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594496</BitOffs>
+            <BitOffs>1303996096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -79318,7 +83358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594504</BitOffs>
+            <BitOffs>1303996104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -79331,7 +83371,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594512</BitOffs>
+            <BitOffs>1303996112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -79354,7 +83394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594528</BitOffs>
+            <BitOffs>1303996128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -79367,7 +83407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594560</BitOffs>
+            <BitOffs>1303996160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -79380,7 +83420,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594624</BitOffs>
+            <BitOffs>1303996224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -79393,7 +83433,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594640</BitOffs>
+            <BitOffs>1303996240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79405,7 +83445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300614016</BitOffs>
+            <BitOffs>1304015616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -79417,7 +83457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300939904</BitOffs>
+            <BitOffs>1304341504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -79430,7 +83470,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947840</BitOffs>
+            <BitOffs>1304349440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -79443,7 +83483,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947848</BitOffs>
+            <BitOffs>1304349448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -79456,7 +83496,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947856</BitOffs>
+            <BitOffs>1304349456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -79479,7 +83519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947872</BitOffs>
+            <BitOffs>1304349472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -79492,7 +83532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947904</BitOffs>
+            <BitOffs>1304349504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -79505,7 +83545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947968</BitOffs>
+            <BitOffs>1304349568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -79518,7 +83558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947984</BitOffs>
+            <BitOffs>1304349584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79530,7 +83570,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300967360</BitOffs>
+            <BitOffs>1304368960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -79542,7 +83582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301293248</BitOffs>
+            <BitOffs>1304694848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -79555,7 +83595,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301184</BitOffs>
+            <BitOffs>1304702784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -79568,7 +83608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301192</BitOffs>
+            <BitOffs>1304702792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -79581,7 +83621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301200</BitOffs>
+            <BitOffs>1304702800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -79604,7 +83644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301216</BitOffs>
+            <BitOffs>1304702816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -79617,7 +83657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301248</BitOffs>
+            <BitOffs>1304702848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -79630,7 +83670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301312</BitOffs>
+            <BitOffs>1304702912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -79643,7 +83683,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301328</BitOffs>
+            <BitOffs>1304702928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79655,7 +83695,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301320704</BitOffs>
+            <BitOffs>1304722304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -79667,7 +83707,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301646592</BitOffs>
+            <BitOffs>1305048192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -79680,7 +83720,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654528</BitOffs>
+            <BitOffs>1305056128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -79693,7 +83733,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654536</BitOffs>
+            <BitOffs>1305056136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -79706,7 +83746,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654544</BitOffs>
+            <BitOffs>1305056144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -79729,7 +83769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654560</BitOffs>
+            <BitOffs>1305056160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -79742,7 +83782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654592</BitOffs>
+            <BitOffs>1305056192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -79755,7 +83795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654656</BitOffs>
+            <BitOffs>1305056256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -79768,7 +83808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654672</BitOffs>
+            <BitOffs>1305056272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79780,7 +83820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301674048</BitOffs>
+            <BitOffs>1305075648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -79792,7 +83832,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1301999936</BitOffs>
+            <BitOffs>1305401536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -79805,7 +83845,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302007872</BitOffs>
+            <BitOffs>1305409472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -79818,7 +83858,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302007880</BitOffs>
+            <BitOffs>1305409480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -79831,7 +83871,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302007888</BitOffs>
+            <BitOffs>1305409488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -79854,7 +83894,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302007904</BitOffs>
+            <BitOffs>1305409504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -79867,7 +83907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302007936</BitOffs>
+            <BitOffs>1305409536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -79880,7 +83920,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302008000</BitOffs>
+            <BitOffs>1305409600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -79893,7 +83933,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302008016</BitOffs>
+            <BitOffs>1305409616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -79905,7 +83945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302027392</BitOffs>
+            <BitOffs>1305428992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -79917,7 +83957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302353280</BitOffs>
+            <BitOffs>1305754880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -79930,7 +83970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361216</BitOffs>
+            <BitOffs>1305762816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -79943,7 +83983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361224</BitOffs>
+            <BitOffs>1305762824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -79956,7 +83996,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361232</BitOffs>
+            <BitOffs>1305762832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -79979,7 +84019,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361248</BitOffs>
+            <BitOffs>1305762848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -79992,7 +84032,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361280</BitOffs>
+            <BitOffs>1305762880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -80005,7 +84045,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361344</BitOffs>
+            <BitOffs>1305762944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -80018,7 +84058,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361360</BitOffs>
+            <BitOffs>1305762960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80030,7 +84070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302380736</BitOffs>
+            <BitOffs>1305782336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -80042,7 +84082,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302706624</BitOffs>
+            <BitOffs>1306108224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -80055,7 +84095,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714560</BitOffs>
+            <BitOffs>1306116160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -80068,7 +84108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714568</BitOffs>
+            <BitOffs>1306116168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -80081,7 +84121,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714576</BitOffs>
+            <BitOffs>1306116176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -80104,7 +84144,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714592</BitOffs>
+            <BitOffs>1306116192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -80117,7 +84157,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714624</BitOffs>
+            <BitOffs>1306116224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -80130,7 +84170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714688</BitOffs>
+            <BitOffs>1306116288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -80143,7 +84183,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714704</BitOffs>
+            <BitOffs>1306116304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80155,7 +84195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302734080</BitOffs>
+            <BitOffs>1306135680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -80167,7 +84207,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303059968</BitOffs>
+            <BitOffs>1306461568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -80180,7 +84220,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303067904</BitOffs>
+            <BitOffs>1306469504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -80193,7 +84233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303067912</BitOffs>
+            <BitOffs>1306469512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -80206,7 +84246,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303067920</BitOffs>
+            <BitOffs>1306469520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -80229,7 +84269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303067936</BitOffs>
+            <BitOffs>1306469536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -80242,7 +84282,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303067968</BitOffs>
+            <BitOffs>1306469568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -80255,7 +84295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303068032</BitOffs>
+            <BitOffs>1306469632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -80268,7 +84308,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303068048</BitOffs>
+            <BitOffs>1306469648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80280,7 +84320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303087424</BitOffs>
+            <BitOffs>1306489024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -80292,7 +84332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303413312</BitOffs>
+            <BitOffs>1306814912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -80305,7 +84345,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421248</BitOffs>
+            <BitOffs>1306822848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -80318,7 +84358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421256</BitOffs>
+            <BitOffs>1306822856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -80331,7 +84371,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421264</BitOffs>
+            <BitOffs>1306822864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -80354,7 +84394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421280</BitOffs>
+            <BitOffs>1306822880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -80367,7 +84407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421312</BitOffs>
+            <BitOffs>1306822912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -80380,7 +84420,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421376</BitOffs>
+            <BitOffs>1306822976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -80393,7 +84433,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421392</BitOffs>
+            <BitOffs>1306822992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80405,7 +84445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303440768</BitOffs>
+            <BitOffs>1306842368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -80417,7 +84457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303766656</BitOffs>
+            <BitOffs>1307168256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -80430,7 +84470,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774592</BitOffs>
+            <BitOffs>1307176192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -80443,7 +84483,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774600</BitOffs>
+            <BitOffs>1307176200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -80456,7 +84496,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774608</BitOffs>
+            <BitOffs>1307176208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -80479,7 +84519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774624</BitOffs>
+            <BitOffs>1307176224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -80492,7 +84532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774656</BitOffs>
+            <BitOffs>1307176256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -80505,7 +84545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774720</BitOffs>
+            <BitOffs>1307176320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -80518,7 +84558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774736</BitOffs>
+            <BitOffs>1307176336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -80530,7 +84570,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303794112</BitOffs>
+            <BitOffs>1307195712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -80545,7 +84585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304118912</BitOffs>
+            <BitOffs>1307520512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -80560,14 +84600,14 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304118928</BitOffs>
+            <BitOffs>1307520528</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -80720,7 +84760,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1282837504</BitOffs>
+            <BitOffs>1282848064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80732,7 +84772,154 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283172544</BitOffs>
+            <BitOffs>1283183104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284815424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284824408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284841344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284850328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284867264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1284876248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285206272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285533696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1285861120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286188544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286515968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1286843392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower01</Name>
@@ -80757,7 +84944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283498720</BitOffs>
+            <BitOffs>1287172800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower02</Name>
@@ -80782,7 +84969,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283498728</BitOffs>
+            <BitOffs>1287172808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower03</Name>
@@ -80807,7 +84994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283498736</BitOffs>
+            <BitOffs>1287172816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bFanOn</Name>
@@ -80831,10 +85018,10 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283498744</BitOffs>
+            <BitOffs>1287172824</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -80843,10 +85030,23 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283507520</BitOffs>
+            <BitOffs>1288503488</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288512472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -80855,10 +85055,23 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1283834944</BitOffs>
+            <BitOffs>1288529408</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1288538392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
@@ -80867,43 +85080,20 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284162368</BitOffs>
+            <BitOffs>1288555328</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284489792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1284817216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1285144640</BitOffs>
+            <BitOffs>1288564312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80915,7 +85105,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285537088</BitOffs>
+            <BitOffs>1288924096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80927,7 +85117,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285864512</BitOffs>
+            <BitOffs>1289251520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80939,7 +85129,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286191936</BitOffs>
+            <BitOffs>1289578944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80951,7 +85141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286519360</BitOffs>
+            <BitOffs>1289906368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -80963,7 +85153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286846784</BitOffs>
+            <BitOffs>1290233792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bLEDPower</Name>
@@ -80988,7 +85178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868352</BitOffs>
+            <BitOffs>1291255360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.iIlluminatorINT</Name>
@@ -81000,7 +85190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868480</BitOffs>
+            <BitOffs>1291255488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.bGigePower</Name>
@@ -81020,7 +85210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868496</BitOffs>
+            <BitOffs>1291255504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbSetIllPercent.iRaw</Name>
@@ -81033,7 +85223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287869568</BitOffs>
+            <BitOffs>1291256576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81045,7 +85235,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287872192</BitOffs>
+            <BitOffs>1291259200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -81061,7 +85251,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288201952</BitOffs>
+            <BitOffs>1291588960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -81081,7 +85271,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1294580328</BitOffs>
+            <BitOffs>1297967336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -81101,7 +85291,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295104680</BitOffs>
+            <BitOffs>1298491688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -81113,7 +85303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295629184</BitOffs>
+            <BitOffs>1299030784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -81126,7 +85316,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295638168</BitOffs>
+            <BitOffs>1299039768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81138,7 +85328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295656640</BitOffs>
+            <BitOffs>1299058240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -81150,7 +85340,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295982528</BitOffs>
+            <BitOffs>1299384128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -81163,7 +85353,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1295991512</BitOffs>
+            <BitOffs>1299393112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81175,7 +85365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296009984</BitOffs>
+            <BitOffs>1299411584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -81187,7 +85377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296335872</BitOffs>
+            <BitOffs>1299737472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -81200,7 +85390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296344856</BitOffs>
+            <BitOffs>1299746456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81212,7 +85402,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296363328</BitOffs>
+            <BitOffs>1299764928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -81224,7 +85414,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296689216</BitOffs>
+            <BitOffs>1300090816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -81237,7 +85427,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296698200</BitOffs>
+            <BitOffs>1300099800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81249,7 +85439,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296716672</BitOffs>
+            <BitOffs>1300118272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -81261,7 +85451,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297042560</BitOffs>
+            <BitOffs>1300444160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -81274,7 +85464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297051544</BitOffs>
+            <BitOffs>1300453144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -81286,7 +85476,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297068480</BitOffs>
+            <BitOffs>1300470080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -81299,7 +85489,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077464</BitOffs>
+            <BitOffs>1300479064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -81311,7 +85501,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297094400</BitOffs>
+            <BitOffs>1300496000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -81324,7 +85514,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297103384</BitOffs>
+            <BitOffs>1300504984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -81336,7 +85526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297120320</BitOffs>
+            <BitOffs>1300521920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -81349,7 +85539,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297129304</BitOffs>
+            <BitOffs>1300530904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -81361,7 +85551,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297146240</BitOffs>
+            <BitOffs>1300547840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -81374,7 +85564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297155224</BitOffs>
+            <BitOffs>1300556824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -81386,7 +85576,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297172160</BitOffs>
+            <BitOffs>1300573760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -81399,7 +85589,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297181144</BitOffs>
+            <BitOffs>1300582744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -81411,7 +85601,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297198080</BitOffs>
+            <BitOffs>1300599680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -81424,7 +85614,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297207064</BitOffs>
+            <BitOffs>1300608664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -81436,7 +85626,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297224000</BitOffs>
+            <BitOffs>1300625600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -81449,7 +85639,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297232984</BitOffs>
+            <BitOffs>1300634584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81461,7 +85651,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297251456</BitOffs>
+            <BitOffs>1300653056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -81473,7 +85663,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297577344</BitOffs>
+            <BitOffs>1300978944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -81486,7 +85676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297586328</BitOffs>
+            <BitOffs>1300987928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81498,7 +85688,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297604800</BitOffs>
+            <BitOffs>1301006400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -81510,7 +85700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297930688</BitOffs>
+            <BitOffs>1301332288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -81523,7 +85713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297939672</BitOffs>
+            <BitOffs>1301341272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81535,7 +85725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1297958144</BitOffs>
+            <BitOffs>1301359744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -81547,7 +85737,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298284032</BitOffs>
+            <BitOffs>1301685632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -81560,7 +85750,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298293016</BitOffs>
+            <BitOffs>1301694616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81572,7 +85762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298311488</BitOffs>
+            <BitOffs>1301713088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -81584,7 +85774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298637376</BitOffs>
+            <BitOffs>1302038976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -81597,7 +85787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298646360</BitOffs>
+            <BitOffs>1302047960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -81609,7 +85799,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298663296</BitOffs>
+            <BitOffs>1302064896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -81622,7 +85812,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298672280</BitOffs>
+            <BitOffs>1302073880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81634,7 +85824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1298690752</BitOffs>
+            <BitOffs>1302092352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -81646,7 +85836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299016640</BitOffs>
+            <BitOffs>1302418240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -81659,7 +85849,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299025624</BitOffs>
+            <BitOffs>1302427224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81671,7 +85861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299044096</BitOffs>
+            <BitOffs>1302445696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -81683,7 +85873,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299369984</BitOffs>
+            <BitOffs>1302771584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -81696,7 +85886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299378968</BitOffs>
+            <BitOffs>1302780568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -81708,7 +85898,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299395904</BitOffs>
+            <BitOffs>1302797504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -81721,7 +85911,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299404888</BitOffs>
+            <BitOffs>1302806488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -81733,7 +85923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299421824</BitOffs>
+            <BitOffs>1302823424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -81746,7 +85936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299430808</BitOffs>
+            <BitOffs>1302832408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -81758,7 +85948,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299447744</BitOffs>
+            <BitOffs>1302849344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -81771,7 +85961,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299456728</BitOffs>
+            <BitOffs>1302858328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -81783,7 +85973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299473664</BitOffs>
+            <BitOffs>1302875264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -81796,7 +85986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299482648</BitOffs>
+            <BitOffs>1302884248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -81808,7 +85998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299499584</BitOffs>
+            <BitOffs>1302901184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -81821,7 +86011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299508568</BitOffs>
+            <BitOffs>1302910168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -81833,7 +86023,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299525504</BitOffs>
+            <BitOffs>1302927104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -81846,7 +86036,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299534488</BitOffs>
+            <BitOffs>1302936088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81858,7 +86048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299552960</BitOffs>
+            <BitOffs>1302954560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -81870,7 +86060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299878848</BitOffs>
+            <BitOffs>1303280448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -81883,7 +86073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299887832</BitOffs>
+            <BitOffs>1303289432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81895,7 +86085,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299906304</BitOffs>
+            <BitOffs>1303307904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -81907,7 +86097,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300232192</BitOffs>
+            <BitOffs>1303633792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -81920,7 +86110,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300241176</BitOffs>
+            <BitOffs>1303642776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81932,7 +86122,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300259648</BitOffs>
+            <BitOffs>1303661248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -81944,7 +86134,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300585536</BitOffs>
+            <BitOffs>1303987136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -81957,7 +86147,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300594520</BitOffs>
+            <BitOffs>1303996120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -81969,7 +86159,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300612992</BitOffs>
+            <BitOffs>1304014592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -81981,7 +86171,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300938880</BitOffs>
+            <BitOffs>1304340480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -81994,7 +86184,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300947864</BitOffs>
+            <BitOffs>1304349464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82006,7 +86196,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1300966336</BitOffs>
+            <BitOffs>1304367936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -82018,7 +86208,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301292224</BitOffs>
+            <BitOffs>1304693824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -82031,7 +86221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301301208</BitOffs>
+            <BitOffs>1304702808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82043,7 +86233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301319680</BitOffs>
+            <BitOffs>1304721280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -82055,7 +86245,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301645568</BitOffs>
+            <BitOffs>1305047168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -82068,7 +86258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301654552</BitOffs>
+            <BitOffs>1305056152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82080,7 +86270,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301673024</BitOffs>
+            <BitOffs>1305074624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -82092,7 +86282,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1301998912</BitOffs>
+            <BitOffs>1305400512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -82105,7 +86295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302007896</BitOffs>
+            <BitOffs>1305409496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82117,7 +86307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302026368</BitOffs>
+            <BitOffs>1305427968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -82129,7 +86319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302352256</BitOffs>
+            <BitOffs>1305753856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -82142,7 +86332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302361240</BitOffs>
+            <BitOffs>1305762840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82154,7 +86344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302379712</BitOffs>
+            <BitOffs>1305781312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -82166,7 +86356,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302705600</BitOffs>
+            <BitOffs>1306107200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -82179,7 +86369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302714584</BitOffs>
+            <BitOffs>1306116184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82191,7 +86381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1302733056</BitOffs>
+            <BitOffs>1306134656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -82203,7 +86393,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303058944</BitOffs>
+            <BitOffs>1306460544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -82216,7 +86406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303067928</BitOffs>
+            <BitOffs>1306469528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82228,7 +86418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303086400</BitOffs>
+            <BitOffs>1306488000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -82240,7 +86430,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303412288</BitOffs>
+            <BitOffs>1306813888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -82253,7 +86443,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303421272</BitOffs>
+            <BitOffs>1306822872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82265,7 +86455,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303439744</BitOffs>
+            <BitOffs>1306841344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -82277,7 +86467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303765632</BitOffs>
+            <BitOffs>1307167232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -82290,7 +86480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303774616</BitOffs>
+            <BitOffs>1307176216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -82302,14 +86492,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303793088</BitOffs>
+            <BitOffs>1307194688</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -89469,54 +93659,35 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264816960</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PiezoSerial.rtInitParams_M1K2</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265046656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
-            <Comment>For timeout reset</Comment>
-            <BitSize>256</BitSize>
-            <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.PT</Name>
-                <DateTime>T#2S</DateTime>
-              </SubItem>
-            </Default>
-            <BitOffs>1265046784</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
             <Comment> Temp testing</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1265051744</BitOffs>
+            <BitOffs>1264935648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1265051760</BitOffs>
+            <BitOffs>1264935664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <BitOffs>1265827776</BitOffs>
+            <BitOffs>1265711680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bM1K1PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265827792</BitOffs>
+            <BitOffs>1265711696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.bM1K1PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265827800</BitOffs>
+            <BitOffs>1265711704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.nEncCntYupM1K1</Name>
@@ -89533,7 +93704,26 @@ Emergency Stop for MR1K1</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265827872</BitOffs>
+            <BitOffs>1265711776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PiezoSerial.rtInitParams_M1K2</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
+            <BitOffs>1265827520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
+            <Comment>For timeout reset</Comment>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="Tc2_Standard">TON</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.PT</Name>
+                <DateTime>T#2S</DateTime>
+              </SubItem>
+            </Default>
+            <BitOffs>1265827648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -90248,7 +94438,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1281586496</BitOffs>
+            <BitOffs>1281597056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
@@ -90263,19 +94453,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1281610048</BitOffs>
+            <BitOffs>1281620608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281997568</BitOffs>
+            <BitOffs>1282008128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1281997632</BitOffs>
+            <BitOffs>1282008192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
@@ -90289,19 +94479,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1281997696</BitOffs>
+            <BitOffs>1282008256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282385216</BitOffs>
+            <BitOffs>1282395776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282385280</BitOffs>
+            <BitOffs>1282395840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
@@ -90315,38 +94505,53 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1282385344</BitOffs>
+            <BitOffs>1282395904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282772864</BitOffs>
+            <BitOffs>1282783424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1282772928</BitOffs>
+            <BitOffs>1282783488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1282772992</BitOffs>
+            <BitOffs>1282783552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1283170880</BitOffs>
+            <BitOffs>1283181440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1283170888</BitOffs>
+            <BitOffs>1283181448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR1K2:SWITCH:COATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283181456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYleftM1K2</Name>
@@ -90363,7 +94568,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283170912</BitOffs>
+            <BitOffs>1283181472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -90371,7 +94576,7 @@ M1K1 BEND US ENC CNT</Comment>
  Using stepper only for now</Comment>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283170944</BitOffs>
+            <BitOffs>1283181504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fYRoll_urad</Name>
@@ -90388,7 +94593,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498368</BitOffs>
+            <BitOffs>1283508928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYrightM1K2</Name>
@@ -90404,7 +94609,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498432</BitOffs>
+            <BitOffs>1283508992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXupM1K2</Name>
@@ -90420,7 +94625,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498464</BitOffs>
+            <BitOffs>1283509024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXdwnM1K2</Name>
@@ -90436,7 +94641,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498496</BitOffs>
+            <BitOffs>1283509056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntPitchM1K2</Name>
@@ -90452,7 +94657,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498528</BitOffs>
+            <BitOffs>1283509088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYleftM1K2</Name>
@@ -90469,7 +94674,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498560</BitOffs>
+            <BitOffs>1283509120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYrightM1K2</Name>
@@ -90485,7 +94690,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498592</BitOffs>
+            <BitOffs>1283509152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXupM1K2</Name>
@@ -90501,7 +94706,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498624</BitOffs>
+            <BitOffs>1283509184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXdwnM1K2</Name>
@@ -90517,7 +94722,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498656</BitOffs>
+            <BitOffs>1283509216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefPitchM1K2</Name>
@@ -90533,20 +94738,35 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283498688</BitOffs>
+            <BitOffs>1283509248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR1K2:SWITCH:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283509280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.mcReadParameterPitchM1K2</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1283498752</BitOffs>
+            <BitOffs>1283509312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncRefPitchM1K2_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1283503744</BitOffs>
+            <BitOffs>1283514304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncLeverArm_mm</Name>
@@ -90556,7 +94776,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>391</Value>
             </Default>
-            <BitOffs>1283503808</BitOffs>
+            <BitOffs>1283514368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1</Name>
@@ -90569,7 +94789,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1283503872</BitOffs>
+            <BitOffs>1283514432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1_val</Name>
@@ -90585,7 +94805,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283504384</BitOffs>
+            <BitOffs>1283514944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2</Name>
@@ -90597,7 +94817,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1283504448</BitOffs>
+            <BitOffs>1283515008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2_val</Name>
@@ -90613,7 +94833,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283504960</BitOffs>
+            <BitOffs>1283515520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1</Name>
@@ -90625,7 +94845,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1283505024</BitOffs>
+            <BitOffs>1283515584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1_val</Name>
@@ -90641,43 +94861,71 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283505536</BitOffs>
+            <BitOffs>1283516096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbCoatingStates</Name>
+            <BitSize>1541120</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR1K2:SWITCH:COATING</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1283516160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.fbYSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1285057280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K2_SWITCH.astCoatingStatesY</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1285149632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283505920</BitOffs>
+            <BitOffs>1285204672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1283833344</BitOffs>
+            <BitOffs>1285532096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284160768</BitOffs>
+            <BitOffs>1285859520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284488192</BitOffs>
+            <BitOffs>1286186944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1284815616</BitOffs>
+            <BitOffs>1286514368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285143040</BitOffs>
+            <BitOffs>1286841792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upeurad</Name>
@@ -90692,7 +94940,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285470720</BitOffs>
+            <BitOffs>1287169472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upeurad</Name>
@@ -90707,7 +94955,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285470784</BitOffs>
+            <BitOffs>1287169536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1</Name>
@@ -90730,7 +94978,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285470848</BitOffs>
+            <BitOffs>1287169600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2</Name>
@@ -90752,7 +95000,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471104</BitOffs>
+            <BitOffs>1287169856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3</Name>
@@ -90774,7 +95022,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471360</BitOffs>
+            <BitOffs>1287170112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4</Name>
@@ -90796,7 +95044,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471616</BitOffs>
+            <BitOffs>1287170368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5</Name>
@@ -90818,7 +95066,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285471872</BitOffs>
+            <BitOffs>1287170624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6</Name>
@@ -90840,7 +95088,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472128</BitOffs>
+            <BitOffs>1287170880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7</Name>
@@ -90862,7 +95110,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472384</BitOffs>
+            <BitOffs>1287171136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8</Name>
@@ -90884,7 +95132,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472640</BitOffs>
+            <BitOffs>1287171392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9</Name>
@@ -90906,7 +95154,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285472896</BitOffs>
+            <BitOffs>1287171648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10</Name>
@@ -90928,7 +95176,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473152</BitOffs>
+            <BitOffs>1287171904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11</Name>
@@ -90950,7 +95198,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473408</BitOffs>
+            <BitOffs>1287172160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12</Name>
@@ -90972,7 +95220,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1285473664</BitOffs>
+            <BitOffs>1287172416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_read</Name>
@@ -90988,7 +95236,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285473920</BitOffs>
+            <BitOffs>1287172672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_set</Name>
@@ -91003,7 +95251,37 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285473984</BitOffs>
+            <BitOffs>1287172736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_Grating_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: SP1K1:MONO:GRATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1287172832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_Grating_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: SP1K1:MONO:GRATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1287172848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_FFO</Name>
@@ -91023,7 +95301,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>4368</Value>
               </SubItem>
             </Default>
-            <BitOffs>1285474048</BitOffs>
+            <BitOffs>1287172864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_e_pmps</Name>
@@ -91032,7 +95310,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>74000.29</Value>
             </Default>
-            <BitOffs>1285499968</BitOffs>
+            <BitOffs>1287198784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1</Name>
@@ -91045,7 +95323,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1285500032</BitOffs>
+            <BitOffs>1287198848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1_val</Name>
@@ -91061,7 +95339,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285500544</BitOffs>
+            <BitOffs>1287199360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2</Name>
@@ -91073,7 +95351,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1285500608</BitOffs>
+            <BitOffs>1287199424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2_val</Name>
@@ -91089,7 +95367,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285501120</BitOffs>
+            <BitOffs>1287199936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1</Name>
@@ -91101,7 +95379,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1285501184</BitOffs>
+            <BitOffs>1287200000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1_val</Name>
@@ -91117,7 +95395,71 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285501696</BitOffs>
+            <BitOffs>1287200512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.stDefaultGH</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>875</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fAccel</Name>
+                <Value>6923</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fDecel</Name>
+                <Value>6923</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bUseRawCounts</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <BitOffs>1287200576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGratingStates</Name>
+            <BitSize>1541120</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: SP1K1:MONO:GRATING</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1287204224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.fbGHSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1288745344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_SP1K1_MONO.astGratingStates</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1288837696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -91137,37 +95479,37 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>3664</Value>
               </SubItem>
             </Default>
-            <BitOffs>1285509568</BitOffs>
+            <BitOffs>1288896576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285535488</BitOffs>
+            <BitOffs>1288922496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285862912</BitOffs>
+            <BitOffs>1289249920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286190336</BitOffs>
+            <BitOffs>1289577344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286517760</BitOffs>
+            <BitOffs>1289904768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1286845184</BitOffs>
+            <BitOffs>1290232192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbStates</Name>
@@ -91182,7 +95524,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287172608</BitOffs>
+            <BitOffs>1290559616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP</Name>
@@ -91203,7 +95545,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_1]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867328</BitOffs>
+            <BitOffs>1291254336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM</Name>
@@ -91224,7 +95566,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_2]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867584</BitOffs>
+            <BitOffs>1291254592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG</Name>
@@ -91245,7 +95587,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_4]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287867840</BitOffs>
+            <BitOffs>1291254848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync</Name>
@@ -91266,7 +95608,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_3]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868096</BitOffs>
+            <BitOffs>1291255104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bInit</Name>
@@ -91275,7 +95617,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1287868360</BitOffs>
+            <BitOffs>1291255368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
@@ -91291,7 +95633,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287868368</BitOffs>
+            <BitOffs>1291255376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
@@ -91307,7 +95649,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287868376</BitOffs>
+            <BitOffs>1291255384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.delta</Name>
@@ -91316,7 +95658,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1287868384</BitOffs>
+            <BitOffs>1291255392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige</Name>
@@ -91335,7 +95677,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bGigePower := TIIB[EL2004_SL1K2]^Channel 3^Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287868416</BitOffs>
+            <BitOffs>1291255424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter</Name>
@@ -91365,7 +95707,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3052_SL1K2_FWM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1287869760</BitOffs>
+            <BitOffs>1291256768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fSmallDelta</Name>
@@ -91375,7 +95717,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.01</Value>
             </Default>
-            <BitOffs>1287870272</BitOffs>
+            <BitOffs>1291257280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fBigDelta</Name>
@@ -91384,7 +95726,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>10</Value>
             </Default>
-            <BitOffs>1287870336</BitOffs>
+            <BitOffs>1291257344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fMaxVelocity</Name>
@@ -91393,7 +95735,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.5</Value>
             </Default>
-            <BitOffs>1287870400</BitOffs>
+            <BitOffs>1291257408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fHighAccel</Name>
@@ -91402,7 +95744,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.8</Value>
             </Default>
-            <BitOffs>1287870464</BitOffs>
+            <BitOffs>1291257472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fLowAccel</Name>
@@ -91411,25 +95753,25 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1287870528</BitOffs>
+            <BitOffs>1291257536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287870592</BitOffs>
+            <BitOffs>1291257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO</Name>
             <BitSize>145024</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>1288199232</BitOffs>
+            <BitOffs>1291586240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>1288344256</BitOffs>
+            <BitOffs>1291731264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ff2_ff1_link_optics</Name>
@@ -91453,7 +95795,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>65535</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288372608</BitOffs>
+            <BitOffs>1291759616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX01</Name>
@@ -91478,7 +95820,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62729</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288398528</BitOffs>
+            <BitOffs>1291785536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX02</Name>
@@ -91502,7 +95844,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62736</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288424448</BitOffs>
+            <BitOffs>1291811456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX05</Name>
@@ -91526,7 +95868,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62737</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288450368</BitOffs>
+            <BitOffs>1291837376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeam</Name>
@@ -91551,7 +95893,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288476288</BitOffs>
+            <BitOffs>1291863296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOS_IN</Name>
@@ -91567,7 +95909,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288502208</BitOffs>
+            <BitOffs>1291889216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOB_on_Lower_Stopper</Name>
@@ -91583,7 +95925,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288502216</BitOffs>
+            <BitOffs>1291889224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
@@ -91599,7 +95941,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288502224</BitOffs>
+            <BitOffs>1291889232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
@@ -91615,7 +95957,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288502232</BitOffs>
+            <BitOffs>1291889240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.nMachineMode</Name>
@@ -91633,110 +95975,110 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288502240</BitOffs>
+            <BitOffs>1291889248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502272</BitOffs>
+            <BitOffs>1291889280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502336</BitOffs>
+            <BitOffs>1291889344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502400</BitOffs>
+            <BitOffs>1291889408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502464</BitOffs>
+            <BitOffs>1291889472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.HZos</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502528</BitOffs>
+            <BitOffs>1291889536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502592</BitOffs>
+            <BitOffs>1291889600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502656</BitOffs>
+            <BitOffs>1291889664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502720</BitOffs>
+            <BitOffs>1291889728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502784</BitOffs>
+            <BitOffs>1291889792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502848</BitOffs>
+            <BitOffs>1291889856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502912</BitOffs>
+            <BitOffs>1291889920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hb0m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288502976</BitOffs>
+            <BitOffs>1291889984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm3</Name>
             <Comment>fixed calc</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288503040</BitOffs>
+            <BitOffs>1291890048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hpiv</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288503104</BitOffs>
+            <BitOffs>1291890112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288503168</BitOffs>
+            <BitOffs>1291890176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288503232</BitOffs>
+            <BitOffs>1291890240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288503296</BitOffs>
+            <BitOffs>1291890304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Delta</Name>
@@ -91752,13 +96094,13 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1288503360</BitOffs>
+            <BitOffs>1291890368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Ans</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288503424</BitOffs>
+            <BitOffs>1291890432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeamExitSlits</Name>
@@ -91782,7 +96124,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1288503488</BitOffs>
+            <BitOffs>1291890496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hi2</Name>
@@ -91792,7 +96134,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>1.4</Value>
             </Default>
-            <BitOffs>1288529408</BitOffs>
+            <BitOffs>1291916416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zi2</Name>
@@ -91802,7 +96144,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>731.613</Value>
             </Default>
-            <BitOffs>1288529472</BitOffs>
+            <BitOffs>1291916480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta0</Name>
@@ -91811,7 +96153,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>1288529536</BitOffs>
+            <BitOffs>1291916544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zm1</Name>
@@ -91821,7 +96163,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>733.772</Value>
             </Default>
-            <BitOffs>1288529600</BitOffs>
+            <BitOffs>1291916608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zmon</Name>
@@ -91831,7 +96173,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>739.622</Value>
             </Default>
-            <BitOffs>1288529664</BitOffs>
+            <BitOffs>1291916672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zpiv</Name>
@@ -91841,7 +96183,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>739.762</Value>
             </Default>
-            <BitOffs>1288529728</BitOffs>
+            <BitOffs>1291916736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zzos</Name>
@@ -91851,7 +96193,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>741.422</Value>
             </Default>
-            <BitOffs>1288529792</BitOffs>
+            <BitOffs>1291916800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1Offset</Name>
@@ -91860,7 +96202,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>18081.1</Value>
             </Default>
-            <BitOffs>1288529856</BitOffs>
+            <BitOffs>1291916864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2Offset</Name>
@@ -91869,7 +96211,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>-90603</Value>
             </Default>
-            <BitOffs>1288529920</BitOffs>
+            <BitOffs>1291916928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3Offset</Name>
@@ -91879,7 +96221,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>-63300</Value>
             </Default>
-            <BitOffs>1288529984</BitOffs>
+            <BitOffs>1291916992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
@@ -91893,19 +96235,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1288530688</BitOffs>
+            <BitOffs>1291917696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288918208</BitOffs>
+            <BitOffs>1292305216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1288918272</BitOffs>
+            <BitOffs>1292305280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
@@ -91918,19 +96260,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1288918336</BitOffs>
+            <BitOffs>1292305344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289305856</BitOffs>
+            <BitOffs>1292692864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289305920</BitOffs>
+            <BitOffs>1292692928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
@@ -91943,19 +96285,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1289305984</BitOffs>
+            <BitOffs>1292692992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289693504</BitOffs>
+            <BitOffs>1293080512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1289693568</BitOffs>
+            <BitOffs>1293080576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefXM2K2</Name>
@@ -91973,7 +96315,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693632</BitOffs>
+            <BitOffs>1293080640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefYM2K2</Name>
@@ -91990,7 +96332,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693664</BitOffs>
+            <BitOffs>1293080672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefrXM2K2</Name>
@@ -92007,7 +96349,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693696</BitOffs>
+            <BitOffs>1293080704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntXM2K2</Name>
@@ -92025,7 +96367,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693728</BitOffs>
+            <BitOffs>1293080736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntYM2K2</Name>
@@ -92042,7 +96384,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693760</BitOffs>
+            <BitOffs>1293080768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntrXM2K2</Name>
@@ -92059,7 +96401,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693792</BitOffs>
+            <BitOffs>1293080800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
@@ -92080,7 +96422,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289693824</BitOffs>
+            <BitOffs>1293080832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
@@ -92094,19 +96436,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1289695616</BitOffs>
+            <BitOffs>1293082624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290083136</BitOffs>
+            <BitOffs>1293470144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290083200</BitOffs>
+            <BitOffs>1293470208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
@@ -92119,19 +96461,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1290083264</BitOffs>
+            <BitOffs>1293470272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290470784</BitOffs>
+            <BitOffs>1293857792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290470848</BitOffs>
+            <BitOffs>1293857856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
@@ -92144,19 +96486,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1290470912</BitOffs>
+            <BitOffs>1293857920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290858432</BitOffs>
+            <BitOffs>1294245440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1290858496</BitOffs>
+            <BitOffs>1294245504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
@@ -92169,19 +96511,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1290858560</BitOffs>
+            <BitOffs>1294245568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291246080</BitOffs>
+            <BitOffs>1294633088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291246144</BitOffs>
+            <BitOffs>1294633152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
@@ -92194,19 +96536,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1291246208</BitOffs>
+            <BitOffs>1294633216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291633728</BitOffs>
+            <BitOffs>1295020736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1291633792</BitOffs>
+            <BitOffs>1295020800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefXM3K2</Name>
@@ -92224,7 +96566,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291633856</BitOffs>
+            <BitOffs>1295020864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefYM3K2</Name>
@@ -92241,7 +96583,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291633888</BitOffs>
+            <BitOffs>1295020896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefrYM3K2</Name>
@@ -92258,7 +96600,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291633920</BitOffs>
+            <BitOffs>1295020928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefUSM3K2</Name>
@@ -92275,7 +96617,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291633952</BitOffs>
+            <BitOffs>1295020960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefDSM3K2</Name>
@@ -92292,7 +96634,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291633984</BitOffs>
+            <BitOffs>1295020992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntXM3K2</Name>
@@ -92310,7 +96652,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634016</BitOffs>
+            <BitOffs>1295021024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntYM3K2</Name>
@@ -92327,7 +96669,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634048</BitOffs>
+            <BitOffs>1295021056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntrYM3K2</Name>
@@ -92344,7 +96686,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634080</BitOffs>
+            <BitOffs>1295021088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntUSM3K2</Name>
@@ -92361,7 +96703,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634112</BitOffs>
+            <BitOffs>1295021120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntDSM3K2</Name>
@@ -92378,7 +96720,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634144</BitOffs>
+            <BitOffs>1295021152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_1</Name>
@@ -92397,7 +96739,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634176</BitOffs>
+            <BitOffs>1295021184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_2</Name>
@@ -92414,7 +96756,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634208</BitOffs>
+            <BitOffs>1295021216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
@@ -92431,7 +96773,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634240</BitOffs>
+            <BitOffs>1295021248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
@@ -92449,7 +96791,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634272</BitOffs>
+            <BitOffs>1295021280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
@@ -92466,7 +96808,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634304</BitOffs>
+            <BitOffs>1295021312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -92483,7 +96825,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634336</BitOffs>
+            <BitOffs>1295021344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
@@ -92504,7 +96846,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1291634432</BitOffs>
+            <BitOffs>1295021440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
@@ -92518,19 +96860,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1291635648</BitOffs>
+            <BitOffs>1295022656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292023168</BitOffs>
+            <BitOffs>1295410176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292023232</BitOffs>
+            <BitOffs>1295410240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
@@ -92543,19 +96885,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1292023296</BitOffs>
+            <BitOffs>1295410304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292410816</BitOffs>
+            <BitOffs>1295797824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292410880</BitOffs>
+            <BitOffs>1295797888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
@@ -92568,19 +96910,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1292410944</BitOffs>
+            <BitOffs>1295797952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292798464</BitOffs>
+            <BitOffs>1296185472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1292798528</BitOffs>
+            <BitOffs>1296185536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
@@ -92593,19 +96935,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1292798592</BitOffs>
+            <BitOffs>1296185600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293186112</BitOffs>
+            <BitOffs>1296573120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293186176</BitOffs>
+            <BitOffs>1296573184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
@@ -92618,19 +96960,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1293186240</BitOffs>
+            <BitOffs>1296573248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293573760</BitOffs>
+            <BitOffs>1296960768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293573824</BitOffs>
+            <BitOffs>1296960832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -92648,7 +96990,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293573888</BitOffs>
+            <BitOffs>1296960896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -92665,7 +97007,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293573920</BitOffs>
+            <BitOffs>1296960928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -92682,7 +97024,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293573952</BitOffs>
+            <BitOffs>1296960960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -92699,7 +97041,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293573984</BitOffs>
+            <BitOffs>1296960992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -92716,7 +97058,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574016</BitOffs>
+            <BitOffs>1296961024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -92734,7 +97076,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574048</BitOffs>
+            <BitOffs>1296961056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -92751,7 +97093,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574080</BitOffs>
+            <BitOffs>1296961088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -92768,7 +97110,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574112</BitOffs>
+            <BitOffs>1296961120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -92785,7 +97127,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574144</BitOffs>
+            <BitOffs>1296961152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -92802,7 +97144,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574176</BitOffs>
+            <BitOffs>1296961184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -92821,7 +97163,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574208</BitOffs>
+            <BitOffs>1296961216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -92838,7 +97180,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574240</BitOffs>
+            <BitOffs>1296961248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -92855,7 +97197,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574272</BitOffs>
+            <BitOffs>1296961280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -92873,7 +97215,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574304</BitOffs>
+            <BitOffs>1296961312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
@@ -92890,7 +97232,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574336</BitOffs>
+            <BitOffs>1296961344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
@@ -92907,7 +97249,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574368</BitOffs>
+            <BitOffs>1296961376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
@@ -92930,7 +97272,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574400</BitOffs>
+            <BitOffs>1296961408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
@@ -92953,7 +97295,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574656</BitOffs>
+            <BitOffs>1296961664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
@@ -92974,7 +97316,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293574976</BitOffs>
+            <BitOffs>1296961984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -93009,7 +97351,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293581248</BitOffs>
+            <BitOffs>1296968256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -93024,7 +97366,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293583744</BitOffs>
+            <BitOffs>1296970752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -93038,7 +97380,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293583808</BitOffs>
+            <BitOffs>1296970816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -93053,7 +97395,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293583872</BitOffs>
+            <BitOffs>1296970880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -93068,7 +97410,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293583936</BitOffs>
+            <BitOffs>1296970944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -93083,7 +97425,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584000</BitOffs>
+            <BitOffs>1296971008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -93098,7 +97440,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584064</BitOffs>
+            <BitOffs>1296971072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -93114,7 +97456,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584192</BitOffs>
+            <BitOffs>1296971200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -93128,7 +97470,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584256</BitOffs>
+            <BitOffs>1296971264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -93142,7 +97484,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584320</BitOffs>
+            <BitOffs>1296971328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -93156,7 +97498,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293584384</BitOffs>
+            <BitOffs>1296971392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -93171,7 +97513,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293586944</BitOffs>
+            <BitOffs>1296973952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -93186,7 +97528,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587008</BitOffs>
+            <BitOffs>1296974016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -93201,7 +97543,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587072</BitOffs>
+            <BitOffs>1296974080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -93217,7 +97559,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587136</BitOffs>
+            <BitOffs>1296974144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -93231,7 +97573,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587200</BitOffs>
+            <BitOffs>1296974208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -93245,7 +97587,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587264</BitOffs>
+            <BitOffs>1296974272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -93260,7 +97602,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587328</BitOffs>
+            <BitOffs>1296974336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -93275,7 +97617,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587392</BitOffs>
+            <BitOffs>1296974400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -93291,7 +97633,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587584</BitOffs>
+            <BitOffs>1296974592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -93305,7 +97647,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587648</BitOffs>
+            <BitOffs>1296974656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -93319,7 +97661,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587712</BitOffs>
+            <BitOffs>1296974720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -93334,7 +97676,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587776</BitOffs>
+            <BitOffs>1296974784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -93349,7 +97691,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587840</BitOffs>
+            <BitOffs>1296974848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -93364,7 +97706,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587904</BitOffs>
+            <BitOffs>1296974912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -93379,7 +97721,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293587968</BitOffs>
+            <BitOffs>1296974976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -93394,7 +97736,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588032</BitOffs>
+            <BitOffs>1296975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -93409,7 +97751,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588096</BitOffs>
+            <BitOffs>1296975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -93425,7 +97767,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588224</BitOffs>
+            <BitOffs>1296975232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -93439,7 +97781,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588288</BitOffs>
+            <BitOffs>1296975296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -93453,7 +97795,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588352</BitOffs>
+            <BitOffs>1296975360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -93467,7 +97809,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588416</BitOffs>
+            <BitOffs>1296975424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -93482,7 +97824,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588480</BitOffs>
+            <BitOffs>1296975488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -93493,7 +97835,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588512</BitOffs>
+            <BitOffs>1296975520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -93511,7 +97853,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1293588544</BitOffs>
+            <BitOffs>1296975552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -93529,7 +97871,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294084288</BitOffs>
+            <BitOffs>1297471296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -93558,7 +97900,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1294580032</BitOffs>
+            <BitOffs>1297967040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -93587,7 +97929,171 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295104384</BitOffs>
+            <BitOffs>1298491392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_States.stDefaultOffsetY</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fAccel</Name>
+                <Value>5050</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fDecel</Name>
+                <Value>5050</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bUseRawCounts</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1299016128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_States.stDefaultOffsetX</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>10000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fAccel</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fDecel</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bUseRawCounts</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1299019776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_States.stDefaultKBX</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>5</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fAccel</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fDecel</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bUseRawCounts</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1299023424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_States.stDefaultKBY</Name>
+            <BitSize>3648</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fDelta</Name>
+                <Value>5</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fAccel</Name>
+                <Value>10</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.fDecel</Name>
+                <Value>10</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bMoveOk</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bValid</Name>
+                <Bool>true</Bool>
+              </SubItem>
+              <SubItem>
+                <Name>.bUseRawCounts</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1299027072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -93625,7 +98131,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295629120</BitOffs>
+            <BitOffs>1299030720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -93636,7 +98142,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295655040</BitOffs>
+            <BitOffs>1299056640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -93674,7 +98180,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1295982464</BitOffs>
+            <BitOffs>1299384064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -93685,7 +98191,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296008384</BitOffs>
+            <BitOffs>1299409984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -93723,7 +98229,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296335808</BitOffs>
+            <BitOffs>1299737408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -93734,7 +98240,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296361728</BitOffs>
+            <BitOffs>1299763328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -93772,7 +98278,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296689152</BitOffs>
+            <BitOffs>1300090752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -93783,7 +98289,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1296715072</BitOffs>
+            <BitOffs>1300116672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -93820,7 +98326,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297042496</BitOffs>
+            <BitOffs>1300444096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -93858,7 +98364,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297068416</BitOffs>
+            <BitOffs>1300470016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -93896,7 +98402,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297120256</BitOffs>
+            <BitOffs>1300521856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -93934,7 +98440,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297146176</BitOffs>
+            <BitOffs>1300547776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -93971,7 +98477,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297172096</BitOffs>
+            <BitOffs>1300573696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -94003,7 +98509,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297198016</BitOffs>
+            <BitOffs>1300599616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -94041,7 +98547,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297223936</BitOffs>
+            <BitOffs>1300625536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -94052,7 +98558,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297249856</BitOffs>
+            <BitOffs>1300651456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -94089,7 +98595,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297577280</BitOffs>
+            <BitOffs>1300978880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -94100,7 +98606,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297603200</BitOffs>
+            <BitOffs>1301004800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -94125,7 +98631,8 @@ M4K2 KBV X ENC CNT</Comment>
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2</Value>
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
               </Property>
               <Property>
                 <Name>pytmc</Name>
@@ -94137,7 +98644,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297930624</BitOffs>
+            <BitOffs>1301332224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -94148,7 +98655,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1297956544</BitOffs>
+            <BitOffs>1301358144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -94185,7 +98692,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298283968</BitOffs>
+            <BitOffs>1301685568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -94196,7 +98703,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298309888</BitOffs>
+            <BitOffs>1301711488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -94234,7 +98741,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298637312</BitOffs>
+            <BitOffs>1302038912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -94267,7 +98774,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298663232</BitOffs>
+            <BitOffs>1302064832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -94278,7 +98785,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1298689152</BitOffs>
+            <BitOffs>1302090752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -94312,7 +98819,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299016576</BitOffs>
+            <BitOffs>1302418176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -94323,7 +98830,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299042496</BitOffs>
+            <BitOffs>1302444096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -94357,7 +98864,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299369920</BitOffs>
+            <BitOffs>1302771520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -94391,7 +98898,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299395840</BitOffs>
+            <BitOffs>1302797440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -94425,7 +98932,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299421760</BitOffs>
+            <BitOffs>1302823360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -94459,7 +98966,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299447680</BitOffs>
+            <BitOffs>1302849280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -94493,7 +99000,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299473600</BitOffs>
+            <BitOffs>1302875200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -94522,7 +99029,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299499520</BitOffs>
+            <BitOffs>1302901120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -94554,7 +99061,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299525440</BitOffs>
+            <BitOffs>1302927040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -94565,7 +99072,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299551360</BitOffs>
+            <BitOffs>1302952960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -94597,7 +99104,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299878784</BitOffs>
+            <BitOffs>1303280384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -94608,7 +99115,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1299904704</BitOffs>
+            <BitOffs>1303306304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -94640,7 +99147,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300232128</BitOffs>
+            <BitOffs>1303633728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -94651,7 +99158,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300258048</BitOffs>
+            <BitOffs>1303659648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -94683,7 +99190,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300585472</BitOffs>
+            <BitOffs>1303987072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -94694,7 +99201,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300611392</BitOffs>
+            <BitOffs>1304012992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -94726,7 +99233,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300938816</BitOffs>
+            <BitOffs>1304340416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -94737,7 +99244,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1300964736</BitOffs>
+            <BitOffs>1304366336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -94769,7 +99276,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301292160</BitOffs>
+            <BitOffs>1304693760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -94780,7 +99287,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301318080</BitOffs>
+            <BitOffs>1304719680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -94812,7 +99319,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301645504</BitOffs>
+            <BitOffs>1305047104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -94823,7 +99330,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301671424</BitOffs>
+            <BitOffs>1305073024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -94855,7 +99362,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1301998848</BitOffs>
+            <BitOffs>1305400448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -94866,7 +99373,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302024768</BitOffs>
+            <BitOffs>1305426368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -94898,7 +99405,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302352192</BitOffs>
+            <BitOffs>1305753792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -94909,7 +99416,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302378112</BitOffs>
+            <BitOffs>1305779712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -94941,7 +99448,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302705536</BitOffs>
+            <BitOffs>1306107136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -94952,7 +99459,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1302731456</BitOffs>
+            <BitOffs>1306133056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -94984,7 +99491,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303058880</BitOffs>
+            <BitOffs>1306460480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -94995,7 +99502,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303084800</BitOffs>
+            <BitOffs>1306486400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -95027,7 +99534,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303412224</BitOffs>
+            <BitOffs>1306813824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -95038,7 +99545,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303438144</BitOffs>
+            <BitOffs>1306839744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -95070,7 +99577,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303765568</BitOffs>
+            <BitOffs>1307167168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -95081,7 +99588,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303791488</BitOffs>
+            <BitOffs>1307193088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -95092,7 +99599,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304118944</BitOffs>
+            <BitOffs>1307520544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -95107,7 +99614,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304118960</BitOffs>
+            <BitOffs>1307520560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -95122,7 +99629,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304118968</BitOffs>
+            <BitOffs>1307520568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -95152,7 +99659,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304118976</BitOffs>
+            <BitOffs>1307520576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -95182,7 +99689,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119040</BitOffs>
+            <BitOffs>1307520640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -95197,7 +99704,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119104</BitOffs>
+            <BitOffs>1307520704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -95212,7 +99719,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119120</BitOffs>
+            <BitOffs>1307520720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -95227,7 +99734,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119136</BitOffs>
+            <BitOffs>1307520736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -95241,7 +99748,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119144</BitOffs>
+            <BitOffs>1307520744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -95256,7 +99763,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119168</BitOffs>
+            <BitOffs>1307520768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -95271,7 +99778,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119200</BitOffs>
+            <BitOffs>1307520800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -95392,7 +99899,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304119232</BitOffs>
+            <BitOffs>1307520832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -95406,7 +99913,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128704</BitOffs>
+            <BitOffs>1307530304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -95420,7 +99927,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304128736</BitOffs>
+            <BitOffs>1307530336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -95441,7 +99948,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304132352</BitOffs>
+            <BitOffs>1307533952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -95513,7 +100020,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304150272</BitOffs>
+            <BitOffs>1307551872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -95585,7 +100092,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304150400</BitOffs>
+            <BitOffs>1307552000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -95657,7 +100164,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304150528</BitOffs>
+            <BitOffs>1307552128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -95729,7 +100236,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304150656</BitOffs>
+            <BitOffs>1307552256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -95801,7 +100308,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304150784</BitOffs>
+            <BitOffs>1307552384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -95873,7 +100380,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304150912</BitOffs>
+            <BitOffs>1307552512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -95899,14 +100406,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304183936</BitOffs>
+            <BitOffs>1307585536</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>164167680</ByteSize>
+          <ByteSize>164560896</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -95986,15 +100493,15 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-08-16T15:37:57</Value>
+          <Value>2024-09-23T14:16:26</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>983040</Value>
+          <Value>1019904</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>162672640</Value>
+          <Value>163098624</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{6F7A53A0-C2D9-A16A-9BED-F44FF998AD64}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C148670C-B896-ACAA-DBAC-169C1BF0BF81}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -27352,6 +27352,34 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>E_MR1K1_States</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>B4C</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OUT</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
         </Property>
       </Properties>
     </DataType>
@@ -72244,10 +72272,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Text>Rh</Text>
         <Enum>2</Enum>
       </EnumInfo>
-      <EnumInfo>
-        <Text>OUT</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
       <Properties>
         <Property>
           <Name>qualified_only</Name>
@@ -81525,6 +81549,339 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</Name>
+      <BitSize>1541440</BitSize>
+      <SubItem>
+        <Name>stMotionStage1</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The 1st motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage2</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> The 2nd motor to move</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState1</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for motor 1, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE:M1
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionState2</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo ReferenceTo="true">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <Comment> All possible position states for motor 2, including unused/invalid states.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATE:M2
+        io: io
+        expand: :%.2d
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumSet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eEnumGet</Name>
+        <Type ReferenceTo="true">UINT</Type>
+        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbArbiter</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
+        <Comment> The arbiter to request beam conditions from.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableMotion</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableBeamParams</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>584</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnablePositionLimits</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>592</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDeviceName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>600</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sTransitionKey</Name>
+        <Type>STRING(80)</Type>
+        <Comment> The name of the transition state in the PMPS database.</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
+        <Comment> Normal EPICS inputs, gathered into a single struct
+ PMPS EPICS inputs, gathered into a single struct</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1904</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSEpicsToPlc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>1936</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadDBNow</Name>
+        <Type>BOOL</Type>
+        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1952</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
+        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>768</BitSize>
+        <BitOffs>1984</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPMPSPlcToEpics</Name>
+        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
+        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>2752</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <Comment> The PMPS database lookup associated with the current position state.</Comment>
+        <BitSize>2496</BitSize>
+        <BitOffs>5248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
+        <BitSize>609536</BitSize>
+        <BitOffs>7744</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbPMPSCore</Name>
+        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
+        <BitSize>682240</BitSize>
+        <BitOffs>617280</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astMotionStageMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <BitSize>77760</BitSize>
+        <BitOffs>1299520</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>astPositionStateMax</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <ArrayInfo Level="0">
+          <LBound>1</LBound>
+          <Elements>3</Elements>
+        </ArrayInfo>
+        <ArrayInfo Level="1">
+          <LBound>1</LBound>
+          <Elements>15</Elements>
+        </ArrayInfo>
+        <BitSize>164160</BitSize>
+        <BitOffs>1377280</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
       <BitSize>1541312</BitSize>
       <SubItem>
@@ -89985,6 +90342,345 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1304133520</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317361024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317368960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317368968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317368976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317368992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317369024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317369088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317369104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317386944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317394880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317394888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317394896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317394912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317394944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317395008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317395024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
+            <BitSize>2048</BitSize>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317412864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
+            <Comment> NC Forward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
+            <Comment> NC Backward Limit Switch: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bHome</Name>
+            <Comment> NO Home Switch: TRUE if at home</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
+            <Comment> NC STO Input: TRUE if ok to move</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: PLC:bHardwareEnable
+        io: i
+        field: ZNAM FALSE
+        field: ONAM TRUE
+        field: DESC TRUE if STO not hit
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
+            <Comment> Raw encoder IO for ULINT (Biss-C)</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
+            <Comment> Raw encoder IO for UINT (Relative Encoders)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
+            <Comment> Raw encoder IO for INT (LVDT)</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420944</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
             <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
@@ -92403,6 +93099,81 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>1303807680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317360000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317368984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317385920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317394904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317411840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1317420824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -98357,6 +99128,36 @@ Emergency Stop for MR1K1</Comment>
               </Property>
             </Properties>
             <BitOffs>633593344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_MR1K1_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR1K1:BEND:COATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>634550864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_MR1K1_States</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR1K1:BEND:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>634550880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_lcls_twincat_motion</Name>
@@ -106612,6 +107413,38 @@ M4K2 KBV X ENC CNT</Comment>
             <BitOffs>1311930688</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_MR1K1_BEND.fbYSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1312414272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbXSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1312506624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.astCoatingStatesY</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1312598976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.astCoatingStatesX</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1312653696</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
@@ -106678,6 +107511,18 @@ M4K2 KBV X ENC CNT</Comment>
               <Elements>15</Elements>
             </ArrayInfo>
             <BitOffs>1315739584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K1_BEND.fbCoatingStates</Name>
+            <BitSize>1541440</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR1K1:BEND:COATING</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1316060416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates</Name>
@@ -106794,15 +107639,15 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-09-23T15:39:50</Value>
+          <Value>2024-09-24T14:37:08</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>1081344</Value>
+          <Value>1089536</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>163110912</Value>
+          <Value>163340288</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -100493,7 +100493,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-09-23T14:16:26</Value>
+          <Value>2024-09-23T15:15:32</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -107639,7 +107639,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-09-24T14:37:08</Value>
+          <Value>2024-09-25T09:49:36</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Implement state movers with PMPS for
- MR1K1 - Coating 2d State Mover. - 50 micron Y-Axis OUT delta
- MR1K2 - Coating 1d State Mover
- SP1K1 -  Grating Selection 1d State Mover
- update  `lcls-twincat-motion` to 4.1.1 needed changes for TcBSD PLC pmps file transfer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I deployed this branch on the PLC and rebuilt the IOC.
- Command each device with each state via `caout` 
- Commanded each device to states via local branch with supporting pcdsdevice and typhos.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-936
related device update: https://github.com/pcdshub/pcdsdevices/pull/1290
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
