### PR TITLE
ENH: standardize mirror RTD implementations

### DIFF
--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{E6887738-6106-B3EA-6F44-1758ABE554CA}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -2439,15 +2439,7 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -2591,6 +2583,70 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
 					<Comment><![CDATA[ RTD error bit]]></Comment>
 					<Type>BOOL</Type>
@@ -2616,38 +2672,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
 					<Comment><![CDATA[Emergency Stop for MR4K2]]></Comment>
 					<Type>BOOL</Type>
@@ -2655,11 +2679,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
-					<Comment><![CDATA[ M1K1 US RTDs]]></Comment>
-					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -2789,6 +2808,11 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
+					<Comment><![CDATA[ M1K1 US RTDs]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
 					<Type>INT</Type>
 				</Var>
@@ -2797,14 +2821,14 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
 					<Comment><![CDATA[ M1K1 DS RTDs]]></Comment>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -2820,25 +2844,17 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
 					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M3K2.nM3K2US_RTD_3</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
 					<Comment><![CDATA[ M3K2 DS RTDs]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -2864,15 +2880,11 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>Main.sio_current</Name>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.sio_load</Name>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
@@ -4406,10 +4418,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
-				<Var>
-					<Name>Main.sio_load</Name>
-					<Type>UINT</Type>
-				</Var>
 			</Vars>
 			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
@@ -4700,6 +4708,10 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5126,10 +5138,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-					<Type>BOOL</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" ContextId="4" AreaNo="68">
@@ -5683,8 +5691,11 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.M3K2KBHbSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL3202-0010_M3K2DS2_M3K2DS3">
-				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2DS_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2DS_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL3202-0010_M3K2US1_M3K2US2">
 				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2US_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
@@ -5692,7 +5703,10 @@ Emergency Stop for MR1K1]]></Comment>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL3202-0010_M3K2US3_M3K2DS1">
 				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2DS_RTD_1" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2US_RTD_3" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL5042_M3K2_BEND_USDS">
 				<Link VarA="PlcTask Inputs^Main.M31.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -5744,14 +5758,14 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^GVL_M4K2.nM4K2US_RTD_3" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 322 (EK1122)^EK1100_MR4K2_BENDER^EL3204_M4K2_CHIN">
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 322 (EK1122)^EK1100_MR4K2_BENDER^EL5042_M4K2_BEND_USDS">
 				<Link VarA="PlcTask Inputs^Main.M36.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{CB96F166-08A2-0ABA-C7F0-6CA5A48D2126}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{57BD9670-089D-434A-85CF-90A857EE0EFF}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
-					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
+					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{57BD9670-089D-434A-85CF-90A857EE0EFF}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
-					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
+					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M3K2.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M3K2.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <GVL Name="GVL_M3K2" Id="{5370e595-0f6e-4259-88a1-5883bdb06ca4}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
@@ -27,14 +27,11 @@ VAR_GLOBAL
     nM3K2US_RTD_1 AT %I* : INT;
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2US1_M3K2US2]^RTD Inputs Channel 2^Value'}
     nM3K2US_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value'}
-    nM3K2US_RTD_3 AT %I* : INT;
+
 
     // M3K2 DS RTDs
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 2^Value'}
     nM3K2DS_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value'}
-    nM3K2DS_RTD_2 AT %I* : INT;
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 2^Value'}
     nM3K2DS_RTD_3 AT %I* : INT;
 

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M4K2.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M4K2.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <GVL Name="GVL_M4K2" Id="{12e24a9c-eb09-4496-9c31-a36df2f36ea7}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
@@ -31,10 +31,7 @@ VAR_GLOBAL
     // M4K2 DS RTDs
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M4K2US3_M4K2DS1]^RTD Inputs Channel 2^Value'}
     nM4K2DS_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 1^Value'}
-    nM4K2DS_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 2^Value'}
-    nM4K2DS_RTD_3 AT %I* : INT;
+
 
 END_VAR]]></Declaration>
   </GVL>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -306,8 +306,8 @@ fbCoatingStates(
     sTransitionKey:='MR3K2:KBH-TRANSITION',
 );
 
-fbM3K2_Chin_Right_RTD();
-fbM3K2_Chin_Left_RTD();]]></ST>
+fbM3K2_Chin_Right_RTD(fResolution:=0.01);
+fbM3K2_Chin_Left_RTD(fResolution:=0.01);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -195,7 +195,7 @@ VAR
                               .bOverrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Overrange;
                               .bError := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Error'}
     {attribute 'pytmc' := '
-        pv: MR3K2:KBV:RTD:CHIN:L
+        pv: MR3K2:KBH:RTD:CHIN:L
         field: EGU C
         io: i
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -120,14 +120,6 @@ VAR
             io: i
         '}
         fM3K2US_RTD_2 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR3K2:KBH:RTD:CHIN:L
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM3K2US_RTD_3 : REAL;
-
         // M3K2 DS RTDs
         {attribute 'pytmc' := '
             pv: MR3K2:KBH:RTD:BEND:DS:1
@@ -136,13 +128,6 @@ VAR
             io: i
         '}
         fM3K2DS_RTD_1 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR3K2:KBH:RTD:CHIN:R
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM3K2DS_RTD_2 : REAL;
         {attribute 'pytmc' := '
             pv: MR3K2:KBH:RTD:BEND:DS:3
             field: ASLO 0.01
@@ -154,9 +139,9 @@ VAR
     // RTD error bit
         bM3K2US_RTD_1_Err AT %I*: BOOL;
         bM3K2US_RTD_2_Err AT %I*: BOOL;
-        bM3K2US_RTD_3_Err AT %I*: BOOL;
+
         bM3K2DS_RTD_1_Err AT %I*: BOOL;
-        bM3K2DS_RTD_2_Err AT %I*: BOOL;
+
         bM3K2DS_RTD_3_Err AT %I*: BOOL;
 
     //Emergency Stop for MR3K2
@@ -195,6 +180,26 @@ VAR
     fbYSetup: FB_StateSetupHelper;
 
     astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR3K2:KBH:RTD:CHIN:R
+        field: EGU C
+        io: i
+    '}
+    fbM3K2_Chin_Right_RTD : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR3K2:KBV:RTD:CHIN:L
+        field: EGU C
+        io: i
+    '}
+    fbM3K2_Chin_Left_RTD : FB_TempSensor;
 
 END_VAR]]></Declaration>
     <Implementation>
@@ -252,18 +257,13 @@ nEncCntDSM3K2  := ULINT_TO_UDINT(M32.nRawEncoderULINT);
 // MR3K2 Bender RTDs
 fM3K2US_RTD_1 := INT_TO_REAL(GVL_M3K2.nM3K2US_RTD_1);
 fM3K2US_RTD_2 := INT_TO_REAL(GVL_M3K2.nM3K2US_RTD_2);
-fM3K2US_RTD_3 := INT_TO_REAL(GVL_M3K2.nM3K2US_RTD_3);
-
 fM3K2DS_RTD_1 := INT_TO_REAL(GVL_M3K2.nM3K2DS_RTD_1);
-fM3K2DS_RTD_2 := INT_TO_REAL(GVL_M3K2.nM3K2DS_RTD_2);
 fM3K2DS_RTD_3 := INT_TO_REAL(GVL_M3K2.nM3K2DS_RTD_3);
 
 // RTD not connected if T=0
 bM3K2US_RTD_1_Err := fM3K2US_RTD_1 = 0;
-bM3K2US_RTD_2_Err := fM3K2DS_RTD_2 = 0;
-bM3K2US_RTD_3_Err := fM3K2US_RTD_3 = 0;
+bM3K2US_RTD_2_Err := fM3K2US_RTD_2 = 0;
 bM3K2DS_RTD_1_Err := fM3K2DS_RTD_1 = 0;
-bM3K2DS_RTD_2_Err := fM3K2DS_RTD_2 = 0;
 bM3K2DS_RTD_3_Err := fM3K2DS_RTD_3 = 0;
 
 // M3K2 Bender RTD interlocks

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -304,7 +304,10 @@ fbCoatingStates(
     bEnableBeamParams:=TRUE,
     sDeviceName:='MR3K2:KBH',
     sTransitionKey:='MR3K2:KBH-TRANSITION',
-);]]></ST>
+);
+
+fbM3K2_Chin_Right_RTD();
+fbM3K2_Chin_Left_RTD();]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
@@ -275,8 +275,8 @@ bM4K2DS_RTD_1_Err := fM4K2DS_RTD_1 = 0;
 M36.bHardwareEnable R= fM4K2US_RTD_1 > 9000 OR bM4K2US_RTD_1_Err;
 M37.bHardwareEnable R= fM4K2DS_RTD_1 > 9000 OR bM4K2DS_RTD_1_Err;
 
-fbM4K2_Chin_Right_RTD();
-fbM4K2_Chin_Left_RTD();
+fbM4K2_Chin_Right_RTD(fResolution:=0.01);
+fbM4K2_Chin_Left_RTD(fResolution:=0.01);
 
 // Axilon Cooling Panel
 fbCoolingPanel();

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
@@ -136,20 +136,6 @@ VAR
             io: i
         '}
         fM4K2DS_RTD_1 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR4K2:KBV:RTD:BEND:DS:2
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM4K2DS_RTD_2 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR4K2:KBV:RTD:BEND:DS:3
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM4K2DS_RTD_3 : REAL;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 1^Status^Overrange;
@@ -159,7 +145,7 @@ VAR
         field: EGU C
         io: i
     '}
-    nM4K2_Chin_Right_RTD : FB_TempSensor;
+    fbM4K2_Chin_Right_RTD : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 2^Value;
                               .bUnderrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 2^Status^Overrange;
@@ -169,7 +155,7 @@ VAR
         field: EGU C
         io: i
     '}
-    nM4K2_Chin_Left_RTD : FB_TempSensor;
+    fbM4K2_Chin_Left_RTD : FB_TempSensor;
 
     // RTD error bit
         bM4K2US_RTD_1_Err AT %I*: BOOL;
@@ -277,23 +263,20 @@ fM4K2US_RTD_2 := INT_TO_REAL(GVL_M4K2.nM4K2US_RTD_2);
 fM4K2US_RTD_3 := INT_TO_REAL(GVL_M4K2.nM4K2US_RTD_3);
 
 fM4K2DS_RTD_1 := INT_TO_REAL(GVL_M4K2.nM4K2DS_RTD_1);
-fM4K2DS_RTD_2 := INT_TO_REAL(GVL_M4K2.nM4K2DS_RTD_2);
-fM4K2DS_RTD_3 := INT_TO_REAL(GVL_M4K2.nM4K2DS_RTD_3);
+
 
 // RTD not connected if T=0
 bM4K2US_RTD_1_Err := fM4K2US_RTD_1 = 0;
-bM4K2US_RTD_2_Err := fM4K2DS_RTD_2 = 0;
+bM4K2US_RTD_2_Err := fM4K2US_RTD_2 = 0;
 bM4K2US_RTD_3_Err := fM4K2US_RTD_3 = 0;
 bM4K2DS_RTD_1_Err := fM4K2DS_RTD_1 = 0;
-bM4K2DS_RTD_2_Err := fM4K2DS_RTD_2 = 0;
-bM4K2DS_RTD_3_Err := fM4K2DS_RTD_3 = 0;
 
 // M4K2 Bender RTD interlocks
 M36.bHardwareEnable R= fM4K2US_RTD_1 > 9000 OR bM4K2US_RTD_1_Err;
 M37.bHardwareEnable R= fM4K2DS_RTD_1 > 9000 OR bM4K2DS_RTD_1_Err;
 
-nM4K2_Chin_Right_RTD();
-nM4K2_Chin_Left_RTD();
+fbM4K2_Chin_Right_RTD();
+fbM4K2_Chin_Left_RTD();
 
 // Axilon Cooling Panel
 fbCoolingPanel();

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82277,7 +82277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82298,7 +82298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82396,7 +82396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82414,7 +82414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82572,7 +82572,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -82669,7 +82669,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82724,7 +82724,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -83201,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -92400,7 +92400,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -94592,7 +94592,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -108983,7 +108983,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109069,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-11-05T15:47:38</Value>
+          <Value>2024-11-05T16:03:18</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{E6887738-6106-B3EA-6F44-1758ABE554CA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10419,31 +10419,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164353168</GetCodeOffs>
+        <GetCodeOffs>164383680</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164353240</GetCodeOffs>
+        <GetCodeOffs>164383752</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353256</GetCodeOffs>
+        <GetCodeOffs>164383768</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353216</GetCodeOffs>
+        <GetCodeOffs>164383728</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353248</GetCodeOffs>
+        <GetCodeOffs>164383760</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11695,15 +11695,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353040</GetCodeOffs>
-        <SetCodeOffs>164353088</SetCodeOffs>
+        <GetCodeOffs>164383552</GetCodeOffs>
+        <SetCodeOffs>164383600</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353120</GetCodeOffs>
-        <SetCodeOffs>164353144</SetCodeOffs>
+        <GetCodeOffs>164383632</GetCodeOffs>
+        <SetCodeOffs>164383656</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11944,31 +11944,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>164353352</GetCodeOffs>
+        <GetCodeOffs>164383864</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164353312</GetCodeOffs>
+        <GetCodeOffs>164383824</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353488</GetCodeOffs>
+        <GetCodeOffs>164384000</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353496</GetCodeOffs>
+        <GetCodeOffs>164384008</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353408</GetCodeOffs>
+        <GetCodeOffs>164383920</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11980,7 +11980,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353504</GetCodeOffs>
+        <GetCodeOffs>164384016</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12573,7 +12573,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164353560</GetCodeOffs>
+        <GetCodeOffs>164384072</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -29737,14 +29737,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164359904</GetCodeOffs>
+        <GetCodeOffs>164390416</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164359808</GetCodeOffs>
+        <GetCodeOffs>164390320</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -30840,7 +30840,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164360056</GetCodeOffs>
+        <GetCodeOffs>164390568</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -31499,7 +31499,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164360168</GetCodeOffs>
+        <GetCodeOffs>164390680</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -41537,7 +41537,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164366856</GetCodeOffs>
+        <GetCodeOffs>164397368</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -43465,31 +43465,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164366256</GetCodeOffs>
+        <GetCodeOffs>164396768</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164366344</GetCodeOffs>
+        <GetCodeOffs>164396856</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164366272</GetCodeOffs>
+        <GetCodeOffs>164396784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164366320</GetCodeOffs>
+        <GetCodeOffs>164396832</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164366360</GetCodeOffs>
+        <GetCodeOffs>164396872</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82270,14 +82270,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306000192</BitOffs>
+            <BitOffs>1306244320</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82291,14 +82291,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306000384</BitOffs>
+            <BitOffs>1306244512</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82315,7 +82315,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303947648</BitOffs>
+            <BitOffs>1303948032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -82326,7 +82326,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303950160</BitOffs>
+            <BitOffs>1303950544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -82340,7 +82340,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314507296</BitOffs>
+            <BitOffs>1314751456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82354,7 +82354,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314507328</BitOffs>
+            <BitOffs>1314751488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -82368,7 +82368,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514496</BitOffs>
+            <BitOffs>1314758656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -82389,14 +82389,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514816</BitOffs>
+            <BitOffs>1314758976</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82407,14 +82407,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307466880</BitOffs>
+            <BitOffs>1307725632</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82516,7 +82516,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307465792</BitOffs>
+            <BitOffs>1307724544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -82530,7 +82530,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514528</BitOffs>
+            <BitOffs>1314758688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -82544,7 +82544,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514560</BitOffs>
+            <BitOffs>1314758720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -82565,20 +82565,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314515712</BitOffs>
+            <BitOffs>1314759872</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265016832</BitOffs>
+            <BitOffs>1265797632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -82613,7 +82613,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955904</BitOffs>
+            <BitOffs>1303956288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -82627,7 +82627,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514592</BitOffs>
+            <BitOffs>1314758752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -82641,7 +82641,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514624</BitOffs>
+            <BitOffs>1314758784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -82662,14 +82662,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314516608</BitOffs>
+            <BitOffs>1314760768</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82685,7 +82685,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133632</BitOffs>
+            <BitOffs>1265017536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -82701,7 +82701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133696</BitOffs>
+            <BitOffs>1265017600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -82717,14 +82717,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133760</BitOffs>
+            <BitOffs>1265017664</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -82868,7 +82868,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265133824</BitOffs>
+            <BitOffs>1265017728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -82877,7 +82877,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265134472</BitOffs>
+            <BitOffs>1265018376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -82886,14 +82886,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265134480</BitOffs>
+            <BitOffs>1265018384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265134488</BitOffs>
+            <BitOffs>1265018392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -82902,20 +82902,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265134496</BitOffs>
+            <BitOffs>1265018400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134528</BitOffs>
+            <BitOffs>1265018432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134592</BitOffs>
+            <BitOffs>1265018496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -82924,19 +82924,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265134656</BitOffs>
+            <BitOffs>1265018560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265134720</BitOffs>
+            <BitOffs>1265018624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134784</BitOffs>
+            <BitOffs>1265018688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -82951,25 +82951,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265134848</BitOffs>
+            <BitOffs>1265018752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265134912</BitOffs>
+            <BitOffs>1265018816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135168</BitOffs>
+            <BitOffs>1265019072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265135232</BitOffs>
+            <BitOffs>1265019136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -82978,19 +82978,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265135296</BitOffs>
+            <BitOffs>1265019200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135360</BitOffs>
+            <BitOffs>1265019264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135424</BitOffs>
+            <BitOffs>1265019328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -83005,67 +83005,67 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265135488</BitOffs>
+            <BitOffs>1265019392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265135552</BitOffs>
+            <BitOffs>1265019456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265136576</BitOffs>
+            <BitOffs>1265020480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136640</BitOffs>
+            <BitOffs>1265020544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136704</BitOffs>
+            <BitOffs>1265020608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136768</BitOffs>
+            <BitOffs>1265020672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265136832</BitOffs>
+            <BitOffs>1265020736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265247424</BitOffs>
+            <BitOffs>1265131328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265522624</BitOffs>
+            <BitOffs>1265406528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265633216</BitOffs>
+            <BitOffs>1265517120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265908416</BitOffs>
+            <BitOffs>1265792320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -83077,7 +83077,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265908928</BitOffs>
+            <BitOffs>1265792832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -83089,14 +83089,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265909504</BitOffs>
+            <BitOffs>1265793408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265910336</BitOffs>
+            <BitOffs>1265794240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -83112,7 +83112,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265910592</BitOffs>
+            <BitOffs>1265794496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -83127,7 +83127,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265910624</BitOffs>
+            <BitOffs>1265794528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -83145,7 +83145,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314509376</BitOffs>
+            <BitOffs>1314753536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -83159,7 +83159,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514656</BitOffs>
+            <BitOffs>1314758816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -83173,7 +83173,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514688</BitOffs>
+            <BitOffs>1314758848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -83194,14 +83194,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314517504</BitOffs>
+            <BitOffs>1314761664</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -86490,18 +86490,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1296362256</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298628992</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -86511,19 +86499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298629008</BitOffs>
+            <BitOffs>1298628928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -86535,7 +86511,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629016</BitOffs>
+            <BitOffs>1298628936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -86552,7 +86528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629024</BitOffs>
+            <BitOffs>1298628944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -86568,7 +86544,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629032</BitOffs>
+            <BitOffs>1298628952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -86581,7 +86557,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629312</BitOffs>
+            <BitOffs>1298629248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -86594,7 +86570,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629824</BitOffs>
+            <BitOffs>1298629760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -86606,7 +86582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299930752</BitOffs>
+            <BitOffs>1299930688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -86619,7 +86595,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938688</BitOffs>
+            <BitOffs>1299938624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -86632,7 +86608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938696</BitOffs>
+            <BitOffs>1299938632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -86645,7 +86621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938704</BitOffs>
+            <BitOffs>1299938640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -86668,7 +86644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938720</BitOffs>
+            <BitOffs>1299938656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -86681,7 +86657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938752</BitOffs>
+            <BitOffs>1299938688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -86694,7 +86670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938816</BitOffs>
+            <BitOffs>1299938752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -86707,7 +86683,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938832</BitOffs>
+            <BitOffs>1299938768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -86719,7 +86695,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299956672</BitOffs>
+            <BitOffs>1299956608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -86732,7 +86708,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964608</BitOffs>
+            <BitOffs>1299964544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -86745,7 +86721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964616</BitOffs>
+            <BitOffs>1299964552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -86758,7 +86734,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964624</BitOffs>
+            <BitOffs>1299964560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -86781,7 +86757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964640</BitOffs>
+            <BitOffs>1299964576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -86794,7 +86770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964672</BitOffs>
+            <BitOffs>1299964608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -86807,7 +86783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964736</BitOffs>
+            <BitOffs>1299964672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -86820,7 +86796,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964752</BitOffs>
+            <BitOffs>1299964688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -86832,7 +86808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299982592</BitOffs>
+            <BitOffs>1299982528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -86845,7 +86821,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990528</BitOffs>
+            <BitOffs>1299990464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -86858,7 +86834,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990536</BitOffs>
+            <BitOffs>1299990472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -86871,7 +86847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990544</BitOffs>
+            <BitOffs>1299990480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -86894,7 +86870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990560</BitOffs>
+            <BitOffs>1299990496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -86907,7 +86883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990592</BitOffs>
+            <BitOffs>1299990528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -86920,7 +86896,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990656</BitOffs>
+            <BitOffs>1299990592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -86933,7 +86909,247 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990672</BitOffs>
+            <BitOffs>1299990608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302257992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -86946,7 +87162,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300171600</BitOffs>
+            <BitOffs>1302258304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -86958,7 +87174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300171608</BitOffs>
+            <BitOffs>1302258312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -86970,7 +87186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257440</BitOffs>
+            <BitOffs>1302258320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -86982,7 +87198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257448</BitOffs>
+            <BitOffs>1302258328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -86994,7 +87210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257456</BitOffs>
+            <BitOffs>1302258336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -87006,127 +87222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: ERR
-        io: input
-        field: ONAM True
-        field: ZNAM False
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: ERR
-        io: input
-        field: ONAM True
-        field: ZNAM False
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257952</BitOffs>
+            <BitOffs>1302258344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -87143,7 +87239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257984</BitOffs>
+            <BitOffs>1302258352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -87159,27 +87255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
-            <Comment> M1K1 US RTDs</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M1K1US1_M1K1US2]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302258032</BitOffs>
+            <BitOffs>1302258360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -87192,7 +87268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258304</BitOffs>
+            <BitOffs>1302258624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -87205,7 +87281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258816</BitOffs>
+            <BitOffs>1302259136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -87217,7 +87293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303559744</BitOffs>
+            <BitOffs>1303560064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -87230,7 +87306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567680</BitOffs>
+            <BitOffs>1303568000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -87243,7 +87319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567688</BitOffs>
+            <BitOffs>1303568008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -87256,7 +87332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567696</BitOffs>
+            <BitOffs>1303568016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -87279,7 +87355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567712</BitOffs>
+            <BitOffs>1303568032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -87292,7 +87368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567744</BitOffs>
+            <BitOffs>1303568064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -87305,7 +87381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567808</BitOffs>
+            <BitOffs>1303568128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -87318,7 +87394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567824</BitOffs>
+            <BitOffs>1303568144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -87330,7 +87406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303585664</BitOffs>
+            <BitOffs>1303585984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -87343,7 +87419,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593600</BitOffs>
+            <BitOffs>1303593920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -87356,7 +87432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593608</BitOffs>
+            <BitOffs>1303593928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -87369,7 +87445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593616</BitOffs>
+            <BitOffs>1303593936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -87392,7 +87468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593632</BitOffs>
+            <BitOffs>1303593952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -87405,7 +87481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593664</BitOffs>
+            <BitOffs>1303593984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -87418,7 +87494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593728</BitOffs>
+            <BitOffs>1303594048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -87431,7 +87507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593744</BitOffs>
+            <BitOffs>1303594064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -87443,7 +87519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303611584</BitOffs>
+            <BitOffs>1303611904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -87456,7 +87532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619520</BitOffs>
+            <BitOffs>1303619840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -87469,7 +87545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619528</BitOffs>
+            <BitOffs>1303619848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -87482,7 +87558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619536</BitOffs>
+            <BitOffs>1303619856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -87505,7 +87581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619552</BitOffs>
+            <BitOffs>1303619872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -87518,7 +87594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619584</BitOffs>
+            <BitOffs>1303619904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -87531,7 +87607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619648</BitOffs>
+            <BitOffs>1303619968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -87544,7 +87620,27 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619664</BitOffs>
+            <BitOffs>1303619984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
+            <Comment> M1K1 US RTDs</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[EL3202-0010_M1K1US1_M1K1US2]^RTD Inputs Channel 1^Value</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303800928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -87563,7 +87659,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303952672</BitOffs>
+            <BitOffs>1303800944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -87582,20 +87678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303952688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1303955136</BitOffs>
+            <BitOffs>1303953056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -87615,7 +87698,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955584</BitOffs>
+            <BitOffs>1303953072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1303955520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -87634,7 +87730,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955600</BitOffs>
+            <BitOffs>1303955968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -87653,7 +87749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955616</BitOffs>
+            <BitOffs>1303955984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -87673,20 +87769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1303958336</BitOffs>
+            <BitOffs>1303956000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -87705,26 +87788,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958912</BitOffs>
+            <BitOffs>1303956016</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
             </Properties>
-            <BitOffs>1303958928</BitOffs>
+            <BitOffs>1303958720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -87744,26 +87821,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303958960</BitOffs>
+            <BitOffs>1303959296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -87782,7 +87840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958976</BitOffs>
+            <BitOffs>1303959312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -87802,7 +87860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958992</BitOffs>
+            <BitOffs>1303959328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -87821,7 +87879,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959008</BitOffs>
+            <BitOffs>1303959344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -87840,7 +87898,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959024</BitOffs>
+            <BitOffs>1303959936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -87860,45 +87918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 2^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959648</BitOffs>
+            <BitOffs>1303959952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -87913,7 +87933,22 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959664</BitOffs>
+            <BitOffs>1306244704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.sio_load</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306244720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -87925,7 +87960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306001664</BitOffs>
+            <BitOffs>1306260416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -87938,7 +87973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009600</BitOffs>
+            <BitOffs>1306268352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -87951,7 +87986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009608</BitOffs>
+            <BitOffs>1306268360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -87964,7 +87999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009616</BitOffs>
+            <BitOffs>1306268368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -87987,7 +88022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009632</BitOffs>
+            <BitOffs>1306268384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -88000,7 +88035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009664</BitOffs>
+            <BitOffs>1306268416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -88013,7 +88048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009728</BitOffs>
+            <BitOffs>1306268480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -88026,7 +88061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009744</BitOffs>
+            <BitOffs>1306268496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88038,7 +88073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306029120</BitOffs>
+            <BitOffs>1306287872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -88050,7 +88085,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306355008</BitOffs>
+            <BitOffs>1306613760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -88063,7 +88098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362944</BitOffs>
+            <BitOffs>1306621696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -88076,7 +88111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362952</BitOffs>
+            <BitOffs>1306621704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -88089,7 +88124,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362960</BitOffs>
+            <BitOffs>1306621712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -88112,7 +88147,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362976</BitOffs>
+            <BitOffs>1306621728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -88125,7 +88160,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363008</BitOffs>
+            <BitOffs>1306621760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -88138,7 +88173,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363072</BitOffs>
+            <BitOffs>1306621824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -88151,7 +88186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363088</BitOffs>
+            <BitOffs>1306621840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88163,7 +88198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306382464</BitOffs>
+            <BitOffs>1306641216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -88175,7 +88210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306708352</BitOffs>
+            <BitOffs>1306967104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -88188,7 +88223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716288</BitOffs>
+            <BitOffs>1306975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -88201,7 +88236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716296</BitOffs>
+            <BitOffs>1306975048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -88214,7 +88249,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716304</BitOffs>
+            <BitOffs>1306975056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -88237,7 +88272,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716320</BitOffs>
+            <BitOffs>1306975072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -88250,7 +88285,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716352</BitOffs>
+            <BitOffs>1306975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -88263,7 +88298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716416</BitOffs>
+            <BitOffs>1306975168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -88276,7 +88311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716432</BitOffs>
+            <BitOffs>1306975184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88288,7 +88323,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306735808</BitOffs>
+            <BitOffs>1306994560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -88300,7 +88335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307061696</BitOffs>
+            <BitOffs>1307320448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -88313,7 +88348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069632</BitOffs>
+            <BitOffs>1307328384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -88326,7 +88361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069640</BitOffs>
+            <BitOffs>1307328392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -88339,7 +88374,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069648</BitOffs>
+            <BitOffs>1307328400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -88362,7 +88397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069664</BitOffs>
+            <BitOffs>1307328416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -88375,7 +88410,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069696</BitOffs>
+            <BitOffs>1307328448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -88388,7 +88423,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069760</BitOffs>
+            <BitOffs>1307328512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -88401,7 +88436,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069776</BitOffs>
+            <BitOffs>1307328528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88413,7 +88448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307089152</BitOffs>
+            <BitOffs>1307347904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -88425,7 +88460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307415040</BitOffs>
+            <BitOffs>1307673792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -88438,7 +88473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422976</BitOffs>
+            <BitOffs>1307681728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -88451,7 +88486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422984</BitOffs>
+            <BitOffs>1307681736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -88464,7 +88499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422992</BitOffs>
+            <BitOffs>1307681744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -88487,7 +88522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423008</BitOffs>
+            <BitOffs>1307681760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -88500,7 +88535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423040</BitOffs>
+            <BitOffs>1307681792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -88513,7 +88548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423104</BitOffs>
+            <BitOffs>1307681856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -88526,7 +88561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423120</BitOffs>
+            <BitOffs>1307681872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -88538,7 +88573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307440960</BitOffs>
+            <BitOffs>1307699712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -88551,7 +88586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448896</BitOffs>
+            <BitOffs>1307707648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -88564,7 +88599,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448904</BitOffs>
+            <BitOffs>1307707656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -88577,7 +88612,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448912</BitOffs>
+            <BitOffs>1307707664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -88600,7 +88635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448928</BitOffs>
+            <BitOffs>1307707680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -88613,7 +88648,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448960</BitOffs>
+            <BitOffs>1307707712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -88626,7 +88661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307449024</BitOffs>
+            <BitOffs>1307707776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -88639,7 +88674,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307449040</BitOffs>
+            <BitOffs>1307707792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -88652,7 +88687,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474816</BitOffs>
+            <BitOffs>1307733568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -88665,7 +88700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474824</BitOffs>
+            <BitOffs>1307733576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -88678,7 +88713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474832</BitOffs>
+            <BitOffs>1307733584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -88701,7 +88736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474848</BitOffs>
+            <BitOffs>1307733600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -88714,7 +88749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474880</BitOffs>
+            <BitOffs>1307733632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -88727,7 +88762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474944</BitOffs>
+            <BitOffs>1307733696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -88740,7 +88775,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474960</BitOffs>
+            <BitOffs>1307733712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -88752,7 +88787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307492800</BitOffs>
+            <BitOffs>1307751552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -88765,7 +88800,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500736</BitOffs>
+            <BitOffs>1307759488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -88778,7 +88813,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500744</BitOffs>
+            <BitOffs>1307759496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -88791,7 +88826,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500752</BitOffs>
+            <BitOffs>1307759504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -88814,7 +88849,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500768</BitOffs>
+            <BitOffs>1307759520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -88827,7 +88862,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500800</BitOffs>
+            <BitOffs>1307759552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -88840,7 +88875,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500864</BitOffs>
+            <BitOffs>1307759616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -88853,7 +88888,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500880</BitOffs>
+            <BitOffs>1307759632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -88865,7 +88900,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307518720</BitOffs>
+            <BitOffs>1307777472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -88878,7 +88913,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526656</BitOffs>
+            <BitOffs>1307785408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -88891,7 +88926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526664</BitOffs>
+            <BitOffs>1307785416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -88904,7 +88939,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526672</BitOffs>
+            <BitOffs>1307785424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -88927,7 +88962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526688</BitOffs>
+            <BitOffs>1307785440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -88940,7 +88975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526720</BitOffs>
+            <BitOffs>1307785472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -88953,7 +88988,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526784</BitOffs>
+            <BitOffs>1307785536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -88966,7 +89001,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526800</BitOffs>
+            <BitOffs>1307785552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -88978,7 +89013,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307544640</BitOffs>
+            <BitOffs>1307803392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -88991,7 +89026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552576</BitOffs>
+            <BitOffs>1307811328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -89004,7 +89039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552584</BitOffs>
+            <BitOffs>1307811336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -89017,7 +89052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552592</BitOffs>
+            <BitOffs>1307811344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -89040,7 +89075,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552608</BitOffs>
+            <BitOffs>1307811360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -89053,7 +89088,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552640</BitOffs>
+            <BitOffs>1307811392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -89066,7 +89101,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552704</BitOffs>
+            <BitOffs>1307811456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -89079,7 +89114,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552720</BitOffs>
+            <BitOffs>1307811472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -89091,7 +89126,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307570560</BitOffs>
+            <BitOffs>1307829312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -89104,7 +89139,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578496</BitOffs>
+            <BitOffs>1307837248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -89117,7 +89152,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578504</BitOffs>
+            <BitOffs>1307837256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -89130,7 +89165,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578512</BitOffs>
+            <BitOffs>1307837264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -89153,7 +89188,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578528</BitOffs>
+            <BitOffs>1307837280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -89166,7 +89201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578560</BitOffs>
+            <BitOffs>1307837312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -89179,7 +89214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578624</BitOffs>
+            <BitOffs>1307837376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -89192,7 +89227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578640</BitOffs>
+            <BitOffs>1307837392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -89204,7 +89239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307596480</BitOffs>
+            <BitOffs>1307855232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -89217,7 +89252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604416</BitOffs>
+            <BitOffs>1307863168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -89230,7 +89265,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604424</BitOffs>
+            <BitOffs>1307863176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -89243,7 +89278,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604432</BitOffs>
+            <BitOffs>1307863184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -89266,7 +89301,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604448</BitOffs>
+            <BitOffs>1307863200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -89279,7 +89314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604480</BitOffs>
+            <BitOffs>1307863232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -89292,7 +89327,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604544</BitOffs>
+            <BitOffs>1307863296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -89305,7 +89340,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604560</BitOffs>
+            <BitOffs>1307863312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89317,7 +89352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307623936</BitOffs>
+            <BitOffs>1307882688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -89329,7 +89364,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307949824</BitOffs>
+            <BitOffs>1308208576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -89342,7 +89377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957760</BitOffs>
+            <BitOffs>1308216512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -89355,7 +89390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957768</BitOffs>
+            <BitOffs>1308216520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -89368,7 +89403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957776</BitOffs>
+            <BitOffs>1308216528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -89391,7 +89426,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957792</BitOffs>
+            <BitOffs>1308216544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -89404,7 +89439,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957824</BitOffs>
+            <BitOffs>1308216576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -89417,7 +89452,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957888</BitOffs>
+            <BitOffs>1308216640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -89430,7 +89465,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957904</BitOffs>
+            <BitOffs>1308216656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89442,7 +89477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307977280</BitOffs>
+            <BitOffs>1308236032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -89454,7 +89489,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308303168</BitOffs>
+            <BitOffs>1308561920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -89467,7 +89502,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311104</BitOffs>
+            <BitOffs>1308569856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -89480,7 +89515,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311112</BitOffs>
+            <BitOffs>1308569864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -89493,7 +89528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311120</BitOffs>
+            <BitOffs>1308569872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -89516,7 +89551,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311136</BitOffs>
+            <BitOffs>1308569888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -89529,7 +89564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311168</BitOffs>
+            <BitOffs>1308569920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -89542,7 +89577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311232</BitOffs>
+            <BitOffs>1308569984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -89555,7 +89590,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311248</BitOffs>
+            <BitOffs>1308570000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89567,7 +89602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308330624</BitOffs>
+            <BitOffs>1308589376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -89579,7 +89614,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308656512</BitOffs>
+            <BitOffs>1308915264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -89592,7 +89627,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664448</BitOffs>
+            <BitOffs>1308923200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -89605,7 +89640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664456</BitOffs>
+            <BitOffs>1308923208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -89618,7 +89653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664464</BitOffs>
+            <BitOffs>1308923216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -89641,7 +89676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664480</BitOffs>
+            <BitOffs>1308923232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -89654,7 +89689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664512</BitOffs>
+            <BitOffs>1308923264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -89667,7 +89702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664576</BitOffs>
+            <BitOffs>1308923328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -89680,7 +89715,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664592</BitOffs>
+            <BitOffs>1308923344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89692,7 +89727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308683968</BitOffs>
+            <BitOffs>1308942720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -89704,7 +89739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309009856</BitOffs>
+            <BitOffs>1309268608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -89717,7 +89752,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017792</BitOffs>
+            <BitOffs>1309276544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -89730,7 +89765,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017800</BitOffs>
+            <BitOffs>1309276552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -89743,7 +89778,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017808</BitOffs>
+            <BitOffs>1309276560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -89766,7 +89801,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017824</BitOffs>
+            <BitOffs>1309276576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -89779,7 +89814,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017856</BitOffs>
+            <BitOffs>1309276608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -89792,7 +89827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017920</BitOffs>
+            <BitOffs>1309276672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -89805,7 +89840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017936</BitOffs>
+            <BitOffs>1309276688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -89817,7 +89852,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309035776</BitOffs>
+            <BitOffs>1309294528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -89830,7 +89865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043712</BitOffs>
+            <BitOffs>1309302464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -89843,7 +89878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043720</BitOffs>
+            <BitOffs>1309302472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -89856,7 +89891,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043728</BitOffs>
+            <BitOffs>1309302480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -89879,7 +89914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043744</BitOffs>
+            <BitOffs>1309302496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -89892,7 +89927,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043776</BitOffs>
+            <BitOffs>1309302528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -89905,7 +89940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043840</BitOffs>
+            <BitOffs>1309302592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -89918,7 +89953,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043856</BitOffs>
+            <BitOffs>1309302608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89930,7 +89965,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309063232</BitOffs>
+            <BitOffs>1309321984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -89942,7 +89977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309389120</BitOffs>
+            <BitOffs>1309647872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -89955,7 +89990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397056</BitOffs>
+            <BitOffs>1309655808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -89968,7 +90003,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397064</BitOffs>
+            <BitOffs>1309655816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -89981,7 +90016,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397072</BitOffs>
+            <BitOffs>1309655824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -90004,7 +90039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397088</BitOffs>
+            <BitOffs>1309655840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -90017,7 +90052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397120</BitOffs>
+            <BitOffs>1309655872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -90030,7 +90065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397184</BitOffs>
+            <BitOffs>1309655936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -90043,7 +90078,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397200</BitOffs>
+            <BitOffs>1309655952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90055,7 +90090,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309416576</BitOffs>
+            <BitOffs>1309675328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -90067,7 +90102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309742464</BitOffs>
+            <BitOffs>1310001216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -90080,7 +90115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750400</BitOffs>
+            <BitOffs>1310009152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -90093,7 +90128,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750408</BitOffs>
+            <BitOffs>1310009160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -90106,7 +90141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750416</BitOffs>
+            <BitOffs>1310009168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -90129,7 +90164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750432</BitOffs>
+            <BitOffs>1310009184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -90142,7 +90177,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750464</BitOffs>
+            <BitOffs>1310009216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -90155,7 +90190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750528</BitOffs>
+            <BitOffs>1310009280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -90168,7 +90203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750544</BitOffs>
+            <BitOffs>1310009296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -90180,7 +90215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309768384</BitOffs>
+            <BitOffs>1310027136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -90193,7 +90228,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776320</BitOffs>
+            <BitOffs>1310035072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -90206,7 +90241,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776328</BitOffs>
+            <BitOffs>1310035080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -90219,7 +90254,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776336</BitOffs>
+            <BitOffs>1310035088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -90242,7 +90277,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776352</BitOffs>
+            <BitOffs>1310035104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -90255,7 +90290,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776384</BitOffs>
+            <BitOffs>1310035136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -90268,7 +90303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776448</BitOffs>
+            <BitOffs>1310035200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -90281,7 +90316,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776464</BitOffs>
+            <BitOffs>1310035216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -90293,7 +90328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309794304</BitOffs>
+            <BitOffs>1310053056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -90306,7 +90341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802240</BitOffs>
+            <BitOffs>1310060992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -90319,7 +90354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802248</BitOffs>
+            <BitOffs>1310061000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -90332,7 +90367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802256</BitOffs>
+            <BitOffs>1310061008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -90355,7 +90390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802272</BitOffs>
+            <BitOffs>1310061024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -90368,7 +90403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802304</BitOffs>
+            <BitOffs>1310061056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -90381,7 +90416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802368</BitOffs>
+            <BitOffs>1310061120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -90394,7 +90429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802384</BitOffs>
+            <BitOffs>1310061136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -90406,7 +90441,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309820224</BitOffs>
+            <BitOffs>1310078976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -90419,7 +90454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828160</BitOffs>
+            <BitOffs>1310086912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -90432,7 +90467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828168</BitOffs>
+            <BitOffs>1310086920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -90445,7 +90480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828176</BitOffs>
+            <BitOffs>1310086928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -90468,7 +90503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828192</BitOffs>
+            <BitOffs>1310086944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -90481,7 +90516,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828224</BitOffs>
+            <BitOffs>1310086976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -90494,7 +90529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828288</BitOffs>
+            <BitOffs>1310087040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -90507,7 +90542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828304</BitOffs>
+            <BitOffs>1310087056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -90519,7 +90554,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309846144</BitOffs>
+            <BitOffs>1310104896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -90532,7 +90567,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854080</BitOffs>
+            <BitOffs>1310112832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -90545,7 +90580,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854088</BitOffs>
+            <BitOffs>1310112840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -90558,7 +90593,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854096</BitOffs>
+            <BitOffs>1310112848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -90581,7 +90616,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854112</BitOffs>
+            <BitOffs>1310112864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -90594,7 +90629,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854144</BitOffs>
+            <BitOffs>1310112896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -90607,7 +90642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854208</BitOffs>
+            <BitOffs>1310112960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -90620,7 +90655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854224</BitOffs>
+            <BitOffs>1310112976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -90632,7 +90667,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309872064</BitOffs>
+            <BitOffs>1310130816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -90645,7 +90680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880000</BitOffs>
+            <BitOffs>1310138752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -90658,7 +90693,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880008</BitOffs>
+            <BitOffs>1310138760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -90671,7 +90706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880016</BitOffs>
+            <BitOffs>1310138768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -90694,7 +90729,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880032</BitOffs>
+            <BitOffs>1310138784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -90707,7 +90742,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880064</BitOffs>
+            <BitOffs>1310138816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -90720,7 +90755,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880128</BitOffs>
+            <BitOffs>1310138880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -90733,7 +90768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880144</BitOffs>
+            <BitOffs>1310138896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -90745,7 +90780,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309897984</BitOffs>
+            <BitOffs>1310156736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -90758,7 +90793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905920</BitOffs>
+            <BitOffs>1310164672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -90771,7 +90806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905928</BitOffs>
+            <BitOffs>1310164680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -90784,7 +90819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905936</BitOffs>
+            <BitOffs>1310164688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -90807,7 +90842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905952</BitOffs>
+            <BitOffs>1310164704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -90820,7 +90855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905984</BitOffs>
+            <BitOffs>1310164736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -90833,7 +90868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309906048</BitOffs>
+            <BitOffs>1310164800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -90846,7 +90881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309906064</BitOffs>
+            <BitOffs>1310164816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90858,7 +90893,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309925440</BitOffs>
+            <BitOffs>1310184192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -90870,7 +90905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310251328</BitOffs>
+            <BitOffs>1310510080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -90883,7 +90918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259264</BitOffs>
+            <BitOffs>1310518016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -90896,7 +90931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259272</BitOffs>
+            <BitOffs>1310518024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -90909,7 +90944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259280</BitOffs>
+            <BitOffs>1310518032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -90932,7 +90967,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259296</BitOffs>
+            <BitOffs>1310518048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -90945,7 +90980,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259328</BitOffs>
+            <BitOffs>1310518080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -90958,7 +90993,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259392</BitOffs>
+            <BitOffs>1310518144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -90971,7 +91006,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259408</BitOffs>
+            <BitOffs>1310518160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90983,7 +91018,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310278784</BitOffs>
+            <BitOffs>1310537536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -90995,7 +91030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310604672</BitOffs>
+            <BitOffs>1310863424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -91008,7 +91043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612608</BitOffs>
+            <BitOffs>1310871360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -91021,7 +91056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612616</BitOffs>
+            <BitOffs>1310871368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -91034,7 +91069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612624</BitOffs>
+            <BitOffs>1310871376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -91057,7 +91092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612640</BitOffs>
+            <BitOffs>1310871392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -91070,7 +91105,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612672</BitOffs>
+            <BitOffs>1310871424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -91083,7 +91118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612736</BitOffs>
+            <BitOffs>1310871488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -91096,7 +91131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612752</BitOffs>
+            <BitOffs>1310871504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91108,7 +91143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310632128</BitOffs>
+            <BitOffs>1310890880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -91120,7 +91155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310958016</BitOffs>
+            <BitOffs>1311216768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -91133,7 +91168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965952</BitOffs>
+            <BitOffs>1311224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -91146,7 +91181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965960</BitOffs>
+            <BitOffs>1311224712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -91159,7 +91194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965968</BitOffs>
+            <BitOffs>1311224720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -91182,7 +91217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965984</BitOffs>
+            <BitOffs>1311224736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -91195,7 +91230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966016</BitOffs>
+            <BitOffs>1311224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -91208,7 +91243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966080</BitOffs>
+            <BitOffs>1311224832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -91221,7 +91256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966096</BitOffs>
+            <BitOffs>1311224848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91233,7 +91268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310985472</BitOffs>
+            <BitOffs>1311244224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -91245,7 +91280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311311360</BitOffs>
+            <BitOffs>1311570112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -91258,7 +91293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319296</BitOffs>
+            <BitOffs>1311578048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -91271,7 +91306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319304</BitOffs>
+            <BitOffs>1311578056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -91284,7 +91319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319312</BitOffs>
+            <BitOffs>1311578064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -91307,7 +91342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319328</BitOffs>
+            <BitOffs>1311578080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -91320,7 +91355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319360</BitOffs>
+            <BitOffs>1311578112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -91333,7 +91368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319424</BitOffs>
+            <BitOffs>1311578176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -91346,7 +91381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319440</BitOffs>
+            <BitOffs>1311578192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91358,7 +91393,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311338816</BitOffs>
+            <BitOffs>1311597568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -91370,7 +91405,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311664704</BitOffs>
+            <BitOffs>1311923456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -91383,7 +91418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672640</BitOffs>
+            <BitOffs>1311931392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -91396,7 +91431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672648</BitOffs>
+            <BitOffs>1311931400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -91409,7 +91444,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672656</BitOffs>
+            <BitOffs>1311931408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -91432,7 +91467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672672</BitOffs>
+            <BitOffs>1311931424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -91445,7 +91480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672704</BitOffs>
+            <BitOffs>1311931456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -91458,7 +91493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672768</BitOffs>
+            <BitOffs>1311931520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -91471,7 +91506,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672784</BitOffs>
+            <BitOffs>1311931536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91483,7 +91518,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311692160</BitOffs>
+            <BitOffs>1311950912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -91495,7 +91530,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312018048</BitOffs>
+            <BitOffs>1312276800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -91508,7 +91543,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312025984</BitOffs>
+            <BitOffs>1312284736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -91521,7 +91556,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312025992</BitOffs>
+            <BitOffs>1312284744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -91534,7 +91569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026000</BitOffs>
+            <BitOffs>1312284752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -91557,7 +91592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026016</BitOffs>
+            <BitOffs>1312284768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -91570,7 +91605,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026048</BitOffs>
+            <BitOffs>1312284800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -91583,7 +91618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026112</BitOffs>
+            <BitOffs>1312284864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -91596,7 +91631,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026128</BitOffs>
+            <BitOffs>1312284880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91608,7 +91643,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312045504</BitOffs>
+            <BitOffs>1312304256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -91620,7 +91655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312371392</BitOffs>
+            <BitOffs>1312630144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -91633,7 +91668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379328</BitOffs>
+            <BitOffs>1312638080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -91646,7 +91681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379336</BitOffs>
+            <BitOffs>1312638088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -91659,7 +91694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379344</BitOffs>
+            <BitOffs>1312638096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -91682,7 +91717,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379360</BitOffs>
+            <BitOffs>1312638112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -91695,7 +91730,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379392</BitOffs>
+            <BitOffs>1312638144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -91708,7 +91743,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379456</BitOffs>
+            <BitOffs>1312638208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -91721,7 +91756,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379472</BitOffs>
+            <BitOffs>1312638224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91733,7 +91768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312398848</BitOffs>
+            <BitOffs>1312657600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -91745,7 +91780,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312724736</BitOffs>
+            <BitOffs>1312983488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -91758,7 +91793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732672</BitOffs>
+            <BitOffs>1312991424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -91771,7 +91806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732680</BitOffs>
+            <BitOffs>1312991432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -91784,7 +91819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732688</BitOffs>
+            <BitOffs>1312991440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -91807,7 +91842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732704</BitOffs>
+            <BitOffs>1312991456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -91820,7 +91855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732736</BitOffs>
+            <BitOffs>1312991488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -91833,7 +91868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732800</BitOffs>
+            <BitOffs>1312991552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -91846,7 +91881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732816</BitOffs>
+            <BitOffs>1312991568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91858,7 +91893,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312752192</BitOffs>
+            <BitOffs>1313010944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -91870,7 +91905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313078080</BitOffs>
+            <BitOffs>1313336832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -91883,7 +91918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086016</BitOffs>
+            <BitOffs>1313344768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -91896,7 +91931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086024</BitOffs>
+            <BitOffs>1313344776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -91909,7 +91944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086032</BitOffs>
+            <BitOffs>1313344784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -91932,7 +91967,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086048</BitOffs>
+            <BitOffs>1313344800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -91945,7 +91980,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086080</BitOffs>
+            <BitOffs>1313344832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -91958,7 +91993,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086144</BitOffs>
+            <BitOffs>1313344896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -91971,7 +92006,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086160</BitOffs>
+            <BitOffs>1313344912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91983,7 +92018,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313105536</BitOffs>
+            <BitOffs>1313364288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -91995,7 +92030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313431424</BitOffs>
+            <BitOffs>1313690176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -92008,7 +92043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439360</BitOffs>
+            <BitOffs>1313698112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -92021,7 +92056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439368</BitOffs>
+            <BitOffs>1313698120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -92034,7 +92069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439376</BitOffs>
+            <BitOffs>1313698128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -92057,7 +92092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439392</BitOffs>
+            <BitOffs>1313698144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -92070,7 +92105,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439424</BitOffs>
+            <BitOffs>1313698176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -92083,7 +92118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439488</BitOffs>
+            <BitOffs>1313698240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -92096,7 +92131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439504</BitOffs>
+            <BitOffs>1313698256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92108,7 +92143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313458880</BitOffs>
+            <BitOffs>1313717632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -92120,7 +92155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313784768</BitOffs>
+            <BitOffs>1314043520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -92133,7 +92168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792704</BitOffs>
+            <BitOffs>1314051456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -92146,7 +92181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792712</BitOffs>
+            <BitOffs>1314051464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -92159,7 +92194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792720</BitOffs>
+            <BitOffs>1314051472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -92182,7 +92217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792736</BitOffs>
+            <BitOffs>1314051488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -92195,7 +92230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792768</BitOffs>
+            <BitOffs>1314051520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -92208,7 +92243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792832</BitOffs>
+            <BitOffs>1314051584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -92221,7 +92256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792848</BitOffs>
+            <BitOffs>1314051600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92233,7 +92268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313812224</BitOffs>
+            <BitOffs>1314070976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -92245,7 +92280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314138112</BitOffs>
+            <BitOffs>1314396864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -92258,7 +92293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146048</BitOffs>
+            <BitOffs>1314404800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -92271,7 +92306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146056</BitOffs>
+            <BitOffs>1314404808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -92284,7 +92319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146064</BitOffs>
+            <BitOffs>1314404816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -92307,7 +92342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146080</BitOffs>
+            <BitOffs>1314404832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -92320,7 +92355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146112</BitOffs>
+            <BitOffs>1314404864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -92333,7 +92368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146176</BitOffs>
+            <BitOffs>1314404928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -92346,7 +92381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146192</BitOffs>
+            <BitOffs>1314404944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92358,29 +92393,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314165568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.sio_load</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490368</BitOffs>
+            <BitOffs>1314424320</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -93186,7 +93206,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299929728</BitOffs>
+            <BitOffs>1299929664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93199,7 +93219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938712</BitOffs>
+            <BitOffs>1299938648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93211,7 +93231,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299955648</BitOffs>
+            <BitOffs>1299955584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93224,7 +93244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964632</BitOffs>
+            <BitOffs>1299964568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93236,7 +93256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299981568</BitOffs>
+            <BitOffs>1299981504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93249,7 +93269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990552</BitOffs>
+            <BitOffs>1299990488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -93261,7 +93281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303558720</BitOffs>
+            <BitOffs>1303559040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93274,7 +93294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567704</BitOffs>
+            <BitOffs>1303568024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93286,7 +93306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303584640</BitOffs>
+            <BitOffs>1303584960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93299,7 +93319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593624</BitOffs>
+            <BitOffs>1303593944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93311,7 +93331,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303610560</BitOffs>
+            <BitOffs>1303610880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93324,7 +93344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619544</BitOffs>
+            <BitOffs>1303619864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -93344,1208 +93364,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304951784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306000640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306009624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306028096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306353984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306362968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306381440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306707328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306716312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306734784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307060672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307069656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307088128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307414016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307423000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307439936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307448920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307465856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307474840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307491776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307500760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307517696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307526680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307543616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307552600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307569536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307578520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307595456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307604440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307622912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307948800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307957784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307976256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308302144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308311128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308329600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308655488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308664472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308682944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309008832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309017816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309034752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309043736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309062208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309388096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309397080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309415552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309741440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309750424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309767360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309776344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309793280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309802264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309819200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309828184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309845120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309854104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309871040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309880024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309896960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309905944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309924416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310250304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310259288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310277760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310603648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310612632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310631104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310956992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310965976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310984448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311310336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311319320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311337792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311663680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311672664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311691136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312017024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312026008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312044480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312370368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312379352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312397824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312723712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312732696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312751168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313077056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313086040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313104512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313430400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313439384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313457856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313783744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313792728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313811200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314137088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314146072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314164544</BitOffs>
+            <BitOffs>1304952040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -94565,14 +93384,1215 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1323772520</BitOffs>
+            <BitOffs>1305598312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306259392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306268376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306286848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306612736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306621720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306640192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306966080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306975064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306993536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307319424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307328408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307346880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307672768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307681752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307698688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307707672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307724608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307733592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307750528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307759512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307776448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307785432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307802368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307811352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307828288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307837272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307854208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307863192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307881664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308207552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308216536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308235008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308560896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308569880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308588352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308914240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308923224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308941696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309267584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309276568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309293504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309302488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309320960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309646848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309655832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309674304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310000192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310009176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310026112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310035096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310052032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310061016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310077952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310086936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310103872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310112856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310129792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310138776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310155712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310164696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310183168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310509056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310518040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310536512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310862400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310871384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310889856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311215744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311224728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311243200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311569088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311578072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311596544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311922432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311931416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311949888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312275776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312284760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312303232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312629120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312638104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312656576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312982464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312991448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313009920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313335808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313344792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313363264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313689152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313698136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313716608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314042496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314051480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314069952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314395840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314404824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314423296</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -101823,10 +101843,29 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264978656</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019440</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265129472</BitOffs>
+            <BitOffs>1265910272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -101839,26 +101878,7 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265129600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135536</BitOffs>
+            <BitOffs>1265910400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -104694,7 +104714,6 @@ M2K2 FLAT X ENC CNT</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates</Name>
-            <Comment>	This state implemtation is waiting on an upgrade to the state mover library because its encoder is inverted.</Comment>
             <BitSize>1541312</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
             <Properties>
@@ -105056,23 +105075,6 @@ M3K2 KBH X ENC CNT</Comment>
             <BitOffs>1298628832</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K2:KBH:RTD:CHIN:L
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298628864</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
             <Comment> M3K2 DS RTDs</Comment>
             <BitSize>32</BitSize>
@@ -105088,24 +105090,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K2:KBH:RTD:CHIN:R
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298628928</BitOffs>
+            <BitOffs>1298628864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -105122,7 +105107,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628960</BitOffs>
+            <BitOffs>1298628896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.eStateSet</Name>
@@ -105137,7 +105122,22 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298629040</BitOffs>
+            <BitOffs>1298628960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR3K2:KBH:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1298628976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
@@ -105158,7 +105158,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298629056</BitOffs>
+            <BitOffs>1298628992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates</Name>
@@ -105178,22 +105178,195 @@ M3K2 KBH X ENC CNT</Comment>
                 <Value>pv: MR3K2:KBH:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1298630272</BitOffs>
+            <BitOffs>1298630208</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.eStateGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Name>PRG_MR3K2_KBH.fbYSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1300171520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.astCoatingStatesY</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1300263872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
             <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-      pv: MR3K2:KBH:COATING:STATE:GET
-      io: i
+        pv: MR3K2:KBH:RTD:CHIN:R
+        field: EGU C
+        io: i
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1300171584</BitOffs>
+            <BitOffs>1300318592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBV:RTD:CHIN:L
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR4K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1300706624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1300706688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
+            <Comment>MR4K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300706752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301094272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301094336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
+            <Comment>MR4K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1301094400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301481920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301481984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
+            <Comment>MR4K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1301482048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301869568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301869632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
+            <Comment>MR4K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1301869696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1302257216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1302257280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -105211,149 +105384,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1300171616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbYSetup</Name>
-            <BitSize>92352</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1300171648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.astCoatingStatesY</Name>
-            <BitSize>54720</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>15</Elements>
-            </ArrayInfo>
-            <BitOffs>1300264000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR4K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1300318720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1300706240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1300706304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
-            <Comment>MR4K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1300706368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301093888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301093952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
-            <Comment>MR4K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1301094016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301481536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301481600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
-            <Comment>MR4K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1301481664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301869184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301869248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
-            <Comment>MR4K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1301869312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1302256832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1302256896</BitOffs>
+            <BitOffs>1302257344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -105370,7 +105401,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302256960</BitOffs>
+            <BitOffs>1302257376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -105387,7 +105418,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302256992</BitOffs>
+            <BitOffs>1302257408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -105404,7 +105435,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257024</BitOffs>
+            <BitOffs>1302257440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -105421,7 +105452,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257056</BitOffs>
+            <BitOffs>1302257472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -105439,7 +105470,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257088</BitOffs>
+            <BitOffs>1302257504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -105456,7 +105487,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257120</BitOffs>
+            <BitOffs>1302257536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -105473,7 +105504,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257152</BitOffs>
+            <BitOffs>1302257568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -105490,7 +105521,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257184</BitOffs>
+            <BitOffs>1302257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -105507,7 +105538,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257216</BitOffs>
+            <BitOffs>1302257632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -105526,7 +105557,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257248</BitOffs>
+            <BitOffs>1302257664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -105543,7 +105574,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257280</BitOffs>
+            <BitOffs>1302257696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -105560,7 +105591,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257312</BitOffs>
+            <BitOffs>1302257728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -105578,44 +105609,10 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257344</BitOffs>
+            <BitOffs>1302257760</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K2:KBV:RTD:BEND:DS:2
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K2:KBV:RTD:BEND:DS:3
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
             <Properties>
@@ -105635,10 +105632,10 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257472</BitOffs>
+            <BitOffs>1302257792</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
             <Properties>
@@ -105658,37 +105655,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.eStateSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: MR4K2:KBV:COATING:STATE:SET
-      io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302258000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.eStateGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: MR4K2:KBV:COATING:STATE:GET
-      io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302258016</BitOffs>
+            <BitOffs>1302258048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
@@ -105709,7 +105676,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302258048</BitOffs>
+            <BitOffs>1302258368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates</Name>
@@ -105729,13 +105696,43 @@ M4K2 KBV X ENC CNT</Comment>
                 <Value>pv: MR4K2:KBV:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1302259264</BitOffs>
+            <BitOffs>1302259584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR4K2:KBV:COATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1303800896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR4K2:KBV:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1303800912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1303800576</BitOffs>
+            <BitOffs>1303800960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.astCoatingStatesX</Name>
@@ -105745,7 +105742,7 @@ M4K2 KBV X ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1303892928</BitOffs>
+            <BitOffs>1303893312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -105780,7 +105777,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303952704</BitOffs>
+            <BitOffs>1303953088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -105795,7 +105792,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955200</BitOffs>
+            <BitOffs>1303955584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -105809,7 +105806,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955264</BitOffs>
+            <BitOffs>1303955648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -105824,7 +105821,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955328</BitOffs>
+            <BitOffs>1303955712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -105839,7 +105836,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955392</BitOffs>
+            <BitOffs>1303955776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -105854,7 +105851,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955456</BitOffs>
+            <BitOffs>1303955840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -105869,7 +105866,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955520</BitOffs>
+            <BitOffs>1303955904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -105885,7 +105882,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955648</BitOffs>
+            <BitOffs>1303956032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -105899,7 +105896,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955712</BitOffs>
+            <BitOffs>1303956096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -105913,7 +105910,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955776</BitOffs>
+            <BitOffs>1303956160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -105927,7 +105924,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955840</BitOffs>
+            <BitOffs>1303956224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -105942,7 +105939,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958400</BitOffs>
+            <BitOffs>1303958784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -105957,7 +105954,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958464</BitOffs>
+            <BitOffs>1303958848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -105972,7 +105969,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958528</BitOffs>
+            <BitOffs>1303958912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -105988,7 +105985,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958592</BitOffs>
+            <BitOffs>1303958976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -106002,7 +105999,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958656</BitOffs>
+            <BitOffs>1303959040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -106016,7 +106013,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958720</BitOffs>
+            <BitOffs>1303959104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -106031,7 +106028,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958784</BitOffs>
+            <BitOffs>1303959168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -106046,7 +106043,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958848</BitOffs>
+            <BitOffs>1303959232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -106062,7 +106059,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959040</BitOffs>
+            <BitOffs>1303959360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -106076,7 +106073,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959104</BitOffs>
+            <BitOffs>1303959424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -106090,7 +106087,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959168</BitOffs>
+            <BitOffs>1303959488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -106105,7 +106102,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959232</BitOffs>
+            <BitOffs>1303959552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -106120,7 +106117,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959296</BitOffs>
+            <BitOffs>1303959616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -106135,7 +106132,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959360</BitOffs>
+            <BitOffs>1303959680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -106150,7 +106147,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959424</BitOffs>
+            <BitOffs>1303959744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -106165,7 +106162,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959488</BitOffs>
+            <BitOffs>1303959808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -106174,64 +106171,6 @@ M4K2 KBV X ENC CNT</Comment>
             <BaseType>ULINT</BaseType>
             <Default>
               <Value>19800000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
-            <Comment> Encoder reference values in counts = nm
- Enc reference values after alignment 3-13-20</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>99171678</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>101371326</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>19501048</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>20872028</Value>
             </Default>
             <Properties>
               <Property>
@@ -106253,18 +106192,65 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959936</BitOffs>
+            <BitOffs>1303959968</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_PMPS.rPhotonEnergy</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
+            <Comment> Encoder reference values in counts = nm
+ Enc reference values after alignment 3-13-20</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>99171678</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959968</BitOffs>
+            <BitOffs>1303960000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>101371326</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303960064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>19501048</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303960128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>20872028</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303960192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -106282,7 +106268,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960000</BitOffs>
+            <BitOffs>1303960256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -106300,7 +106286,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304455744</BitOffs>
+            <BitOffs>1304456000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -106329,1558 +106315,47 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304951488</BitOffs>
+            <BitOffs>1304951744</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M1</Name>
-            <Comment> M1K2 Yleft</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
+            <BitSize>646272</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
             <Default>
               <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
+                <Name>.bAutoReset</Name>
                 <Bool>true</Bool>
               </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:YLEFT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306000576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m1</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306026496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2</Name>
-            <Comment> M1K2 Yright</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
               <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:YRIGHT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306353920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m2</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306379840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3</Name>
-            <Comment> M1K2 Xup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
-                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:XUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306707264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m3</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306733184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4</Name>
-            <Comment> M1K2 Xdwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:XDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307060608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m4</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307086528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5</Name>
-            <Comment> M1K2 Pitch Stepper</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>30</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307413952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6</Name>
-            <Comment> M_PI, urad</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
+                <Name>.i_sNetID</Name>
+                <String>172.21.42.126.1.1</String>
               </SubItem>
             </Default>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_PI
-    </Value>
+                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
               </Property>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
               </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307439872</BitOffs>
+            <BitOffs>1305598016</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M8</Name>
-            <Comment> M_H, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_H
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307491712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9</Name>
-            <Comment> G_H, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>1000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:G_H
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307517632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10</Name>
-            <Comment> SD_V, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:SD_V
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307543552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11</Name>
-            <Comment> SD_R, urad</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:SD_ROT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307569472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12</Name>
-            <Comment> M1K1 Yup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
-                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:YUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307595392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m12</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Name>GVL_PMPS.rPhotonEnergy</Name>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307621312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13</Name>
-            <Comment> M1K1 Ydwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:YDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307948736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m13</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307974656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14</Name>
-            <Comment> M1K1 Xup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:XUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308302080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m14</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308328000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15</Name>
-            <Comment> M1K1 Xdwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:XDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308655424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m15</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308681344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16</Name>
-            <Comment> M1K1 Pitch Stepper</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>30</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Pitch]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309008768</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17</Name>
-            <Comment>MR1K1 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: MR1K1:BEND:MMS:US
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309034688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m17</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309060608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18</Name>
-            <Comment>MR1K1 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: MR1K1:BEND:MMS:DS
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309388032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m18</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309413952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19</Name>
-            <Comment> Air Pitch</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:PITCH</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.12</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 1;
-                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309741376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20</Name>
-            <Comment> Air Vertical</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:VERT</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.3</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
-                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:VERT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309767296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21</Name>
-            <Comment> Air Roll</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:ROLL</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.24</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:ROLL
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309793216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22</Name>
-            <Comment> GAP</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:GAP</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:GAP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309819136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23</Name>
-            <Comment> YAG</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:YAG</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.5</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:YAG
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309845056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24</Name>
-            <Comment> ST1K1-ZOS-MMS</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>ST1K1:ZOS:MMS</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: ST1K1:ZOS:MMS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable  := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
-                              .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309870976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309896896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM25</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309922816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310250240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM26</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310276160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310603584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM27</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310629504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310956928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM28</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310982848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311310272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM29</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311336192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311663616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM30</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311689536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31</Name>
-            <Comment>MR3K2 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:MMS:BEND:US</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312016960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM31</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312042880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32</Name>
-            <Comment>MR3K2 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:BEND:DS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312370304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM32</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312396224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312723648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM33</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312749568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313076992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM34</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313102912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313430336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM35</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313456256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36</Name>
-            <Comment>MR4K2 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:MMS:BEND:US</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313783680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM36</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313809600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37</Name>
-            <Comment>MR4K2 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:BEND:DS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314137024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM37</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314162944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.dummyBool</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490416</BitOffs>
+            <BitOffs>1306244288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetY</Name>
@@ -107921,7 +106396,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314490432</BitOffs>
+            <BitOffs>1306244736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetX</Name>
@@ -107962,7 +106437,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314494080</BitOffs>
+            <BitOffs>1306248384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBX</Name>
@@ -108003,7 +106478,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314497728</BitOffs>
+            <BitOffs>1306252032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBY</Name>
@@ -108044,7 +106519,1543 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314501376</BitOffs>
+            <BitOffs>1306255680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1</Name>
+            <Comment> M1K2 Yleft</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:YLEFT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306259328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m1</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306285248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2</Name>
+            <Comment> M1K2 Yright</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:YRIGHT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306612672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m2</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306638592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3</Name>
+            <Comment> M1K2 Xup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:XUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306966016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m3</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306991936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4</Name>
+            <Comment> M1K2 Xdwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:XDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307319360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m4</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307345280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5</Name>
+            <Comment> M1K2 Pitch Stepper</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>30</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307672704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6</Name>
+            <Comment> M_PI, urad</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_PI
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307698624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8</Name>
+            <Comment> M_H, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_H
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307750464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9</Name>
+            <Comment> G_H, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:G_H
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307776384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10</Name>
+            <Comment> SD_V, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:SD_V
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307802304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11</Name>
+            <Comment> SD_R, urad</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:SD_ROT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307828224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12</Name>
+            <Comment> M1K1 Yup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
+                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:YUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307854144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m12</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307880064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13</Name>
+            <Comment> M1K1 Ydwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:YDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308207488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m13</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308233408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14</Name>
+            <Comment> M1K1 Xup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:XUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308560832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m14</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308586752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15</Name>
+            <Comment> M1K1 Xdwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:XDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308914176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m15</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308940096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16</Name>
+            <Comment> M1K1 Pitch Stepper</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>30</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Pitch]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309267520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17</Name>
+            <Comment>MR1K1 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: MR1K1:BEND:MMS:US
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309293440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m17</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309319360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18</Name>
+            <Comment>MR1K1 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: MR1K1:BEND:MMS:DS
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309646784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m18</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309672704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19</Name>
+            <Comment> Air Pitch</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:PITCH</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.12</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 1;
+                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310000128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20</Name>
+            <Comment> Air Vertical</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:VERT</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.3</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:VERT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310026048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21</Name>
+            <Comment> Air Roll</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:ROLL</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.24</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:ROLL
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310051968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22</Name>
+            <Comment> GAP</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:GAP</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:GAP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310077888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23</Name>
+            <Comment> YAG</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:YAG</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.5</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:YAG
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310103808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24</Name>
+            <Comment> ST1K1-ZOS-MMS</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>ST1K1:ZOS:MMS</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: ST1K1:ZOS:MMS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable  := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
+                              .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310129728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310155648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM25</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310181568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310508992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM26</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310534912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310862336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM27</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310888256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311215680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM28</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311241600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311569024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM29</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311594944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311922368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM30</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311948288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31</Name>
+            <Comment>MR3K2 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:MMS:BEND:US</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312275712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM31</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312301632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32</Name>
+            <Comment>MR3K2 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:BEND:DS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312629056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM32</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312654976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312982400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM33</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313008320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313335744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM34</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313361664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313689088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM35</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313715008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36</Name>
+            <Comment>MR4K2 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:MMS:BEND:US</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314042432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM36</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314068352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37</Name>
+            <Comment>MR4K2 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:BEND:DS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314395776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM37</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314421696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.dummyBool</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -108074,7 +108085,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505024</BitOffs>
+            <BitOffs>1314749152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -108104,7 +108115,22 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505088</BitOffs>
+            <BitOffs>1314749216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -108119,7 +108145,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505152</BitOffs>
+            <BitOffs>1314749296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -108134,7 +108160,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505168</BitOffs>
+            <BitOffs>1314749312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -108148,7 +108174,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505176</BitOffs>
+            <BitOffs>1314749320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -108163,7 +108189,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505184</BitOffs>
+            <BitOffs>1314749344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -108178,7 +108204,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505216</BitOffs>
+            <BitOffs>1314749376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -108299,7 +108325,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505248</BitOffs>
+            <BitOffs>1314749408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -108313,7 +108339,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514720</BitOffs>
+            <BitOffs>1314758880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -108327,7 +108353,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514752</BitOffs>
+            <BitOffs>1314758912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -108348,7 +108374,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314518400</BitOffs>
+            <BitOffs>1314762560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -108420,7 +108446,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536320</BitOffs>
+            <BitOffs>1314780480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -108492,7 +108518,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536448</BitOffs>
+            <BitOffs>1314780608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -108564,7 +108590,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536576</BitOffs>
+            <BitOffs>1314780736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -108636,7 +108662,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536704</BitOffs>
+            <BitOffs>1314780864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -108708,7 +108734,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536832</BitOffs>
+            <BitOffs>1314780992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -108780,7 +108806,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536960</BitOffs>
+            <BitOffs>1314781120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -108852,7 +108878,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314537088</BitOffs>
+            <BitOffs>1314781248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -108924,7 +108950,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314537216</BitOffs>
+            <BitOffs>1314781376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -108950,43 +108976,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314570240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
-            <BitSize>646272</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.bAutoReset</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.42.126.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1323772224</BitOffs>
+            <BitOffs>1314814400</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109072,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-10-08T17:21:58</Value>
+          <Value>2024-10-25T15:23:10</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CB96F166-08A2-0ABA-C7F0-6CA5A48D2126}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82277,7 +82277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82298,7 +82298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82396,7 +82396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82414,7 +82414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82572,7 +82572,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -82669,7 +82669,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82724,7 +82724,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -83201,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -92400,7 +92400,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -94592,7 +94592,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -108983,7 +108983,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109069,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-11-05T16:03:18</Value>
+          <Value>2024-11-11T08:48:44</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82277,7 +82277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82298,7 +82298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82396,7 +82396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82414,7 +82414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82572,13 +82572,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265797632</BitOffs>
+            <BitOffs>1265016832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -82669,7 +82669,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82685,7 +82685,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265017536</BitOffs>
+            <BitOffs>1265133632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -82701,7 +82701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265017600</BitOffs>
+            <BitOffs>1265133696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -82717,14 +82717,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265017664</BitOffs>
+            <BitOffs>1265133760</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -82868,7 +82868,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265017728</BitOffs>
+            <BitOffs>1265133824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -82877,7 +82877,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265018376</BitOffs>
+            <BitOffs>1265134472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -82886,14 +82886,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265018384</BitOffs>
+            <BitOffs>1265134480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265018392</BitOffs>
+            <BitOffs>1265134488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -82902,20 +82902,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265018400</BitOffs>
+            <BitOffs>1265134496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265018432</BitOffs>
+            <BitOffs>1265134528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265018496</BitOffs>
+            <BitOffs>1265134592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -82924,19 +82924,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265018560</BitOffs>
+            <BitOffs>1265134656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265018624</BitOffs>
+            <BitOffs>1265134720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265018688</BitOffs>
+            <BitOffs>1265134784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -82951,25 +82951,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265018752</BitOffs>
+            <BitOffs>1265134848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265018816</BitOffs>
+            <BitOffs>1265134912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265019072</BitOffs>
+            <BitOffs>1265135168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265019136</BitOffs>
+            <BitOffs>1265135232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -82978,19 +82978,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265019200</BitOffs>
+            <BitOffs>1265135296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265019264</BitOffs>
+            <BitOffs>1265135360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265019328</BitOffs>
+            <BitOffs>1265135424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -83005,67 +83005,67 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265019392</BitOffs>
+            <BitOffs>1265135488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265019456</BitOffs>
+            <BitOffs>1265135552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265020480</BitOffs>
+            <BitOffs>1265136576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265020544</BitOffs>
+            <BitOffs>1265136640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265020608</BitOffs>
+            <BitOffs>1265136704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265020672</BitOffs>
+            <BitOffs>1265136768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265020736</BitOffs>
+            <BitOffs>1265136832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265131328</BitOffs>
+            <BitOffs>1265247424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265406528</BitOffs>
+            <BitOffs>1265522624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265517120</BitOffs>
+            <BitOffs>1265633216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265792320</BitOffs>
+            <BitOffs>1265908416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -83077,7 +83077,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265792832</BitOffs>
+            <BitOffs>1265908928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -83089,14 +83089,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265793408</BitOffs>
+            <BitOffs>1265909504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265794240</BitOffs>
+            <BitOffs>1265910336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -83112,7 +83112,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265794496</BitOffs>
+            <BitOffs>1265910592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -83127,7 +83127,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265794528</BitOffs>
+            <BitOffs>1265910624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -83201,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -92400,7 +92400,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -94592,7 +94592,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -101843,29 +101843,10 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264978656</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265019408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265019424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265019440</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265910272</BitOffs>
+            <BitOffs>1265129472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -101878,7 +101859,26 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265910400</BitOffs>
+            <BitOffs>1265129600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265135504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265135520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265135536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -105234,7 +105234,7 @@ M3K2 KBH X ENC CNT</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: MR3K2:KBV:RTD:CHIN:L
+        pv: MR3K2:KBH:RTD:CHIN:L
         field: EGU C
         io: i
     </Value>
@@ -108983,7 +108983,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109069,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-10-25T15:23:10</Value>
+          <Value>2024-11-05T15:47:38</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- update MR3/4K2 mirror RTD implementations to match TMO. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- KBO mirrors using the same pcds device so updating them all at once makes sense.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running on PLC, tested by viewing PCDS device typhos screen.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-6705

## Screenshots (if appropriate):
![KBs-mirror-temp](https://github.com/user-attachments/assets/5120ea5b-005d-451b-9a96-c0f3bab624ab)

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
