### PR TITLE
ENH: set pmps stages bPowerSelf false

### DIFF
--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{E6887738-6106-B3EA-6F44-1758ABE554CA}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{DBABC26D-83F2-88FA-0326-2669F15C1163}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -4703,6 +4703,10 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
+					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
 					<Name>Main.M1.Axis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
@@ -5126,10 +5130,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-					<Type>BOOL</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" ContextId="4" AreaNo="68">

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/Main.TcGVL
@@ -19,7 +19,7 @@
     {attribute 'pytmc' := '
         pv: MR1K2:SWITCH:MMS:YLEFT
     '}
-    M1 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K2 Yleft
+    M1 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=False); // M1K2 Yleft
     fbMotionStage_m1 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
@@ -84,7 +84,7 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position'}
-    M9: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=1000.0, bPowerSelf:=True); // G_H, um
+    M9: ST_MotionStage:=(nEnableMode:=ENUM_StageEnableMode.DURING_MOTION, fVelocity:=1000.0, bPowerSelf:=False); // G_H, um
     {attribute 'pytmc' := '
         pv: SP1K1:MONO:MMS:SD_V
     '}
@@ -109,7 +109,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:YUP
     '}
-    M12 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Yup
+    M12 : ST_MotionStage := (fVelocity:=100.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=False); // M1K1 Yup
     fbMotionStage_m12 : FB_MotionStage;
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
                         .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2'}
@@ -125,7 +125,7 @@
     {attribute 'pytmc' := '
         pv: MR1K1:BEND:MMS:XUP
     '}
-    M14 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=True); // M1K1 Xup
+    M14 : ST_MotionStage := (fVelocity:=150.0, nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=False); // M1K1 Xup
     fbMotionStage_m14 : FB_MotionStage;
 
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
@@ -218,7 +218,7 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position'}
-    M25 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
+    M25 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=FALSE); //X mot
        fbMotionStageM25 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR2K2:FLAT:MMS:Y'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
@@ -244,7 +244,7 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position'}
-    M29 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //Y mot
+    M29 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=FALSE); //Y mot
     fbMotionStageM29 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR3K2:KBH:MMS:PITCH'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
@@ -271,7 +271,7 @@
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
                               .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
                               .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position'}
-    M33 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=TRUE); //X mot
+    M33 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS, bPowerSelf:=FALSE); //X mot
     fbMotionStageM33 : FB_MotionStage;
     {attribute 'pytmc' := 'pv: MR4K2:KBV:MMS:Y'}
     {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{E6887738-6106-B3EA-6F44-1758ABE554CA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{DBABC26D-83F2-88FA-0326-2669F15C1163}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10419,31 +10419,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164353168</GetCodeOffs>
+        <GetCodeOffs>164383648</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164353240</GetCodeOffs>
+        <GetCodeOffs>164383720</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353256</GetCodeOffs>
+        <GetCodeOffs>164383736</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353216</GetCodeOffs>
+        <GetCodeOffs>164383696</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353248</GetCodeOffs>
+        <GetCodeOffs>164383728</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11695,15 +11695,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353040</GetCodeOffs>
-        <SetCodeOffs>164353088</SetCodeOffs>
+        <GetCodeOffs>164383520</GetCodeOffs>
+        <SetCodeOffs>164383568</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353120</GetCodeOffs>
-        <SetCodeOffs>164353144</SetCodeOffs>
+        <GetCodeOffs>164383600</GetCodeOffs>
+        <SetCodeOffs>164383624</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11944,31 +11944,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>164353352</GetCodeOffs>
+        <GetCodeOffs>164383832</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164353312</GetCodeOffs>
+        <GetCodeOffs>164383792</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353488</GetCodeOffs>
+        <GetCodeOffs>164383968</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353496</GetCodeOffs>
+        <GetCodeOffs>164383976</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353408</GetCodeOffs>
+        <GetCodeOffs>164383888</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11980,7 +11980,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353504</GetCodeOffs>
+        <GetCodeOffs>164383984</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12573,7 +12573,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164353560</GetCodeOffs>
+        <GetCodeOffs>164384040</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -29737,14 +29737,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164359904</GetCodeOffs>
+        <GetCodeOffs>164390384</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164359808</GetCodeOffs>
+        <GetCodeOffs>164390288</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -30840,7 +30840,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164360056</GetCodeOffs>
+        <GetCodeOffs>164390536</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -31499,7 +31499,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164360168</GetCodeOffs>
+        <GetCodeOffs>164390648</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -41537,7 +41537,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164366856</GetCodeOffs>
+        <GetCodeOffs>164397336</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -43465,31 +43465,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164366256</GetCodeOffs>
+        <GetCodeOffs>164396736</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164366344</GetCodeOffs>
+        <GetCodeOffs>164396824</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164366272</GetCodeOffs>
+        <GetCodeOffs>164396752</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164366320</GetCodeOffs>
+        <GetCodeOffs>164396800</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164366360</GetCodeOffs>
+        <GetCodeOffs>164396840</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82270,14 +82270,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306000192</BitOffs>
+            <BitOffs>1306244032</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82291,14 +82291,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306000384</BitOffs>
+            <BitOffs>1306244224</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82340,7 +82340,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314507296</BitOffs>
+            <BitOffs>1314751136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82354,7 +82354,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314507328</BitOffs>
+            <BitOffs>1314751168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -82368,7 +82368,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514496</BitOffs>
+            <BitOffs>1314758336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -82389,14 +82389,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514816</BitOffs>
+            <BitOffs>1314758656</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82407,14 +82407,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307466880</BitOffs>
+            <BitOffs>1307725312</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82516,7 +82516,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307465792</BitOffs>
+            <BitOffs>1307724224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -82530,7 +82530,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514528</BitOffs>
+            <BitOffs>1314758368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -82544,7 +82544,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514560</BitOffs>
+            <BitOffs>1314758400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -82565,20 +82565,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314515712</BitOffs>
+            <BitOffs>1314759552</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265016832</BitOffs>
+            <BitOffs>1265797632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -82627,7 +82627,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514592</BitOffs>
+            <BitOffs>1314758432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -82641,7 +82641,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514624</BitOffs>
+            <BitOffs>1314758464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -82662,14 +82662,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314516608</BitOffs>
+            <BitOffs>1314760448</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82685,7 +82685,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133632</BitOffs>
+            <BitOffs>1265017536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -82701,7 +82701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133696</BitOffs>
+            <BitOffs>1265017600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -82717,14 +82717,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133760</BitOffs>
+            <BitOffs>1265017664</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -82868,7 +82868,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265133824</BitOffs>
+            <BitOffs>1265017728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -82877,7 +82877,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265134472</BitOffs>
+            <BitOffs>1265018376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -82886,14 +82886,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265134480</BitOffs>
+            <BitOffs>1265018384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265134488</BitOffs>
+            <BitOffs>1265018392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -82902,20 +82902,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265134496</BitOffs>
+            <BitOffs>1265018400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134528</BitOffs>
+            <BitOffs>1265018432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134592</BitOffs>
+            <BitOffs>1265018496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -82924,19 +82924,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265134656</BitOffs>
+            <BitOffs>1265018560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265134720</BitOffs>
+            <BitOffs>1265018624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134784</BitOffs>
+            <BitOffs>1265018688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -82951,25 +82951,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265134848</BitOffs>
+            <BitOffs>1265018752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265134912</BitOffs>
+            <BitOffs>1265018816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135168</BitOffs>
+            <BitOffs>1265019072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265135232</BitOffs>
+            <BitOffs>1265019136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -82978,19 +82978,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265135296</BitOffs>
+            <BitOffs>1265019200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135360</BitOffs>
+            <BitOffs>1265019264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135424</BitOffs>
+            <BitOffs>1265019328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -83005,67 +83005,67 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265135488</BitOffs>
+            <BitOffs>1265019392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265135552</BitOffs>
+            <BitOffs>1265019456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265136576</BitOffs>
+            <BitOffs>1265020480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136640</BitOffs>
+            <BitOffs>1265020544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136704</BitOffs>
+            <BitOffs>1265020608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136768</BitOffs>
+            <BitOffs>1265020672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265136832</BitOffs>
+            <BitOffs>1265020736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265247424</BitOffs>
+            <BitOffs>1265131328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265522624</BitOffs>
+            <BitOffs>1265406528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265633216</BitOffs>
+            <BitOffs>1265517120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265908416</BitOffs>
+            <BitOffs>1265792320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -83077,7 +83077,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265908928</BitOffs>
+            <BitOffs>1265792832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -83089,14 +83089,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265909504</BitOffs>
+            <BitOffs>1265793408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265910336</BitOffs>
+            <BitOffs>1265794240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -83112,7 +83112,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265910592</BitOffs>
+            <BitOffs>1265794496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -83127,7 +83127,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265910624</BitOffs>
+            <BitOffs>1265794528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -83145,7 +83145,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314509376</BitOffs>
+            <BitOffs>1314753216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -83159,7 +83159,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514656</BitOffs>
+            <BitOffs>1314758496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -83173,7 +83173,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514688</BitOffs>
+            <BitOffs>1314758528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -83194,14 +83194,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314517504</BitOffs>
+            <BitOffs>1314761344</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -87925,7 +87925,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306001664</BitOffs>
+            <BitOffs>1306260096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -87938,7 +87938,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009600</BitOffs>
+            <BitOffs>1306268032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -87951,7 +87951,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009608</BitOffs>
+            <BitOffs>1306268040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -87964,7 +87964,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009616</BitOffs>
+            <BitOffs>1306268048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -87987,7 +87987,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009632</BitOffs>
+            <BitOffs>1306268064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -88000,7 +88000,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009664</BitOffs>
+            <BitOffs>1306268096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -88013,7 +88013,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009728</BitOffs>
+            <BitOffs>1306268160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -88026,7 +88026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009744</BitOffs>
+            <BitOffs>1306268176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88038,7 +88038,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306029120</BitOffs>
+            <BitOffs>1306287552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -88050,7 +88050,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306355008</BitOffs>
+            <BitOffs>1306613440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -88063,7 +88063,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362944</BitOffs>
+            <BitOffs>1306621376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -88076,7 +88076,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362952</BitOffs>
+            <BitOffs>1306621384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -88089,7 +88089,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362960</BitOffs>
+            <BitOffs>1306621392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -88112,7 +88112,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362976</BitOffs>
+            <BitOffs>1306621408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -88125,7 +88125,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363008</BitOffs>
+            <BitOffs>1306621440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -88138,7 +88138,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363072</BitOffs>
+            <BitOffs>1306621504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -88151,7 +88151,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363088</BitOffs>
+            <BitOffs>1306621520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88163,7 +88163,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306382464</BitOffs>
+            <BitOffs>1306640896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -88175,7 +88175,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306708352</BitOffs>
+            <BitOffs>1306966784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -88188,7 +88188,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716288</BitOffs>
+            <BitOffs>1306974720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -88201,7 +88201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716296</BitOffs>
+            <BitOffs>1306974728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -88214,7 +88214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716304</BitOffs>
+            <BitOffs>1306974736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -88237,7 +88237,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716320</BitOffs>
+            <BitOffs>1306974752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -88250,7 +88250,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716352</BitOffs>
+            <BitOffs>1306974784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -88263,7 +88263,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716416</BitOffs>
+            <BitOffs>1306974848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -88276,7 +88276,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716432</BitOffs>
+            <BitOffs>1306974864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88288,7 +88288,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306735808</BitOffs>
+            <BitOffs>1306994240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -88300,7 +88300,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307061696</BitOffs>
+            <BitOffs>1307320128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -88313,7 +88313,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069632</BitOffs>
+            <BitOffs>1307328064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -88326,7 +88326,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069640</BitOffs>
+            <BitOffs>1307328072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -88339,7 +88339,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069648</BitOffs>
+            <BitOffs>1307328080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -88362,7 +88362,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069664</BitOffs>
+            <BitOffs>1307328096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -88375,7 +88375,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069696</BitOffs>
+            <BitOffs>1307328128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -88388,7 +88388,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069760</BitOffs>
+            <BitOffs>1307328192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -88401,7 +88401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069776</BitOffs>
+            <BitOffs>1307328208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88413,7 +88413,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307089152</BitOffs>
+            <BitOffs>1307347584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -88425,7 +88425,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307415040</BitOffs>
+            <BitOffs>1307673472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -88438,7 +88438,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422976</BitOffs>
+            <BitOffs>1307681408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -88451,7 +88451,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422984</BitOffs>
+            <BitOffs>1307681416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -88464,7 +88464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422992</BitOffs>
+            <BitOffs>1307681424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -88487,7 +88487,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423008</BitOffs>
+            <BitOffs>1307681440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -88500,7 +88500,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423040</BitOffs>
+            <BitOffs>1307681472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -88513,7 +88513,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423104</BitOffs>
+            <BitOffs>1307681536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -88526,7 +88526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423120</BitOffs>
+            <BitOffs>1307681552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -88538,7 +88538,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307440960</BitOffs>
+            <BitOffs>1307699392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -88551,7 +88551,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448896</BitOffs>
+            <BitOffs>1307707328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -88564,7 +88564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448904</BitOffs>
+            <BitOffs>1307707336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -88577,7 +88577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448912</BitOffs>
+            <BitOffs>1307707344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -88600,7 +88600,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448928</BitOffs>
+            <BitOffs>1307707360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -88613,7 +88613,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448960</BitOffs>
+            <BitOffs>1307707392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -88626,7 +88626,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307449024</BitOffs>
+            <BitOffs>1307707456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -88639,7 +88639,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307449040</BitOffs>
+            <BitOffs>1307707472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -88652,7 +88652,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474816</BitOffs>
+            <BitOffs>1307733248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -88665,7 +88665,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474824</BitOffs>
+            <BitOffs>1307733256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -88678,7 +88678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474832</BitOffs>
+            <BitOffs>1307733264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -88701,7 +88701,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474848</BitOffs>
+            <BitOffs>1307733280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -88714,7 +88714,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474880</BitOffs>
+            <BitOffs>1307733312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -88727,7 +88727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474944</BitOffs>
+            <BitOffs>1307733376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -88740,7 +88740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474960</BitOffs>
+            <BitOffs>1307733392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -88752,7 +88752,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307492800</BitOffs>
+            <BitOffs>1307751232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -88765,7 +88765,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500736</BitOffs>
+            <BitOffs>1307759168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -88778,7 +88778,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500744</BitOffs>
+            <BitOffs>1307759176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -88791,7 +88791,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500752</BitOffs>
+            <BitOffs>1307759184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -88814,7 +88814,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500768</BitOffs>
+            <BitOffs>1307759200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -88827,7 +88827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500800</BitOffs>
+            <BitOffs>1307759232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -88840,7 +88840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500864</BitOffs>
+            <BitOffs>1307759296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -88853,7 +88853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500880</BitOffs>
+            <BitOffs>1307759312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -88865,7 +88865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307518720</BitOffs>
+            <BitOffs>1307777152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -88878,7 +88878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526656</BitOffs>
+            <BitOffs>1307785088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -88891,7 +88891,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526664</BitOffs>
+            <BitOffs>1307785096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -88904,7 +88904,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526672</BitOffs>
+            <BitOffs>1307785104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -88927,7 +88927,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526688</BitOffs>
+            <BitOffs>1307785120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -88940,7 +88940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526720</BitOffs>
+            <BitOffs>1307785152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -88953,7 +88953,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526784</BitOffs>
+            <BitOffs>1307785216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -88966,7 +88966,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526800</BitOffs>
+            <BitOffs>1307785232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -88978,7 +88978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307544640</BitOffs>
+            <BitOffs>1307803072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -88991,7 +88991,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552576</BitOffs>
+            <BitOffs>1307811008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -89004,7 +89004,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552584</BitOffs>
+            <BitOffs>1307811016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -89017,7 +89017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552592</BitOffs>
+            <BitOffs>1307811024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -89040,7 +89040,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552608</BitOffs>
+            <BitOffs>1307811040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -89053,7 +89053,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552640</BitOffs>
+            <BitOffs>1307811072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -89066,7 +89066,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552704</BitOffs>
+            <BitOffs>1307811136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -89079,7 +89079,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552720</BitOffs>
+            <BitOffs>1307811152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -89091,7 +89091,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307570560</BitOffs>
+            <BitOffs>1307828992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -89104,7 +89104,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578496</BitOffs>
+            <BitOffs>1307836928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -89117,7 +89117,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578504</BitOffs>
+            <BitOffs>1307836936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -89130,7 +89130,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578512</BitOffs>
+            <BitOffs>1307836944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -89153,7 +89153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578528</BitOffs>
+            <BitOffs>1307836960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -89166,7 +89166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578560</BitOffs>
+            <BitOffs>1307836992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -89179,7 +89179,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578624</BitOffs>
+            <BitOffs>1307837056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -89192,7 +89192,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578640</BitOffs>
+            <BitOffs>1307837072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -89204,7 +89204,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307596480</BitOffs>
+            <BitOffs>1307854912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -89217,7 +89217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604416</BitOffs>
+            <BitOffs>1307862848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -89230,7 +89230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604424</BitOffs>
+            <BitOffs>1307862856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -89243,7 +89243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604432</BitOffs>
+            <BitOffs>1307862864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -89266,7 +89266,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604448</BitOffs>
+            <BitOffs>1307862880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -89279,7 +89279,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604480</BitOffs>
+            <BitOffs>1307862912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -89292,7 +89292,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604544</BitOffs>
+            <BitOffs>1307862976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -89305,7 +89305,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604560</BitOffs>
+            <BitOffs>1307862992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89317,7 +89317,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307623936</BitOffs>
+            <BitOffs>1307882368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -89329,7 +89329,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307949824</BitOffs>
+            <BitOffs>1308208256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -89342,7 +89342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957760</BitOffs>
+            <BitOffs>1308216192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -89355,7 +89355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957768</BitOffs>
+            <BitOffs>1308216200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -89368,7 +89368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957776</BitOffs>
+            <BitOffs>1308216208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -89391,7 +89391,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957792</BitOffs>
+            <BitOffs>1308216224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -89404,7 +89404,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957824</BitOffs>
+            <BitOffs>1308216256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -89417,7 +89417,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957888</BitOffs>
+            <BitOffs>1308216320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -89430,7 +89430,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957904</BitOffs>
+            <BitOffs>1308216336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89442,7 +89442,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307977280</BitOffs>
+            <BitOffs>1308235712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -89454,7 +89454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308303168</BitOffs>
+            <BitOffs>1308561600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -89467,7 +89467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311104</BitOffs>
+            <BitOffs>1308569536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -89480,7 +89480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311112</BitOffs>
+            <BitOffs>1308569544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -89493,7 +89493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311120</BitOffs>
+            <BitOffs>1308569552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -89516,7 +89516,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311136</BitOffs>
+            <BitOffs>1308569568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -89529,7 +89529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311168</BitOffs>
+            <BitOffs>1308569600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -89542,7 +89542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311232</BitOffs>
+            <BitOffs>1308569664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -89555,7 +89555,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311248</BitOffs>
+            <BitOffs>1308569680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89567,7 +89567,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308330624</BitOffs>
+            <BitOffs>1308589056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -89579,7 +89579,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308656512</BitOffs>
+            <BitOffs>1308914944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -89592,7 +89592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664448</BitOffs>
+            <BitOffs>1308922880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -89605,7 +89605,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664456</BitOffs>
+            <BitOffs>1308922888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -89618,7 +89618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664464</BitOffs>
+            <BitOffs>1308922896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -89641,7 +89641,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664480</BitOffs>
+            <BitOffs>1308922912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -89654,7 +89654,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664512</BitOffs>
+            <BitOffs>1308922944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -89667,7 +89667,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664576</BitOffs>
+            <BitOffs>1308923008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -89680,7 +89680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664592</BitOffs>
+            <BitOffs>1308923024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89692,7 +89692,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308683968</BitOffs>
+            <BitOffs>1308942400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -89704,7 +89704,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309009856</BitOffs>
+            <BitOffs>1309268288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -89717,7 +89717,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017792</BitOffs>
+            <BitOffs>1309276224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -89730,7 +89730,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017800</BitOffs>
+            <BitOffs>1309276232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -89743,7 +89743,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017808</BitOffs>
+            <BitOffs>1309276240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -89766,7 +89766,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017824</BitOffs>
+            <BitOffs>1309276256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -89779,7 +89779,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017856</BitOffs>
+            <BitOffs>1309276288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -89792,7 +89792,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017920</BitOffs>
+            <BitOffs>1309276352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -89805,7 +89805,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017936</BitOffs>
+            <BitOffs>1309276368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -89817,7 +89817,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309035776</BitOffs>
+            <BitOffs>1309294208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -89830,7 +89830,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043712</BitOffs>
+            <BitOffs>1309302144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -89843,7 +89843,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043720</BitOffs>
+            <BitOffs>1309302152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -89856,7 +89856,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043728</BitOffs>
+            <BitOffs>1309302160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -89879,7 +89879,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043744</BitOffs>
+            <BitOffs>1309302176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -89892,7 +89892,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043776</BitOffs>
+            <BitOffs>1309302208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -89905,7 +89905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043840</BitOffs>
+            <BitOffs>1309302272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -89918,7 +89918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043856</BitOffs>
+            <BitOffs>1309302288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89930,7 +89930,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309063232</BitOffs>
+            <BitOffs>1309321664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -89942,7 +89942,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309389120</BitOffs>
+            <BitOffs>1309647552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -89955,7 +89955,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397056</BitOffs>
+            <BitOffs>1309655488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -89968,7 +89968,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397064</BitOffs>
+            <BitOffs>1309655496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -89981,7 +89981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397072</BitOffs>
+            <BitOffs>1309655504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -90004,7 +90004,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397088</BitOffs>
+            <BitOffs>1309655520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -90017,7 +90017,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397120</BitOffs>
+            <BitOffs>1309655552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -90030,7 +90030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397184</BitOffs>
+            <BitOffs>1309655616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -90043,7 +90043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397200</BitOffs>
+            <BitOffs>1309655632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90055,7 +90055,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309416576</BitOffs>
+            <BitOffs>1309675008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -90067,7 +90067,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309742464</BitOffs>
+            <BitOffs>1310000896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -90080,7 +90080,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750400</BitOffs>
+            <BitOffs>1310008832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -90093,7 +90093,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750408</BitOffs>
+            <BitOffs>1310008840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -90106,7 +90106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750416</BitOffs>
+            <BitOffs>1310008848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -90129,7 +90129,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750432</BitOffs>
+            <BitOffs>1310008864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -90142,7 +90142,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750464</BitOffs>
+            <BitOffs>1310008896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -90155,7 +90155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750528</BitOffs>
+            <BitOffs>1310008960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -90168,7 +90168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750544</BitOffs>
+            <BitOffs>1310008976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -90180,7 +90180,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309768384</BitOffs>
+            <BitOffs>1310026816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -90193,7 +90193,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776320</BitOffs>
+            <BitOffs>1310034752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -90206,7 +90206,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776328</BitOffs>
+            <BitOffs>1310034760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -90219,7 +90219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776336</BitOffs>
+            <BitOffs>1310034768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -90242,7 +90242,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776352</BitOffs>
+            <BitOffs>1310034784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -90255,7 +90255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776384</BitOffs>
+            <BitOffs>1310034816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -90268,7 +90268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776448</BitOffs>
+            <BitOffs>1310034880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -90281,7 +90281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776464</BitOffs>
+            <BitOffs>1310034896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -90293,7 +90293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309794304</BitOffs>
+            <BitOffs>1310052736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -90306,7 +90306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802240</BitOffs>
+            <BitOffs>1310060672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -90319,7 +90319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802248</BitOffs>
+            <BitOffs>1310060680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -90332,7 +90332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802256</BitOffs>
+            <BitOffs>1310060688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -90355,7 +90355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802272</BitOffs>
+            <BitOffs>1310060704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -90368,7 +90368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802304</BitOffs>
+            <BitOffs>1310060736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -90381,7 +90381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802368</BitOffs>
+            <BitOffs>1310060800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -90394,7 +90394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802384</BitOffs>
+            <BitOffs>1310060816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -90406,7 +90406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309820224</BitOffs>
+            <BitOffs>1310078656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -90419,7 +90419,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828160</BitOffs>
+            <BitOffs>1310086592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -90432,7 +90432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828168</BitOffs>
+            <BitOffs>1310086600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -90445,7 +90445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828176</BitOffs>
+            <BitOffs>1310086608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -90468,7 +90468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828192</BitOffs>
+            <BitOffs>1310086624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -90481,7 +90481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828224</BitOffs>
+            <BitOffs>1310086656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -90494,7 +90494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828288</BitOffs>
+            <BitOffs>1310086720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -90507,7 +90507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828304</BitOffs>
+            <BitOffs>1310086736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -90519,7 +90519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309846144</BitOffs>
+            <BitOffs>1310104576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -90532,7 +90532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854080</BitOffs>
+            <BitOffs>1310112512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -90545,7 +90545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854088</BitOffs>
+            <BitOffs>1310112520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -90558,7 +90558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854096</BitOffs>
+            <BitOffs>1310112528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -90581,7 +90581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854112</BitOffs>
+            <BitOffs>1310112544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -90594,7 +90594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854144</BitOffs>
+            <BitOffs>1310112576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -90607,7 +90607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854208</BitOffs>
+            <BitOffs>1310112640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -90620,7 +90620,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854224</BitOffs>
+            <BitOffs>1310112656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -90632,7 +90632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309872064</BitOffs>
+            <BitOffs>1310130496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -90645,7 +90645,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880000</BitOffs>
+            <BitOffs>1310138432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -90658,7 +90658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880008</BitOffs>
+            <BitOffs>1310138440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -90671,7 +90671,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880016</BitOffs>
+            <BitOffs>1310138448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -90694,7 +90694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880032</BitOffs>
+            <BitOffs>1310138464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -90707,7 +90707,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880064</BitOffs>
+            <BitOffs>1310138496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -90720,7 +90720,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880128</BitOffs>
+            <BitOffs>1310138560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -90733,7 +90733,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880144</BitOffs>
+            <BitOffs>1310138576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -90745,7 +90745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309897984</BitOffs>
+            <BitOffs>1310156416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -90758,7 +90758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905920</BitOffs>
+            <BitOffs>1310164352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -90771,7 +90771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905928</BitOffs>
+            <BitOffs>1310164360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -90784,7 +90784,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905936</BitOffs>
+            <BitOffs>1310164368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -90807,7 +90807,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905952</BitOffs>
+            <BitOffs>1310164384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -90820,7 +90820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905984</BitOffs>
+            <BitOffs>1310164416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -90833,7 +90833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309906048</BitOffs>
+            <BitOffs>1310164480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -90846,7 +90846,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309906064</BitOffs>
+            <BitOffs>1310164496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90858,7 +90858,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309925440</BitOffs>
+            <BitOffs>1310183872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -90870,7 +90870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310251328</BitOffs>
+            <BitOffs>1310509760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -90883,7 +90883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259264</BitOffs>
+            <BitOffs>1310517696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -90896,7 +90896,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259272</BitOffs>
+            <BitOffs>1310517704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -90909,7 +90909,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259280</BitOffs>
+            <BitOffs>1310517712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -90932,7 +90932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259296</BitOffs>
+            <BitOffs>1310517728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -90945,7 +90945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259328</BitOffs>
+            <BitOffs>1310517760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -90958,7 +90958,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259392</BitOffs>
+            <BitOffs>1310517824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -90971,7 +90971,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259408</BitOffs>
+            <BitOffs>1310517840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90983,7 +90983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310278784</BitOffs>
+            <BitOffs>1310537216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -90995,7 +90995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310604672</BitOffs>
+            <BitOffs>1310863104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -91008,7 +91008,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612608</BitOffs>
+            <BitOffs>1310871040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -91021,7 +91021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612616</BitOffs>
+            <BitOffs>1310871048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -91034,7 +91034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612624</BitOffs>
+            <BitOffs>1310871056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -91057,7 +91057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612640</BitOffs>
+            <BitOffs>1310871072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -91070,7 +91070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612672</BitOffs>
+            <BitOffs>1310871104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -91083,7 +91083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612736</BitOffs>
+            <BitOffs>1310871168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -91096,7 +91096,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612752</BitOffs>
+            <BitOffs>1310871184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91108,7 +91108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310632128</BitOffs>
+            <BitOffs>1310890560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -91120,7 +91120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310958016</BitOffs>
+            <BitOffs>1311216448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -91133,7 +91133,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965952</BitOffs>
+            <BitOffs>1311224384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -91146,7 +91146,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965960</BitOffs>
+            <BitOffs>1311224392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -91159,7 +91159,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965968</BitOffs>
+            <BitOffs>1311224400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -91182,7 +91182,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965984</BitOffs>
+            <BitOffs>1311224416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -91195,7 +91195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966016</BitOffs>
+            <BitOffs>1311224448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -91208,7 +91208,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966080</BitOffs>
+            <BitOffs>1311224512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -91221,7 +91221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966096</BitOffs>
+            <BitOffs>1311224528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91233,7 +91233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310985472</BitOffs>
+            <BitOffs>1311243904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -91245,7 +91245,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311311360</BitOffs>
+            <BitOffs>1311569792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -91258,7 +91258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319296</BitOffs>
+            <BitOffs>1311577728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -91271,7 +91271,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319304</BitOffs>
+            <BitOffs>1311577736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -91284,7 +91284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319312</BitOffs>
+            <BitOffs>1311577744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -91307,7 +91307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319328</BitOffs>
+            <BitOffs>1311577760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -91320,7 +91320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319360</BitOffs>
+            <BitOffs>1311577792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -91333,7 +91333,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319424</BitOffs>
+            <BitOffs>1311577856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -91346,7 +91346,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319440</BitOffs>
+            <BitOffs>1311577872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91358,7 +91358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311338816</BitOffs>
+            <BitOffs>1311597248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -91370,7 +91370,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311664704</BitOffs>
+            <BitOffs>1311923136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -91383,7 +91383,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672640</BitOffs>
+            <BitOffs>1311931072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -91396,7 +91396,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672648</BitOffs>
+            <BitOffs>1311931080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -91409,7 +91409,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672656</BitOffs>
+            <BitOffs>1311931088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -91432,7 +91432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672672</BitOffs>
+            <BitOffs>1311931104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -91445,7 +91445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672704</BitOffs>
+            <BitOffs>1311931136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -91458,7 +91458,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672768</BitOffs>
+            <BitOffs>1311931200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -91471,7 +91471,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672784</BitOffs>
+            <BitOffs>1311931216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91483,7 +91483,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311692160</BitOffs>
+            <BitOffs>1311950592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -91495,7 +91495,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312018048</BitOffs>
+            <BitOffs>1312276480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -91508,7 +91508,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312025984</BitOffs>
+            <BitOffs>1312284416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -91521,7 +91521,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312025992</BitOffs>
+            <BitOffs>1312284424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -91534,7 +91534,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026000</BitOffs>
+            <BitOffs>1312284432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -91557,7 +91557,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026016</BitOffs>
+            <BitOffs>1312284448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -91570,7 +91570,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026048</BitOffs>
+            <BitOffs>1312284480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -91583,7 +91583,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026112</BitOffs>
+            <BitOffs>1312284544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -91596,7 +91596,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026128</BitOffs>
+            <BitOffs>1312284560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91608,7 +91608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312045504</BitOffs>
+            <BitOffs>1312303936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -91620,7 +91620,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312371392</BitOffs>
+            <BitOffs>1312629824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -91633,7 +91633,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379328</BitOffs>
+            <BitOffs>1312637760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -91646,7 +91646,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379336</BitOffs>
+            <BitOffs>1312637768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -91659,7 +91659,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379344</BitOffs>
+            <BitOffs>1312637776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -91682,7 +91682,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379360</BitOffs>
+            <BitOffs>1312637792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -91695,7 +91695,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379392</BitOffs>
+            <BitOffs>1312637824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -91708,7 +91708,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379456</BitOffs>
+            <BitOffs>1312637888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -91721,7 +91721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379472</BitOffs>
+            <BitOffs>1312637904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91733,7 +91733,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312398848</BitOffs>
+            <BitOffs>1312657280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -91745,7 +91745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312724736</BitOffs>
+            <BitOffs>1312983168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -91758,7 +91758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732672</BitOffs>
+            <BitOffs>1312991104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -91771,7 +91771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732680</BitOffs>
+            <BitOffs>1312991112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -91784,7 +91784,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732688</BitOffs>
+            <BitOffs>1312991120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -91807,7 +91807,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732704</BitOffs>
+            <BitOffs>1312991136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -91820,7 +91820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732736</BitOffs>
+            <BitOffs>1312991168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -91833,7 +91833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732800</BitOffs>
+            <BitOffs>1312991232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -91846,7 +91846,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732816</BitOffs>
+            <BitOffs>1312991248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91858,7 +91858,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312752192</BitOffs>
+            <BitOffs>1313010624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -91870,7 +91870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313078080</BitOffs>
+            <BitOffs>1313336512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -91883,7 +91883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086016</BitOffs>
+            <BitOffs>1313344448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -91896,7 +91896,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086024</BitOffs>
+            <BitOffs>1313344456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -91909,7 +91909,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086032</BitOffs>
+            <BitOffs>1313344464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -91932,7 +91932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086048</BitOffs>
+            <BitOffs>1313344480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -91945,7 +91945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086080</BitOffs>
+            <BitOffs>1313344512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -91958,7 +91958,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086144</BitOffs>
+            <BitOffs>1313344576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -91971,7 +91971,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086160</BitOffs>
+            <BitOffs>1313344592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91983,7 +91983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313105536</BitOffs>
+            <BitOffs>1313363968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -91995,7 +91995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313431424</BitOffs>
+            <BitOffs>1313689856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -92008,7 +92008,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439360</BitOffs>
+            <BitOffs>1313697792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -92021,7 +92021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439368</BitOffs>
+            <BitOffs>1313697800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -92034,7 +92034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439376</BitOffs>
+            <BitOffs>1313697808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -92057,7 +92057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439392</BitOffs>
+            <BitOffs>1313697824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -92070,7 +92070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439424</BitOffs>
+            <BitOffs>1313697856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -92083,7 +92083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439488</BitOffs>
+            <BitOffs>1313697920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -92096,7 +92096,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439504</BitOffs>
+            <BitOffs>1313697936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92108,7 +92108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313458880</BitOffs>
+            <BitOffs>1313717312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -92120,7 +92120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313784768</BitOffs>
+            <BitOffs>1314043200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -92133,7 +92133,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792704</BitOffs>
+            <BitOffs>1314051136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -92146,7 +92146,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792712</BitOffs>
+            <BitOffs>1314051144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -92159,7 +92159,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792720</BitOffs>
+            <BitOffs>1314051152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -92182,7 +92182,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792736</BitOffs>
+            <BitOffs>1314051168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -92195,7 +92195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792768</BitOffs>
+            <BitOffs>1314051200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -92208,7 +92208,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792832</BitOffs>
+            <BitOffs>1314051264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -92221,7 +92221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792848</BitOffs>
+            <BitOffs>1314051280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92233,7 +92233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313812224</BitOffs>
+            <BitOffs>1314070656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -92245,7 +92245,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314138112</BitOffs>
+            <BitOffs>1314396544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -92258,7 +92258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146048</BitOffs>
+            <BitOffs>1314404480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -92271,7 +92271,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146056</BitOffs>
+            <BitOffs>1314404488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -92284,7 +92284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146064</BitOffs>
+            <BitOffs>1314404496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -92307,7 +92307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146080</BitOffs>
+            <BitOffs>1314404512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -92320,7 +92320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146112</BitOffs>
+            <BitOffs>1314404544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -92333,7 +92333,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146176</BitOffs>
+            <BitOffs>1314404608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -92346,7 +92346,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146192</BitOffs>
+            <BitOffs>1314404624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92358,7 +92358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314165568</BitOffs>
+            <BitOffs>1314424000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -92373,14 +92373,14 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314490368</BitOffs>
+            <BitOffs>1314748800</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -93347,1207 +93347,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1304951784</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M1.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306000640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306009624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306028096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306353984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306362968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306381440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306707328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306716312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306734784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307060672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307069656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307088128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307414016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307423000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307439936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307448920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307465856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307474840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307491776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307500760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307517696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307526680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307543616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307552600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307569536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307578520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307595456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307604440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307622912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307948800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307957784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307976256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308302144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308311128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308329600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308655488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308664472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308682944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309008832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309017816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309034752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309043736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309062208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309388096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309397080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309415552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309741440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309750424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309767360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309776344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309793280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309802264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309819200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309828184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309845120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309854104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309871040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309880024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309896960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309905944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309924416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310250304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310259288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310277760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310603648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310612632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310631104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310956992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310965976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310984448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311310336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311319320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311337792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311663680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311672664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311691136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312017024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312026008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312044480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312370368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312379352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312397824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312723712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312732696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312751168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313077056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313086040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313104512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313430400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313439384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313457856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313783744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313792728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313811200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314137088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314146072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314164544</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -94565,14 +93364,1215 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1323772520</BitOffs>
+            <BitOffs>1305598056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306259072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306268056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306286528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306612416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306621400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306639872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306965760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306974744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306993216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307319104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307328088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307346560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307672448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307681432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307698368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307707352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307724288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307733272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307750208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307759192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307776128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307785112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307802048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307811032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307827968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307836952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307853888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307862872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307881344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308207232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308216216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308234688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308560576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308569560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308588032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308913920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308922904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308941376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309267264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309276248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309293184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309302168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309320640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309646528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309655512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309673984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309999872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310008856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310025792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310034776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310051712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310060696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310077632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310086616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310103552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310112536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310129472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310138456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310155392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310164376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310182848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310508736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310517720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310536192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310862080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310871064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310889536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311215424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311224408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311242880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311568768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311577752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311596224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311922112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311931096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311949568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312275456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312284440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312302912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312628800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312637784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312656256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312982144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312991128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313009600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313335488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313344472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313362944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313688832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313697816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313716288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314042176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314051160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314069632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314395520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314404504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314422976</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -101823,10 +101823,29 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264978656</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019440</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265129472</BitOffs>
+            <BitOffs>1265910272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -101839,26 +101858,7 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265129600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135536</BitOffs>
+            <BitOffs>1265910400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -104694,7 +104694,6 @@ M2K2 FLAT X ENC CNT</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates</Name>
-            <Comment>	This state implemtation is waiting on an upgrade to the state mover library because its encoder is inverted.</Comment>
             <BitSize>1541312</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
             <Properties>
@@ -106332,1555 +106331,33 @@ M4K2 KBV X ENC CNT</Comment>
             <BitOffs>1304951488</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M1</Name>
-            <Comment> M1K2 Yleft</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
+            <BitSize>646272</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
             <Default>
               <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
+                <Name>.bAutoReset</Name>
                 <Bool>true</Bool>
               </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:YLEFT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306000576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m1</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306026496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2</Name>
-            <Comment> M1K2 Yright</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
               <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:YRIGHT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306353920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m2</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306379840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3</Name>
-            <Comment> M1K2 Xup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
-                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:XUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306707264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m3</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306733184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4</Name>
-            <Comment> M1K2 Xdwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:XDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307060608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m4</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307086528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5</Name>
-            <Comment> M1K2 Pitch Stepper</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>30</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307413952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6</Name>
-            <Comment> M_PI, urad</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
+                <Name>.i_sNetID</Name>
+                <String>172.21.42.126.1.1</String>
               </SubItem>
             </Default>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_PI
-    </Value>
+                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
               </Property>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
               </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307439872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8</Name>
-            <Comment> M_H, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_H
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307491712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9</Name>
-            <Comment> G_H, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>1000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:G_H
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307517632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10</Name>
-            <Comment> SD_V, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:SD_V
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307543552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11</Name>
-            <Comment> SD_R, urad</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:SD_ROT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307569472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12</Name>
-            <Comment> M1K1 Yup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
-                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:YUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307595392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m12</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307621312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13</Name>
-            <Comment> M1K1 Ydwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:YDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307948736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m13</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307974656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14</Name>
-            <Comment> M1K1 Xup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:XUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308302080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m14</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308328000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15</Name>
-            <Comment> M1K1 Xdwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:XDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308655424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m15</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308681344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16</Name>
-            <Comment> M1K1 Pitch Stepper</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>30</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Pitch]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309008768</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17</Name>
-            <Comment>MR1K1 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: MR1K1:BEND:MMS:US
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309034688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m17</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309060608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18</Name>
-            <Comment>MR1K1 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: MR1K1:BEND:MMS:DS
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309388032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m18</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309413952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19</Name>
-            <Comment> Air Pitch</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:PITCH</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.12</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 1;
-                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309741376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20</Name>
-            <Comment> Air Vertical</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:VERT</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.3</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
-                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:VERT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309767296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21</Name>
-            <Comment> Air Roll</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:ROLL</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.24</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:ROLL
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309793216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22</Name>
-            <Comment> GAP</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:GAP</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:GAP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309819136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23</Name>
-            <Comment> YAG</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:YAG</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.5</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:YAG
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309845056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24</Name>
-            <Comment> ST1K1-ZOS-MMS</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>ST1K1:ZOS:MMS</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: ST1K1:ZOS:MMS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable  := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
-                              .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309870976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309896896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM25</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309922816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310250240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM26</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310276160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310603584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM27</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310629504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310956928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM28</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310982848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311310272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM29</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311336192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311663616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM30</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311689536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31</Name>
-            <Comment>MR3K2 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:MMS:BEND:US</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312016960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM31</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312042880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32</Name>
-            <Comment>MR3K2 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:BEND:DS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312370304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM32</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312396224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312723648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM33</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312749568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313076992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM34</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313102912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313430336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM35</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313456256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36</Name>
-            <Comment>MR4K2 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:MMS:BEND:US</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313783680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM36</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313809600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37</Name>
-            <Comment>MR4K2 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:BEND:DS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314137024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM37</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314162944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.dummyBool</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490416</BitOffs>
+            <BitOffs>1305597760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetY</Name>
@@ -107921,7 +106398,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314490432</BitOffs>
+            <BitOffs>1306244416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetX</Name>
@@ -107962,7 +106439,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314494080</BitOffs>
+            <BitOffs>1306248064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBX</Name>
@@ -108003,7 +106480,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314497728</BitOffs>
+            <BitOffs>1306251712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBY</Name>
@@ -108044,7 +106521,1543 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314501376</BitOffs>
+            <BitOffs>1306255360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1</Name>
+            <Comment> M1K2 Yleft</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:YLEFT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306259008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m1</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306284928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2</Name>
+            <Comment> M1K2 Yright</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:YRIGHT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306612352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m2</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306638272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3</Name>
+            <Comment> M1K2 Xup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:XUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306965696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m3</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306991616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4</Name>
+            <Comment> M1K2 Xdwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:XDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307319040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m4</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307344960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5</Name>
+            <Comment> M1K2 Pitch Stepper</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>30</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307672384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6</Name>
+            <Comment> M_PI, urad</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_PI
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307698304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8</Name>
+            <Comment> M_H, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_H
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307750144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9</Name>
+            <Comment> G_H, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:G_H
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307776064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10</Name>
+            <Comment> SD_V, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:SD_V
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307801984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11</Name>
+            <Comment> SD_R, urad</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:SD_ROT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307827904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12</Name>
+            <Comment> M1K1 Yup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
+                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:YUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307853824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m12</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307879744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13</Name>
+            <Comment> M1K1 Ydwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:YDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308207168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m13</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308233088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14</Name>
+            <Comment> M1K1 Xup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:XUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308560512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m14</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308586432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15</Name>
+            <Comment> M1K1 Xdwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:XDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308913856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m15</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308939776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16</Name>
+            <Comment> M1K1 Pitch Stepper</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>30</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Pitch]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309267200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17</Name>
+            <Comment>MR1K1 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: MR1K1:BEND:MMS:US
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309293120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m17</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309319040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18</Name>
+            <Comment>MR1K1 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: MR1K1:BEND:MMS:DS
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309646464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m18</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309672384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19</Name>
+            <Comment> Air Pitch</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:PITCH</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.12</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 1;
+                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309999808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20</Name>
+            <Comment> Air Vertical</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:VERT</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.3</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:VERT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310025728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21</Name>
+            <Comment> Air Roll</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:ROLL</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.24</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:ROLL
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310051648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22</Name>
+            <Comment> GAP</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:GAP</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:GAP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310077568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23</Name>
+            <Comment> YAG</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:YAG</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.5</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:YAG
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310103488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24</Name>
+            <Comment> ST1K1-ZOS-MMS</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>ST1K1:ZOS:MMS</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: ST1K1:ZOS:MMS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable  := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
+                              .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310129408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310155328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM25</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310181248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310508672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM26</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310534592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310862016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM27</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310887936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311215360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM28</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311241280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311568704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM29</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311594624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311922048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM30</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311947968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31</Name>
+            <Comment>MR3K2 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:MMS:BEND:US</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312275392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM31</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312301312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32</Name>
+            <Comment>MR3K2 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:BEND:DS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312628736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM32</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312654656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>false</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312982080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM33</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313008000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313335424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM34</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313361344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313688768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM35</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313714688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36</Name>
+            <Comment>MR4K2 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:MMS:BEND:US</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314042112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM36</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314068032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37</Name>
+            <Comment>MR4K2 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:BEND:DS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314395456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM37</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314421376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.dummyBool</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314748816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314748832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314748840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -108074,7 +108087,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505024</BitOffs>
+            <BitOffs>1314748848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -108104,7 +108117,22 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505088</BitOffs>
+            <BitOffs>1314748912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314748976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -108119,7 +108147,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505152</BitOffs>
+            <BitOffs>1314748992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -108134,7 +108162,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505168</BitOffs>
+            <BitOffs>1314749008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -108148,7 +108176,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505176</BitOffs>
+            <BitOffs>1314749016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -108163,7 +108191,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505184</BitOffs>
+            <BitOffs>1314749024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -108178,7 +108206,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505216</BitOffs>
+            <BitOffs>1314749056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -108299,7 +108327,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505248</BitOffs>
+            <BitOffs>1314749088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -108313,7 +108341,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514720</BitOffs>
+            <BitOffs>1314758560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -108327,7 +108355,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514752</BitOffs>
+            <BitOffs>1314758592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -108348,7 +108376,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314518400</BitOffs>
+            <BitOffs>1314762240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -108420,7 +108448,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536320</BitOffs>
+            <BitOffs>1314780160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -108492,7 +108520,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536448</BitOffs>
+            <BitOffs>1314780288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -108564,7 +108592,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536576</BitOffs>
+            <BitOffs>1314780416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -108636,7 +108664,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536704</BitOffs>
+            <BitOffs>1314780544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -108708,7 +108736,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536832</BitOffs>
+            <BitOffs>1314780672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -108780,7 +108808,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536960</BitOffs>
+            <BitOffs>1314780800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -108852,7 +108880,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314537088</BitOffs>
+            <BitOffs>1314780928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -108924,7 +108952,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314537216</BitOffs>
+            <BitOffs>1314781056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -108950,43 +108978,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314570240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
-            <BitSize>646272</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.bAutoReset</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.42.126.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1323772224</BitOffs>
+            <BitOffs>1314814080</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109072,7 +109071,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-10-08T17:21:58</Value>
+          <Value>2024-10-17T16:11:36</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
set PMPS state mover stages bPowerSelf false.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This causes a bug where fbPower cant reset error thrown on the first cycle of program execution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
not running, waiting on a good time to make an online change.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-6591

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
