### PR TITLE
Change MR1K1 Bend State Mover to 1 Dimension

### DIFF
--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{E6887738-6106-B3EA-6F44-1758ABE554CA}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -2439,15 +2439,7 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
 					<Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -2591,6 +2583,70 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
 					<Comment><![CDATA[ RTD error bit]]></Comment>
 					<Type>BOOL</Type>
@@ -2616,38 +2672,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
 					<Comment><![CDATA[Emergency Stop for MR4K2]]></Comment>
 					<Type>BOOL</Type>
@@ -2655,11 +2679,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
 					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
-					<Comment><![CDATA[ M1K1 US RTDs]]></Comment>
-					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -2789,6 +2808,11 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
+					<Comment><![CDATA[ M1K1 US RTDs]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
 					<Type>INT</Type>
 				</Var>
@@ -2797,14 +2821,14 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
 					<Comment><![CDATA[ M1K1 DS RTDs]]></Comment>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -2820,25 +2844,17 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
 					<Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
 					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M3K2.nM3K2US_RTD_2</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M3K2.nM3K2US_RTD_3</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
 					<Comment><![CDATA[ M3K2 DS RTDs]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
 					<Type>INT</Type>
 				</Var>
 				<Var>
@@ -2864,15 +2880,11 @@ Emergency Stop for MR1K1]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
-					<Type>INT</Type>
-				</Var>
-				<Var>
 					<Name>Main.sio_current</Name>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.sio_load</Name>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
@@ -4406,10 +4418,6 @@ Emergency Stop for MR1K1]]></Comment>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
-				<Var>
-					<Name>Main.sio_load</Name>
-					<Type>UINT</Type>
-				</Var>
 			</Vars>
 			<Vars VarGrpType="2" ContextId="4" AreaNo="65">
 				<Name>PlcTask Outputs</Name>
@@ -4700,6 +4708,10 @@ Emergency Stop for MR1K1]]></Comment>
 				</Var>
 				<Var>
 					<Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -5126,10 +5138,6 @@ Emergency Stop for MR1K1]]></Comment>
 				<Var>
 					<Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-					<Type>BOOL</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" ContextId="4" AreaNo="68">
@@ -5683,8 +5691,11 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.M3K2KBHbSTOEnable2" VarB="Channel 2^Input" AutoLink="true" Size="1"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL3202-0010_M3K2DS2_M3K2DS3">
-				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2DS_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2DS_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL3202-0010_M3K2US1_M3K2US2">
 				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2US_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
@@ -5692,7 +5703,10 @@ Emergency Stop for MR1K1]]></Comment>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL3202-0010_M3K2US3_M3K2DS1">
 				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2DS_RTD_1" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^GVL_M3K2.nM3K2US_RTD_3" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 310 (EK1122)^EK1100_MR3K2_BENDER^EL5042_M3K2_BEND_USDS">
 				<Link VarA="PlcTask Inputs^Main.M31.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>
@@ -5744,14 +5758,14 @@ Emergency Stop for MR1K1]]></Comment>
 				<Link VarA="PlcTask Inputs^GVL_M4K2.nM4K2US_RTD_3" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 322 (EK1122)^EK1100_MR4K2_BENDER^EL3204_M4K2_CHIN">
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
-				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 79 (EK1521-0010)^Term 306 (EK1501-0010)^Term 322 (EK1122)^EK1100_MR4K2_BENDER^EL5042_M4K2_BEND_USDS">
 				<Link VarA="PlcTask Inputs^Main.M36.nRawEncoderULINT" VarB="FB Inputs Channel 1^Position" AutoLink="true"/>

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{CB96F166-08A2-0ABA-C7F0-6CA5A48D2126}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{CB96F166-08A2-0ABA-C7F0-6CA5A48D2126}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{72DA45E9-3817-001B-E29D-62FE2DAB0BB3}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
+++ b/lcls-plc-rixs-optics/_Config/PLC/rixs_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{85BF455D-934D-415A-B04C-6D4CDD9FF10E}" Name="rixs_optics" PrjFilePath="..\..\rixs_optics\rixs_optics.plcproj" TmcFilePath="..\..\rixs_optics\rixs_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="rixs_optics\rixs_optics.tmc" TmcHash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}">
 			<Name>rixs_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{57BD9670-089D-434A-85CF-90A857EE0EFF}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
-					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
+					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
+++ b/lcls-plc-rixs-optics/lcls-plc-rixs-optics.tsproj
@@ -13,8 +13,8 @@
 					<ManualSelect>{57BD9670-089D-434A-85CF-90A857EE0EFF}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<TargetSelect TargetId="2">{57BD9670-089D-434A-85CF-90A857EE0EFF}</TargetSelect>
-					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
+					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
 					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
 					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M3K2.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M3K2.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <GVL Name="GVL_M3K2" Id="{5370e595-0f6e-4259-88a1-5883bdb06ca4}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
@@ -27,14 +27,11 @@ VAR_GLOBAL
     nM3K2US_RTD_1 AT %I* : INT;
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2US1_M3K2US2]^RTD Inputs Channel 2^Value'}
     nM3K2US_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value'}
-    nM3K2US_RTD_3 AT %I* : INT;
+
 
     // M3K2 DS RTDs
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 2^Value'}
     nM3K2DS_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value'}
-    nM3K2DS_RTD_2 AT %I* : INT;
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 2^Value'}
     nM3K2DS_RTD_3 AT %I* : INT;
 

--- a/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M4K2.TcGVL
+++ b/lcls-plc-rixs-optics/rixs_optics/GVLs/GVL_M4K2.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <GVL Name="GVL_M4K2" Id="{12e24a9c-eb09-4496-9c31-a36df2f36ea7}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
@@ -31,10 +31,7 @@ VAR_GLOBAL
     // M4K2 DS RTDs
     {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M4K2US3_M4K2DS1]^RTD Inputs Channel 2^Value'}
     nM4K2DS_RTD_1 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 1^Value'}
-    nM4K2DS_RTD_2 AT %I* : INT;
-    {attribute 'TcLinkTo' := 'TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 2^Value'}
-    nM4K2DS_RTD_3 AT %I* : INT;
+
 
 END_VAR]]></Declaration>
   </GVL>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU
@@ -187,7 +187,7 @@ VAR
     fM1K1_Press_1_val : LREAL;
 
     {attribute 'pytmc' := 'pv: MR1K1:BEND:COATING'}
-    fbCoatingStates: FB_PositionStatePMPS2D;
+    fbCoatingStates: FB_PositionStatePMPS1D;
     {attribute 'pytmc' := '
       pv: MR1K1:BEND:COATING:STATE:SET
       io: io
@@ -199,10 +199,10 @@ VAR
     '}
     eStateGet: E_MR1K1_States;
     fbYSetup: FB_StateSetupHelper;
-    fbXSetup: FB_StateSetupHelper;
+    //fbXSetup: FB_StateSetupHelper;
 
     astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
-    astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    //astCoatingStatesX: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
 
 END_VAR
 ]]></Declaration>
@@ -306,35 +306,35 @@ nEncRefPitchM1K1 := LREAL_TO_UDINT(ABS(fEncRefPitchM1K1_urad) * fEncLeverArm_mm)
     fM1K1_Press_1_val := fM1K1_Press_1.fReal;
 
 fbYSetup(stPositionState:=GVL_States.stDefaultOffsetY, bSetDefault:=TRUE);
-fbXSetup(stPositionState:=GVL_States.stDefaultOffsetX, bSetDefault:=TRUE);
+// fbXSetup(stPositionState:=GVL_States.stDefaultOffsetX, bSetDefault:=TRUE);
 
 fbYSetup(stPositionState:=astCoatingStatesY[E_MR1K1_States.B4C],
     sName:='B4C',
     sPmpsState:='MR1K1:BEND-B4C',
     nEncoderCount:=31911452
 );
+(*
 fbXSetup(stPositionState:=astCoatingStatesX[E_MR1K1_States.B4C],
     sName:='B4C',
     sPmpsState:='MR1K1:BEND-B4C',
     nEncoderCount:=19829647
 );
+*)
 fbYSetup(stPositionState:=astCoatingStatesY[E_MR1K1_States.OUT],
     sName:='OUT',
     sPmpsState:='MR1K1:BEND-OUT',
     nEncoderCount:=13412630,
     fDelta:=50
 );
-// Out position determined solely by Y Axis
+(* Out position determined solely by Y Axis
 fbXSetup(stPositionState:=astCoatingStatesX[E_MR1K1_States.OUT],
     sName:='OUT',
     sPmpsState:='MR1K1:BEND-OUT',
     nEncoderCount:=ULINT_TO_UDINT(M14.nRawEncoderULINT)
-);
+);*)
 fbCoatingStates(
-    stMotionStage1:=Main.M12,
-    stMotionStage2:=Main.M14,
-    astPositionState1:=astCoatingStatesY,
-    astPositionState2:=astCoatingStatesX,
+    stMotionStage:=Main.M12,
+    astPositionState:=astCoatingStatesY,
     eEnumSet:=eStateSet,
     eEnumGet:=eStateGet,
     fbFFHWO:=GVL_PMPS.fbFastFaultOutput1,

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -306,8 +306,8 @@ fbCoatingStates(
     sTransitionKey:='MR3K2:KBH-TRANSITION',
 );
 
-fbM3K2_Chin_Right_RTD();
-fbM3K2_Chin_Left_RTD();]]></ST>
+fbM3K2_Chin_Right_RTD(fResolution:=0.01);
+fbM3K2_Chin_Left_RTD(fResolution:=0.01);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -195,7 +195,7 @@ VAR
                               .bOverrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Overrange;
                               .bError := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Error'}
     {attribute 'pytmc' := '
-        pv: MR3K2:KBV:RTD:CHIN:L
+        pv: MR3K2:KBH:RTD:CHIN:L
         field: EGU C
         io: i
     '}

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -120,14 +120,6 @@ VAR
             io: i
         '}
         fM3K2US_RTD_2 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR3K2:KBH:RTD:CHIN:L
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM3K2US_RTD_3 : REAL;
-
         // M3K2 DS RTDs
         {attribute 'pytmc' := '
             pv: MR3K2:KBH:RTD:BEND:DS:1
@@ -136,13 +128,6 @@ VAR
             io: i
         '}
         fM3K2DS_RTD_1 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR3K2:KBH:RTD:CHIN:R
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM3K2DS_RTD_2 : REAL;
         {attribute 'pytmc' := '
             pv: MR3K2:KBH:RTD:BEND:DS:3
             field: ASLO 0.01
@@ -154,9 +139,9 @@ VAR
     // RTD error bit
         bM3K2US_RTD_1_Err AT %I*: BOOL;
         bM3K2US_RTD_2_Err AT %I*: BOOL;
-        bM3K2US_RTD_3_Err AT %I*: BOOL;
+
         bM3K2DS_RTD_1_Err AT %I*: BOOL;
-        bM3K2DS_RTD_2_Err AT %I*: BOOL;
+
         bM3K2DS_RTD_3_Err AT %I*: BOOL;
 
     //Emergency Stop for MR3K2
@@ -195,6 +180,26 @@ VAR
     fbYSetup: FB_StateSetupHelper;
 
     astCoatingStatesY: ARRAY[1..GeneralConstants.MAX_STATES] OF ST_PositionState;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR3K2:KBH:RTD:CHIN:R
+        field: EGU C
+        io: i
+    '}
+    fbM3K2_Chin_Right_RTD : FB_TempSensor;
+    {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Error'}
+    {attribute 'pytmc' := '
+        pv: MR3K2:KBV:RTD:CHIN:L
+        field: EGU C
+        io: i
+    '}
+    fbM3K2_Chin_Left_RTD : FB_TempSensor;
 
 END_VAR]]></Declaration>
     <Implementation>
@@ -252,18 +257,13 @@ nEncCntDSM3K2  := ULINT_TO_UDINT(M32.nRawEncoderULINT);
 // MR3K2 Bender RTDs
 fM3K2US_RTD_1 := INT_TO_REAL(GVL_M3K2.nM3K2US_RTD_1);
 fM3K2US_RTD_2 := INT_TO_REAL(GVL_M3K2.nM3K2US_RTD_2);
-fM3K2US_RTD_3 := INT_TO_REAL(GVL_M3K2.nM3K2US_RTD_3);
-
 fM3K2DS_RTD_1 := INT_TO_REAL(GVL_M3K2.nM3K2DS_RTD_1);
-fM3K2DS_RTD_2 := INT_TO_REAL(GVL_M3K2.nM3K2DS_RTD_2);
 fM3K2DS_RTD_3 := INT_TO_REAL(GVL_M3K2.nM3K2DS_RTD_3);
 
 // RTD not connected if T=0
 bM3K2US_RTD_1_Err := fM3K2US_RTD_1 = 0;
-bM3K2US_RTD_2_Err := fM3K2DS_RTD_2 = 0;
-bM3K2US_RTD_3_Err := fM3K2US_RTD_3 = 0;
+bM3K2US_RTD_2_Err := fM3K2US_RTD_2 = 0;
 bM3K2DS_RTD_1_Err := fM3K2DS_RTD_1 = 0;
-bM3K2DS_RTD_2_Err := fM3K2DS_RTD_2 = 0;
 bM3K2DS_RTD_3_Err := fM3K2DS_RTD_3 = 0;
 
 // M3K2 Bender RTD interlocks

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR3K2_KBH.TcPOU
@@ -304,7 +304,10 @@ fbCoatingStates(
     bEnableBeamParams:=TRUE,
     sDeviceName:='MR3K2:KBH',
     sTransitionKey:='MR3K2:KBH-TRANSITION',
-);]]></ST>
+);
+
+fbM3K2_Chin_Right_RTD();
+fbM3K2_Chin_Left_RTD();]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
@@ -275,8 +275,8 @@ bM4K2DS_RTD_1_Err := fM4K2DS_RTD_1 = 0;
 M36.bHardwareEnable R= fM4K2US_RTD_1 > 9000 OR bM4K2US_RTD_1_Err;
 M37.bHardwareEnable R= fM4K2DS_RTD_1 > 9000 OR bM4K2DS_RTD_1_Err;
 
-fbM4K2_Chin_Right_RTD();
-fbM4K2_Chin_Left_RTD();
+fbM4K2_Chin_Right_RTD(fResolution:=0.01);
+fbM4K2_Chin_Left_RTD(fResolution:=0.01);
 
 // Axilon Cooling Panel
 fbCoolingPanel();

--- a/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
+++ b/lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR4K2_KBV.TcPOU
@@ -136,20 +136,6 @@ VAR
             io: i
         '}
         fM4K2DS_RTD_1 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR4K2:KBV:RTD:BEND:DS:2
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM4K2DS_RTD_2 : REAL;
-        {attribute 'pytmc' := '
-            pv: MR4K2:KBV:RTD:BEND:DS:3
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        '}
-        fM4K2DS_RTD_3 : REAL;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 1^Value;
                               .bUnderrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 1^Status^Underrange;
                               .bOverrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 1^Status^Overrange;
@@ -159,7 +145,7 @@ VAR
         field: EGU C
         io: i
     '}
-    nM4K2_Chin_Right_RTD : FB_TempSensor;
+    fbM4K2_Chin_Right_RTD : FB_TempSensor;
     {attribute 'TcLinkTo' := '.iRaw := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 2^Value;
                               .bUnderrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 2^Status^Underrange;
                               .bOverrange := TIIB[EL3204_M4K2_CHIN]^RTD Inputs Channel 2^Status^Overrange;
@@ -169,7 +155,7 @@ VAR
         field: EGU C
         io: i
     '}
-    nM4K2_Chin_Left_RTD : FB_TempSensor;
+    fbM4K2_Chin_Left_RTD : FB_TempSensor;
 
     // RTD error bit
         bM4K2US_RTD_1_Err AT %I*: BOOL;
@@ -277,23 +263,20 @@ fM4K2US_RTD_2 := INT_TO_REAL(GVL_M4K2.nM4K2US_RTD_2);
 fM4K2US_RTD_3 := INT_TO_REAL(GVL_M4K2.nM4K2US_RTD_3);
 
 fM4K2DS_RTD_1 := INT_TO_REAL(GVL_M4K2.nM4K2DS_RTD_1);
-fM4K2DS_RTD_2 := INT_TO_REAL(GVL_M4K2.nM4K2DS_RTD_2);
-fM4K2DS_RTD_3 := INT_TO_REAL(GVL_M4K2.nM4K2DS_RTD_3);
+
 
 // RTD not connected if T=0
 bM4K2US_RTD_1_Err := fM4K2US_RTD_1 = 0;
-bM4K2US_RTD_2_Err := fM4K2DS_RTD_2 = 0;
+bM4K2US_RTD_2_Err := fM4K2US_RTD_2 = 0;
 bM4K2US_RTD_3_Err := fM4K2US_RTD_3 = 0;
 bM4K2DS_RTD_1_Err := fM4K2DS_RTD_1 = 0;
-bM4K2DS_RTD_2_Err := fM4K2DS_RTD_2 = 0;
-bM4K2DS_RTD_3_Err := fM4K2DS_RTD_3 = 0;
 
 // M4K2 Bender RTD interlocks
 M36.bHardwareEnable R= fM4K2US_RTD_1 > 9000 OR bM4K2US_RTD_1_Err;
 M37.bHardwareEnable R= fM4K2DS_RTD_1 > 9000 OR bM4K2DS_RTD_1_Err;
 
-nM4K2_Chin_Right_RTD();
-nM4K2_Chin_Left_RTD();
+fbM4K2_Chin_Right_RTD();
+fbM4K2_Chin_Left_RTD();
 
 // Axilon Cooling Panel
 fbCoolingPanel();

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CB96F166-08A2-0ABA-C7F0-6CA5A48D2126}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{72DA45E9-3817-001B-E29D-62FE2DAB0BB3}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10419,31 +10419,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164383680</GetCodeOffs>
+        <GetCodeOffs>164365176</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164383752</GetCodeOffs>
+        <GetCodeOffs>164365248</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164383768</GetCodeOffs>
+        <GetCodeOffs>164365264</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164383728</GetCodeOffs>
+        <GetCodeOffs>164365224</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164383760</GetCodeOffs>
+        <GetCodeOffs>164365256</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11695,15 +11695,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164383552</GetCodeOffs>
-        <SetCodeOffs>164383600</SetCodeOffs>
+        <GetCodeOffs>164365048</GetCodeOffs>
+        <SetCodeOffs>164365096</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164383632</GetCodeOffs>
-        <SetCodeOffs>164383656</SetCodeOffs>
+        <GetCodeOffs>164365128</GetCodeOffs>
+        <SetCodeOffs>164365152</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11944,31 +11944,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>164383864</GetCodeOffs>
+        <GetCodeOffs>164365360</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164383824</GetCodeOffs>
+        <GetCodeOffs>164365320</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164384000</GetCodeOffs>
+        <GetCodeOffs>164365496</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164384008</GetCodeOffs>
+        <GetCodeOffs>164365504</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164383920</GetCodeOffs>
+        <GetCodeOffs>164365416</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11980,7 +11980,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164384016</GetCodeOffs>
+        <GetCodeOffs>164365512</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12573,7 +12573,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164384072</GetCodeOffs>
+        <GetCodeOffs>164365568</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -29737,14 +29737,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164390416</GetCodeOffs>
+        <GetCodeOffs>164371912</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164390320</GetCodeOffs>
+        <GetCodeOffs>164371816</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -30840,7 +30840,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164390568</GetCodeOffs>
+        <GetCodeOffs>164372064</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -31499,7 +31499,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164390680</GetCodeOffs>
+        <GetCodeOffs>164372176</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -41537,7 +41537,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164397368</GetCodeOffs>
+        <GetCodeOffs>164378864</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -43465,31 +43465,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164396768</GetCodeOffs>
+        <GetCodeOffs>164378264</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164396856</GetCodeOffs>
+        <GetCodeOffs>164378352</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164396784</GetCodeOffs>
+        <GetCodeOffs>164378280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164396832</GetCodeOffs>
+        <GetCodeOffs>164378328</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164396872</GetCodeOffs>
+        <GetCodeOffs>164378368</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -65303,587 +65303,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</Name>
-      <BitSize>1541440</BitSize>
-      <SubItem>
-        <Name>stMotionStage1</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The 1st motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stMotionStage2</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> The 2nd motor to move</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState1</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All possible position states for motor 1, including unused/invalid states.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATE:M1
-        io: io
-        expand: :%.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionState2</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo ReferenceTo="true">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <Comment> All possible position states for motor 2, including unused/invalid states.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATE:M2
-        io: io
-        expand: :%.2d
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumSet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> Set this to a nonzero value to request a new move. It will be reset to zero every cycle. This should be hooked up to a user's EPICS enum input.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eEnumGet</Name>
-        <Type ReferenceTo="true">UINT</Type>
-        <Comment> The current state index, or zero if we are not at a state. This should be hooked up to a user's EPICS enum output.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbFFHWO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <Comment> The fast fault output to fault to.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbArbiter</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_Arbiter</Type>
-        <Comment> The arbiter to request beam conditions from.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableMotion</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable input state moves, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableBeamParams</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable beam parameter checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>584</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnablePositionLimits</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to enable position limit checks, or FALSE to disable them.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>592</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDeviceName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the device for use in the PMPS DB lookup and diagnostic screens.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>600</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sTransitionKey</Name>
-        <Type>STRING(80)</Type>
-        <Comment> The name of the transition state in the PMPS database.</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>1248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StateEpicsToPlc</Type>
-        <Comment> Normal EPICS inputs, gathered into a single struct
- PMPS EPICS inputs, gathered into a single struct</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1904</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSEpicsToPlc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StatePMPSEpicsToPlc</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>1936</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadDBNow</Name>
-        <Type>BOOL</Type>
-        <Comment> Set this to TRUE to re-read the loaded database immediately (useful for debug)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>1952</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StatePlcToEpics</Type>
-        <Comment> Normal EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>768</BitSize>
-        <BitOffs>1984</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPMPSPlcToEpics</Name>
-        <Type Namespace="lcls_twincat_motion">ST_StatePMPSPlcToEpics</Type>
-        <Comment> PMPS EPICS outputs, gathered into a single struct</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>2752</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <Comment> The PMPS database lookup associated with the current position state.</Comment>
-        <BitSize>2496</BitSize>
-        <BitOffs>5248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbCore</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStateND_Core</Type>
-        <BitSize>609536</BitSize>
-        <BitOffs>7744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbPMPSCore</Name>
-        <Type Namespace="lcls_twincat_motion">FB_PositionStatePMPSND_Core</Type>
-        <BitSize>682240</BitSize>
-        <BitOffs>617280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astMotionStageMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <BitSize>77760</BitSize>
-        <BitOffs>1299520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>astPositionStateMax</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <ArrayInfo Level="0">
-          <LBound>1</LBound>
-          <Elements>3</Elements>
-        </ArrayInfo>
-        <ArrayInfo Level="1">
-          <LBound>1</LBound>
-          <Elements>15</Elements>
-        </ArrayInfo>
-        <BitSize>164160</BitSize>
-        <BitOffs>1377280</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
-      <BitSize>92352</BitSize>
-      <SubItem>
-        <Name>stPositionState</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSetDefault</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bForceUpdate</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>136</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>144</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fPosition</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nEncoderCount</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDelta</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1024</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fAccel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fDecel</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoveOk</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bLocked</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValid</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUseRawCounts</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>1240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sPmpsState</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>1248</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stDefault</Name>
-        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
-        <BitSize>3648</BitSize>
-        <BitOffs>1920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbWarning</Name>
-        <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>86080</BitSize>
-        <BitOffs>5568</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bHasDefault</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>91648</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bHasWarned</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>91656</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sJson</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>91664</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>E_B4C_Rh_CoatingStates</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>Unknown</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>B4C</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Rh</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>strict</Name>
-        </Property>
-        <Property>
-          <Name>generate_implicit_init_function</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</Name>
       <BitSize>1541312</BitSize>
       <SubItem>
@@ -66175,6 +65594,254 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_StateSetupHelper</Name>
+      <BitSize>92352</BitSize>
+      <SubItem>
+        <Name>stPositionState</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_PositionState</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSetDefault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bForceUpdate</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>136</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>144</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fPosition</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nEncoderCount</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDelta</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fVelocity</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1024</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fAccel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fDecel</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1152</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMoveOk</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bLocked</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUseRawCounts</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1240</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPmpsState</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1248</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stDefault</Name>
+        <Type Namespace="lcls_twincat_motion">ST_PositionState</Type>
+        <BitSize>3648</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbWarning</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>86080</BitSize>
+        <BitOffs>5568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHasDefault</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>91648</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bHasWarned</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>91656</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sJson</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>91664</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>E_B4C_Rh_CoatingStates</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>Unknown</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>B4C</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Rh</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
         </Property>
       </Properties>
     </DataType>
@@ -82270,7 +81937,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306244320</BitOffs>
+            <BitOffs>1306096736</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82291,7 +81958,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306244512</BitOffs>
+            <BitOffs>1306096928</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82315,7 +81982,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303948032</BitOffs>
+            <BitOffs>1303800448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -82326,7 +81993,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303950544</BitOffs>
+            <BitOffs>1303802960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -82340,7 +82007,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314751456</BitOffs>
+            <BitOffs>1314603872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82354,7 +82021,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314751488</BitOffs>
+            <BitOffs>1314603904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -82368,7 +82035,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758656</BitOffs>
+            <BitOffs>1314611072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -82389,7 +82056,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758976</BitOffs>
+            <BitOffs>1314611392</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82407,7 +82074,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307725632</BitOffs>
+            <BitOffs>1307578048</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82516,7 +82183,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307724544</BitOffs>
+            <BitOffs>1307576960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -82530,7 +82197,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758688</BitOffs>
+            <BitOffs>1314611104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -82544,7 +82211,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758720</BitOffs>
+            <BitOffs>1314611136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -82565,7 +82232,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314759872</BitOffs>
+            <BitOffs>1314612288</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -82613,7 +82280,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956288</BitOffs>
+            <BitOffs>1303808704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -82627,7 +82294,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758752</BitOffs>
+            <BitOffs>1314611168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -82641,7 +82308,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758784</BitOffs>
+            <BitOffs>1314611200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -82662,7 +82329,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314760768</BitOffs>
+            <BitOffs>1314613184</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -83145,7 +82812,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314753536</BitOffs>
+            <BitOffs>1314605952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -83159,7 +82826,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758816</BitOffs>
+            <BitOffs>1314611232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -83173,7 +82840,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758848</BitOffs>
+            <BitOffs>1314611264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -83194,7 +82861,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314761664</BitOffs>
+            <BitOffs>1314614080</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -83446,7 +83113,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276380544</BitOffs>
+            <BitOffs>1276380416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -83459,7 +83126,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388480</BitOffs>
+            <BitOffs>1276388352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -83472,7 +83139,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388488</BitOffs>
+            <BitOffs>1276388360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -83485,7 +83152,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388496</BitOffs>
+            <BitOffs>1276388368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -83508,7 +83175,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388512</BitOffs>
+            <BitOffs>1276388384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -83521,7 +83188,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388544</BitOffs>
+            <BitOffs>1276388416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -83534,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388608</BitOffs>
+            <BitOffs>1276388480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -83547,7 +83214,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388624</BitOffs>
+            <BitOffs>1276388496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -83559,7 +83226,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276406464</BitOffs>
+            <BitOffs>1276406336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -83572,7 +83239,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414400</BitOffs>
+            <BitOffs>1276414272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -83585,7 +83252,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414408</BitOffs>
+            <BitOffs>1276414280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -83598,7 +83265,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414416</BitOffs>
+            <BitOffs>1276414288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -83621,7 +83288,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414432</BitOffs>
+            <BitOffs>1276414304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -83634,7 +83301,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414464</BitOffs>
+            <BitOffs>1276414336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -83647,7 +83314,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414528</BitOffs>
+            <BitOffs>1276414400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -83660,7 +83327,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414544</BitOffs>
+            <BitOffs>1276414416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -83672,7 +83339,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276432384</BitOffs>
+            <BitOffs>1276432256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -83685,7 +83352,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440320</BitOffs>
+            <BitOffs>1276440192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -83698,7 +83365,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440328</BitOffs>
+            <BitOffs>1276440200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -83711,7 +83378,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440336</BitOffs>
+            <BitOffs>1276440208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -83734,7 +83401,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440352</BitOffs>
+            <BitOffs>1276440224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -83747,7 +83414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440384</BitOffs>
+            <BitOffs>1276440256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -83760,7 +83427,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440448</BitOffs>
+            <BitOffs>1276440320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -83773,7 +83440,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440464</BitOffs>
+            <BitOffs>1276440336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable1</Name>
@@ -83791,7 +83458,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277690944</BitOffs>
+            <BitOffs>1277543744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.M1K1BENDbSTOEnable2</Name>
@@ -83807,7 +83474,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277690952</BitOffs>
+            <BitOffs>1277543752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_1_Err</Name>
@@ -83820,7 +83487,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277690960</BitOffs>
+            <BitOffs>1277543760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_2_Err</Name>
@@ -83832,7 +83499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277690968</BitOffs>
+            <BitOffs>1277543768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1US_RTD_3_Err</Name>
@@ -83844,7 +83511,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277691168</BitOffs>
+            <BitOffs>1277543968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_1_Err</Name>
@@ -83856,7 +83523,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277691176</BitOffs>
+            <BitOffs>1277543976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_2_Err</Name>
@@ -83868,7 +83535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277691184</BitOffs>
+            <BitOffs>1277543984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.bM1K1DS_RTD_3_Err</Name>
@@ -83880,7 +83547,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1277691192</BitOffs>
+            <BitOffs>1277543992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable1</Name>
@@ -83893,7 +83560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283517120</BitOffs>
+            <BitOffs>1283369536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.bSTOEnable2</Name>
@@ -83905,7 +83572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283517128</BitOffs>
+            <BitOffs>1283369544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYupEnc</Name>
@@ -83918,7 +83585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283517184</BitOffs>
+            <BitOffs>1283369600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stYdwnEnc</Name>
@@ -83930,7 +83597,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283517312</BitOffs>
+            <BitOffs>1283369728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXupEnc</Name>
@@ -83942,7 +83609,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283517440</BitOffs>
+            <BitOffs>1283369856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.stXdwnEnc</Name>
@@ -83954,7 +83621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283517568</BitOffs>
+            <BitOffs>1283369984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -83967,7 +83634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283518336</BitOffs>
+            <BitOffs>1283370752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -83980,7 +83647,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283518464</BitOffs>
+            <BitOffs>1283370880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -83993,7 +83660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283529088</BitOffs>
+            <BitOffs>1283381504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -84006,7 +83673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1283529216</BitOffs>
+            <BitOffs>1283381632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84018,7 +83685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1284767936</BitOffs>
+            <BitOffs>1284620352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84030,7 +83697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285102912</BitOffs>
+            <BitOffs>1284955328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1.iRaw</Name>
@@ -84043,7 +83710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285433280</BitOffs>
+            <BitOffs>1285285696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2.iRaw</Name>
@@ -84056,7 +83723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285433856</BitOffs>
+            <BitOffs>1285286272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1.iRaw</Name>
@@ -84069,7 +83736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1285434432</BitOffs>
+            <BitOffs>1285286848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -84081,7 +83748,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286735424</BitOffs>
+            <BitOffs>1286587840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -84094,7 +83761,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743360</BitOffs>
+            <BitOffs>1286595776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -84107,7 +83774,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743368</BitOffs>
+            <BitOffs>1286595784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -84120,7 +83787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743376</BitOffs>
+            <BitOffs>1286595792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -84143,7 +83810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743392</BitOffs>
+            <BitOffs>1286595808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -84156,7 +83823,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743424</BitOffs>
+            <BitOffs>1286595840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -84169,7 +83836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743488</BitOffs>
+            <BitOffs>1286595904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -84182,7 +83849,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743504</BitOffs>
+            <BitOffs>1286595920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -84194,7 +83861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286761344</BitOffs>
+            <BitOffs>1286613760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -84207,7 +83874,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769280</BitOffs>
+            <BitOffs>1286621696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -84220,7 +83887,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769288</BitOffs>
+            <BitOffs>1286621704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -84233,7 +83900,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769296</BitOffs>
+            <BitOffs>1286621712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -84256,7 +83923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769312</BitOffs>
+            <BitOffs>1286621728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -84269,7 +83936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769344</BitOffs>
+            <BitOffs>1286621760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -84282,7 +83949,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769408</BitOffs>
+            <BitOffs>1286621824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -84295,7 +83962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769424</BitOffs>
+            <BitOffs>1286621840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -84307,7 +83974,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286787264</BitOffs>
+            <BitOffs>1286639680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -84320,7 +83987,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795200</BitOffs>
+            <BitOffs>1286647616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -84333,7 +84000,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795208</BitOffs>
+            <BitOffs>1286647624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -84346,7 +84013,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795216</BitOffs>
+            <BitOffs>1286647632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -84369,7 +84036,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795232</BitOffs>
+            <BitOffs>1286647648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -84382,7 +84049,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795264</BitOffs>
+            <BitOffs>1286647680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -84395,7 +84062,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795328</BitOffs>
+            <BitOffs>1286647744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -84408,7 +84075,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795344</BitOffs>
+            <BitOffs>1286647760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable1</Name>
@@ -84425,7 +84092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287123648</BitOffs>
+            <BitOffs>1286976064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bSTOEnable2</Name>
@@ -84441,7 +84108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287123656</BitOffs>
+            <BitOffs>1286976072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84453,7 +84120,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287126336</BitOffs>
+            <BitOffs>1286978752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84465,7 +84132,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287453760</BitOffs>
+            <BitOffs>1287306176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84477,7 +84144,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1287781184</BitOffs>
+            <BitOffs>1287633600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84489,7 +84156,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288108608</BitOffs>
+            <BitOffs>1287961024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84501,7 +84168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288436032</BitOffs>
+            <BitOffs>1288288448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -84513,7 +84180,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1288763456</BitOffs>
+            <BitOffs>1288615872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upe</Name>
@@ -84535,7 +84202,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088256</BitOffs>
+            <BitOffs>1288940672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upe</Name>
@@ -84557,7 +84224,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088384</BitOffs>
+            <BitOffs>1288940800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bError</Name>
@@ -84581,7 +84248,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088840</BitOffs>
+            <BitOffs>1288941256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bUnderrange</Name>
@@ -84593,7 +84260,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088848</BitOffs>
+            <BitOffs>1288941264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.bOverrange</Name>
@@ -84605,7 +84272,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088856</BitOffs>
+            <BitOffs>1288941272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1.iRaw</Name>
@@ -84617,7 +84284,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088864</BitOffs>
+            <BitOffs>1288941280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bError</Name>
@@ -84641,7 +84308,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089096</BitOffs>
+            <BitOffs>1288941512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bUnderrange</Name>
@@ -84653,7 +84320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089104</BitOffs>
+            <BitOffs>1288941520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.bOverrange</Name>
@@ -84665,7 +84332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089112</BitOffs>
+            <BitOffs>1288941528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2.iRaw</Name>
@@ -84677,7 +84344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089120</BitOffs>
+            <BitOffs>1288941536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bError</Name>
@@ -84701,7 +84368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089352</BitOffs>
+            <BitOffs>1288941768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bUnderrange</Name>
@@ -84713,7 +84380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089360</BitOffs>
+            <BitOffs>1288941776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.bOverrange</Name>
@@ -84725,7 +84392,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089368</BitOffs>
+            <BitOffs>1288941784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3.iRaw</Name>
@@ -84737,7 +84404,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089376</BitOffs>
+            <BitOffs>1288941792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bError</Name>
@@ -84761,7 +84428,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089608</BitOffs>
+            <BitOffs>1288942024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bUnderrange</Name>
@@ -84773,7 +84440,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089616</BitOffs>
+            <BitOffs>1288942032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.bOverrange</Name>
@@ -84785,7 +84452,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089624</BitOffs>
+            <BitOffs>1288942040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4.iRaw</Name>
@@ -84797,7 +84464,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089632</BitOffs>
+            <BitOffs>1288942048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bError</Name>
@@ -84821,7 +84488,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089864</BitOffs>
+            <BitOffs>1288942280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bUnderrange</Name>
@@ -84833,7 +84500,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089872</BitOffs>
+            <BitOffs>1288942288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.bOverrange</Name>
@@ -84845,7 +84512,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089880</BitOffs>
+            <BitOffs>1288942296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5.iRaw</Name>
@@ -84857,7 +84524,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089888</BitOffs>
+            <BitOffs>1288942304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bError</Name>
@@ -84881,7 +84548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090120</BitOffs>
+            <BitOffs>1288942536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bUnderrange</Name>
@@ -84893,7 +84560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090128</BitOffs>
+            <BitOffs>1288942544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.bOverrange</Name>
@@ -84905,7 +84572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090136</BitOffs>
+            <BitOffs>1288942552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6.iRaw</Name>
@@ -84917,7 +84584,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090144</BitOffs>
+            <BitOffs>1288942560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bError</Name>
@@ -84941,7 +84608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090376</BitOffs>
+            <BitOffs>1288942792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bUnderrange</Name>
@@ -84953,7 +84620,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090384</BitOffs>
+            <BitOffs>1288942800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.bOverrange</Name>
@@ -84965,7 +84632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090392</BitOffs>
+            <BitOffs>1288942808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7.iRaw</Name>
@@ -84977,7 +84644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090400</BitOffs>
+            <BitOffs>1288942816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bError</Name>
@@ -85001,7 +84668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090632</BitOffs>
+            <BitOffs>1288943048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bUnderrange</Name>
@@ -85013,7 +84680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090640</BitOffs>
+            <BitOffs>1288943056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.bOverrange</Name>
@@ -85025,7 +84692,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090648</BitOffs>
+            <BitOffs>1288943064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8.iRaw</Name>
@@ -85037,7 +84704,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090656</BitOffs>
+            <BitOffs>1288943072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bError</Name>
@@ -85061,7 +84728,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090888</BitOffs>
+            <BitOffs>1288943304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bUnderrange</Name>
@@ -85073,7 +84740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090896</BitOffs>
+            <BitOffs>1288943312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.bOverrange</Name>
@@ -85085,7 +84752,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090904</BitOffs>
+            <BitOffs>1288943320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9.iRaw</Name>
@@ -85097,7 +84764,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090912</BitOffs>
+            <BitOffs>1288943328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bError</Name>
@@ -85121,7 +84788,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091144</BitOffs>
+            <BitOffs>1288943560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bUnderrange</Name>
@@ -85133,7 +84800,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091152</BitOffs>
+            <BitOffs>1288943568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.bOverrange</Name>
@@ -85145,7 +84812,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091160</BitOffs>
+            <BitOffs>1288943576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10.iRaw</Name>
@@ -85157,7 +84824,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091168</BitOffs>
+            <BitOffs>1288943584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bError</Name>
@@ -85181,7 +84848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091400</BitOffs>
+            <BitOffs>1288943816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bUnderrange</Name>
@@ -85193,7 +84860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091408</BitOffs>
+            <BitOffs>1288943824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.bOverrange</Name>
@@ -85205,7 +84872,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091416</BitOffs>
+            <BitOffs>1288943832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11.iRaw</Name>
@@ -85217,7 +84884,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091424</BitOffs>
+            <BitOffs>1288943840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bError</Name>
@@ -85241,7 +84908,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091656</BitOffs>
+            <BitOffs>1288944072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bUnderrange</Name>
@@ -85253,7 +84920,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091664</BitOffs>
+            <BitOffs>1288944080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.bOverrange</Name>
@@ -85265,7 +84932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091672</BitOffs>
+            <BitOffs>1288944088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12.iRaw</Name>
@@ -85277,7 +84944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091680</BitOffs>
+            <BitOffs>1288944096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1.iRaw</Name>
@@ -85290,7 +84957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289117888</BitOffs>
+            <BitOffs>1288970304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2.iRaw</Name>
@@ -85303,7 +84970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289118464</BitOffs>
+            <BitOffs>1288970880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1.iRaw</Name>
@@ -85316,7 +84983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1289119040</BitOffs>
+            <BitOffs>1288971456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -85328,7 +84995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290423680</BitOffs>
+            <BitOffs>1290276096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -85341,7 +85008,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431616</BitOffs>
+            <BitOffs>1290284032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -85354,7 +85021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431624</BitOffs>
+            <BitOffs>1290284040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHome</Name>
@@ -85367,7 +85034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431632</BitOffs>
+            <BitOffs>1290284048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -85390,7 +85057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431648</BitOffs>
+            <BitOffs>1290284064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -85403,7 +85070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431680</BitOffs>
+            <BitOffs>1290284096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -85416,7 +85083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431744</BitOffs>
+            <BitOffs>1290284160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -85429,7 +85096,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431760</BitOffs>
+            <BitOffs>1290284176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -85441,7 +85108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290449600</BitOffs>
+            <BitOffs>1290302016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -85454,7 +85121,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457536</BitOffs>
+            <BitOffs>1290309952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -85467,7 +85134,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457544</BitOffs>
+            <BitOffs>1290309960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHome</Name>
@@ -85480,7 +85147,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457552</BitOffs>
+            <BitOffs>1290309968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -85503,7 +85170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457568</BitOffs>
+            <BitOffs>1290309984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -85516,7 +85183,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457600</BitOffs>
+            <BitOffs>1290310016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -85529,7 +85196,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457664</BitOffs>
+            <BitOffs>1290310080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -85542,7 +85209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457680</BitOffs>
+            <BitOffs>1290310096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -85554,7 +85221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290475520</BitOffs>
+            <BitOffs>1290327936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -85567,7 +85234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483456</BitOffs>
+            <BitOffs>1290335872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -85580,7 +85247,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483464</BitOffs>
+            <BitOffs>1290335880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHome</Name>
@@ -85593,7 +85260,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483472</BitOffs>
+            <BitOffs>1290335888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -85616,7 +85283,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483488</BitOffs>
+            <BitOffs>1290335904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -85629,7 +85296,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483520</BitOffs>
+            <BitOffs>1290335936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -85642,7 +85309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483584</BitOffs>
+            <BitOffs>1290336000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -85655,7 +85322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483600</BitOffs>
+            <BitOffs>1290336016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -85667,7 +85334,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1290844352</BitOffs>
+            <BitOffs>1290696768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -85679,7 +85346,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291171776</BitOffs>
+            <BitOffs>1291024192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -85691,7 +85358,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291499200</BitOffs>
+            <BitOffs>1291351616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -85703,7 +85370,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1291826624</BitOffs>
+            <BitOffs>1291679040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -85715,7 +85382,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1292154048</BitOffs>
+            <BitOffs>1292006464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bError</Name>
@@ -85739,7 +85406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293173768</BitOffs>
+            <BitOffs>1293026184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bUnderrange</Name>
@@ -85751,7 +85418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293173776</BitOffs>
+            <BitOffs>1293026192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.bOverrange</Name>
@@ -85763,7 +85430,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293173784</BitOffs>
+            <BitOffs>1293026200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP.iRaw</Name>
@@ -85775,7 +85442,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293173792</BitOffs>
+            <BitOffs>1293026208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bError</Name>
@@ -85799,7 +85466,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174024</BitOffs>
+            <BitOffs>1293026440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bUnderrange</Name>
@@ -85811,7 +85478,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174032</BitOffs>
+            <BitOffs>1293026448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.bOverrange</Name>
@@ -85823,7 +85490,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174040</BitOffs>
+            <BitOffs>1293026456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM.iRaw</Name>
@@ -85835,7 +85502,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174048</BitOffs>
+            <BitOffs>1293026464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bError</Name>
@@ -85859,7 +85526,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174280</BitOffs>
+            <BitOffs>1293026696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bUnderrange</Name>
@@ -85871,7 +85538,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174288</BitOffs>
+            <BitOffs>1293026704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.bOverrange</Name>
@@ -85883,7 +85550,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174296</BitOffs>
+            <BitOffs>1293026712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG.iRaw</Name>
@@ -85895,7 +85562,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174304</BitOffs>
+            <BitOffs>1293026720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bError</Name>
@@ -85919,7 +85586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174536</BitOffs>
+            <BitOffs>1293026952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bUnderrange</Name>
@@ -85931,7 +85598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174544</BitOffs>
+            <BitOffs>1293026960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.bOverrange</Name>
@@ -85943,7 +85610,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174552</BitOffs>
+            <BitOffs>1293026968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync.iRaw</Name>
@@ -85955,7 +85622,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174560</BitOffs>
+            <BitOffs>1293026976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbGetIllPercent.iRaw</Name>
@@ -85968,7 +85635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174848</BitOffs>
+            <BitOffs>1293027264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter.iRaw</Name>
@@ -85981,7 +85648,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293176000</BitOffs>
+            <BitOffs>1293028416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -85993,7 +85660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293179392</BitOffs>
+            <BitOffs>1293031808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.i_stCurrentBP</Name>
@@ -86009,7 +85676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293506368</BitOffs>
+            <BitOffs>1293358784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_toggle</Name>
@@ -86030,7 +85697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293509888</BitOffs>
+            <BitOffs>1293362304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.xTxPDO_state</Name>
@@ -86051,7 +85718,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1293509889</BitOffs>
+            <BitOffs>1293362305</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable1</Name>
@@ -86068,7 +85735,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295000000</BitOffs>
+            <BitOffs>1294852416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.M2K2FLATbSTOEnable2</Name>
@@ -86084,7 +85751,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295000008</BitOffs>
+            <BitOffs>1294852424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_1_Err</Name>
@@ -86097,7 +85764,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295000048</BitOffs>
+            <BitOffs>1294852464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2US_RTD_2_Err</Name>
@@ -86109,7 +85776,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295000056</BitOffs>
+            <BitOffs>1294852472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -86122,7 +85789,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295000320</BitOffs>
+            <BitOffs>1294852736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -86135,7 +85802,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295000832</BitOffs>
+            <BitOffs>1294853248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel.fbFlow_2.iRaw</Name>
@@ -86148,7 +85815,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1295001408</BitOffs>
+            <BitOffs>1294853824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -86160,7 +85827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296302336</BitOffs>
+            <BitOffs>1296154752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -86173,7 +85840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310272</BitOffs>
+            <BitOffs>1296162688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -86186,7 +85853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310280</BitOffs>
+            <BitOffs>1296162696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -86199,7 +85866,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310288</BitOffs>
+            <BitOffs>1296162704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -86222,7 +85889,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310304</BitOffs>
+            <BitOffs>1296162720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -86235,7 +85902,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310336</BitOffs>
+            <BitOffs>1296162752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -86248,7 +85915,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310400</BitOffs>
+            <BitOffs>1296162816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -86261,7 +85928,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310416</BitOffs>
+            <BitOffs>1296162832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -86273,7 +85940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296328256</BitOffs>
+            <BitOffs>1296180672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -86286,7 +85953,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336192</BitOffs>
+            <BitOffs>1296188608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -86299,7 +85966,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336200</BitOffs>
+            <BitOffs>1296188616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -86312,7 +85979,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336208</BitOffs>
+            <BitOffs>1296188624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -86335,7 +86002,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336224</BitOffs>
+            <BitOffs>1296188640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -86348,7 +86015,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336256</BitOffs>
+            <BitOffs>1296188672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -86361,7 +86028,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336320</BitOffs>
+            <BitOffs>1296188736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -86374,7 +86041,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336336</BitOffs>
+            <BitOffs>1296188752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -86386,7 +86053,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296354176</BitOffs>
+            <BitOffs>1296206592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -86399,7 +86066,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362112</BitOffs>
+            <BitOffs>1296214528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -86412,7 +86079,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362120</BitOffs>
+            <BitOffs>1296214536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -86425,7 +86092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362128</BitOffs>
+            <BitOffs>1296214544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -86448,7 +86115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362144</BitOffs>
+            <BitOffs>1296214560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -86461,7 +86128,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362176</BitOffs>
+            <BitOffs>1296214592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -86474,7 +86141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362240</BitOffs>
+            <BitOffs>1296214656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -86487,7 +86154,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362256</BitOffs>
+            <BitOffs>1296214672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
@@ -86499,7 +86166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298628928</BitOffs>
+            <BitOffs>1298481344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -86511,7 +86178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298628936</BitOffs>
+            <BitOffs>1298481352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -86528,7 +86195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298628944</BitOffs>
+            <BitOffs>1298481360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -86544,7 +86211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298628952</BitOffs>
+            <BitOffs>1298481368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -86557,7 +86224,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629248</BitOffs>
+            <BitOffs>1298481664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -86570,7 +86237,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629760</BitOffs>
+            <BitOffs>1298482176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -86582,7 +86249,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299930688</BitOffs>
+            <BitOffs>1299783104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -86595,7 +86262,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938624</BitOffs>
+            <BitOffs>1299791040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -86608,7 +86275,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938632</BitOffs>
+            <BitOffs>1299791048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -86621,7 +86288,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938640</BitOffs>
+            <BitOffs>1299791056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -86644,7 +86311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938656</BitOffs>
+            <BitOffs>1299791072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -86657,7 +86324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938688</BitOffs>
+            <BitOffs>1299791104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -86670,7 +86337,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938752</BitOffs>
+            <BitOffs>1299791168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -86683,7 +86350,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938768</BitOffs>
+            <BitOffs>1299791184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -86695,7 +86362,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299956608</BitOffs>
+            <BitOffs>1299809024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -86708,7 +86375,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964544</BitOffs>
+            <BitOffs>1299816960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -86721,7 +86388,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964552</BitOffs>
+            <BitOffs>1299816968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -86734,7 +86401,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964560</BitOffs>
+            <BitOffs>1299816976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -86757,7 +86424,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964576</BitOffs>
+            <BitOffs>1299816992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -86770,7 +86437,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964608</BitOffs>
+            <BitOffs>1299817024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -86783,7 +86450,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964672</BitOffs>
+            <BitOffs>1299817088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -86796,7 +86463,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964688</BitOffs>
+            <BitOffs>1299817104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -86808,7 +86475,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299982528</BitOffs>
+            <BitOffs>1299834944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -86821,7 +86488,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990464</BitOffs>
+            <BitOffs>1299842880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -86834,7 +86501,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990472</BitOffs>
+            <BitOffs>1299842888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -86847,7 +86514,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990480</BitOffs>
+            <BitOffs>1299842896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -86870,7 +86537,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990496</BitOffs>
+            <BitOffs>1299842912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -86883,7 +86550,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990528</BitOffs>
+            <BitOffs>1299842944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -86896,7 +86563,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990592</BitOffs>
+            <BitOffs>1299843008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -86909,7 +86576,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990608</BitOffs>
+            <BitOffs>1299843024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError</Name>
@@ -86933,7 +86600,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300318792</BitOffs>
+            <BitOffs>1300171208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange</Name>
@@ -86945,7 +86612,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300318800</BitOffs>
+            <BitOffs>1300171216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange</Name>
@@ -86957,7 +86624,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300318808</BitOffs>
+            <BitOffs>1300171224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw</Name>
@@ -86969,7 +86636,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300318816</BitOffs>
+            <BitOffs>1300171232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError</Name>
@@ -86993,7 +86660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300319048</BitOffs>
+            <BitOffs>1300171464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange</Name>
@@ -87005,7 +86672,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300319056</BitOffs>
+            <BitOffs>1300171472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange</Name>
@@ -87017,7 +86684,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300319064</BitOffs>
+            <BitOffs>1300171480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw</Name>
@@ -87029,7 +86696,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300319072</BitOffs>
+            <BitOffs>1300171488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError</Name>
@@ -87053,7 +86720,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257992</BitOffs>
+            <BitOffs>1302110408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange</Name>
@@ -87065,7 +86732,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258000</BitOffs>
+            <BitOffs>1302110416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange</Name>
@@ -87077,7 +86744,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258008</BitOffs>
+            <BitOffs>1302110424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw</Name>
@@ -87089,7 +86756,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258016</BitOffs>
+            <BitOffs>1302110432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError</Name>
@@ -87113,7 +86780,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258248</BitOffs>
+            <BitOffs>1302110664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange</Name>
@@ -87125,7 +86792,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258256</BitOffs>
+            <BitOffs>1302110672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange</Name>
@@ -87137,7 +86804,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258264</BitOffs>
+            <BitOffs>1302110680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw</Name>
@@ -87149,7 +86816,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258272</BitOffs>
+            <BitOffs>1302110688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -87162,7 +86829,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258304</BitOffs>
+            <BitOffs>1302110720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -87174,7 +86841,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258312</BitOffs>
+            <BitOffs>1302110728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -87186,7 +86853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258320</BitOffs>
+            <BitOffs>1302110736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -87198,7 +86865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258328</BitOffs>
+            <BitOffs>1302110744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -87210,7 +86877,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258336</BitOffs>
+            <BitOffs>1302110752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -87222,7 +86889,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258344</BitOffs>
+            <BitOffs>1302110760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -87239,7 +86906,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258352</BitOffs>
+            <BitOffs>1302110768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -87255,7 +86922,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258360</BitOffs>
+            <BitOffs>1302110776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -87268,7 +86935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258624</BitOffs>
+            <BitOffs>1302111040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -87281,7 +86948,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302259136</BitOffs>
+            <BitOffs>1302111552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -87293,7 +86960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303560064</BitOffs>
+            <BitOffs>1303412480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -87306,7 +86973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568000</BitOffs>
+            <BitOffs>1303420416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -87319,7 +86986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568008</BitOffs>
+            <BitOffs>1303420424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -87332,7 +86999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568016</BitOffs>
+            <BitOffs>1303420432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -87355,7 +87022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568032</BitOffs>
+            <BitOffs>1303420448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -87368,7 +87035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568064</BitOffs>
+            <BitOffs>1303420480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -87381,7 +87048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568128</BitOffs>
+            <BitOffs>1303420544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -87394,7 +87061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568144</BitOffs>
+            <BitOffs>1303420560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -87406,7 +87073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303585984</BitOffs>
+            <BitOffs>1303438400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -87419,7 +87086,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593920</BitOffs>
+            <BitOffs>1303446336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -87432,7 +87099,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593928</BitOffs>
+            <BitOffs>1303446344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -87445,7 +87112,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593936</BitOffs>
+            <BitOffs>1303446352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -87468,7 +87135,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593952</BitOffs>
+            <BitOffs>1303446368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -87481,7 +87148,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593984</BitOffs>
+            <BitOffs>1303446400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -87494,7 +87161,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303594048</BitOffs>
+            <BitOffs>1303446464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -87507,7 +87174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303594064</BitOffs>
+            <BitOffs>1303446480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -87519,7 +87186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303611904</BitOffs>
+            <BitOffs>1303464320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -87532,7 +87199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619840</BitOffs>
+            <BitOffs>1303472256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -87545,7 +87212,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619848</BitOffs>
+            <BitOffs>1303472264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -87558,7 +87225,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619856</BitOffs>
+            <BitOffs>1303472272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -87581,7 +87248,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619872</BitOffs>
+            <BitOffs>1303472288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -87594,7 +87261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619904</BitOffs>
+            <BitOffs>1303472320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -87607,7 +87274,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619968</BitOffs>
+            <BitOffs>1303472384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -87620,7 +87287,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619984</BitOffs>
+            <BitOffs>1303472400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
@@ -87640,7 +87307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303800928</BitOffs>
+            <BitOffs>1303653344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -87659,7 +87326,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303800944</BitOffs>
+            <BitOffs>1303653360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -87678,7 +87345,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303953056</BitOffs>
+            <BitOffs>1303805472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -87698,7 +87365,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303953072</BitOffs>
+            <BitOffs>1303805488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
@@ -87711,7 +87378,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303955520</BitOffs>
+            <BitOffs>1303807936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -87730,7 +87397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955968</BitOffs>
+            <BitOffs>1303808384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -87749,7 +87416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955984</BitOffs>
+            <BitOffs>1303808400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -87769,7 +87436,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956000</BitOffs>
+            <BitOffs>1303808416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -87788,7 +87455,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956016</BitOffs>
+            <BitOffs>1303808432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
@@ -87801,7 +87468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303958720</BitOffs>
+            <BitOffs>1303811136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -87821,7 +87488,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959296</BitOffs>
+            <BitOffs>1303811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -87840,7 +87507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959312</BitOffs>
+            <BitOffs>1303811728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -87860,7 +87527,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959328</BitOffs>
+            <BitOffs>1303811744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -87879,7 +87546,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959344</BitOffs>
+            <BitOffs>1303811760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -87898,7 +87565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959936</BitOffs>
+            <BitOffs>1303812352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -87918,7 +87585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959952</BitOffs>
+            <BitOffs>1303812368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -87933,7 +87600,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306244704</BitOffs>
+            <BitOffs>1306097120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_load</Name>
@@ -87948,7 +87615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306244720</BitOffs>
+            <BitOffs>1306097136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -87960,7 +87627,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306260416</BitOffs>
+            <BitOffs>1306112832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -87973,7 +87640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268352</BitOffs>
+            <BitOffs>1306120768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -87986,7 +87653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268360</BitOffs>
+            <BitOffs>1306120776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -87999,7 +87666,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268368</BitOffs>
+            <BitOffs>1306120784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -88022,7 +87689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268384</BitOffs>
+            <BitOffs>1306120800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -88035,7 +87702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268416</BitOffs>
+            <BitOffs>1306120832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -88048,7 +87715,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268480</BitOffs>
+            <BitOffs>1306120896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -88061,7 +87728,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268496</BitOffs>
+            <BitOffs>1306120912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88073,7 +87740,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306287872</BitOffs>
+            <BitOffs>1306140288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -88085,7 +87752,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306613760</BitOffs>
+            <BitOffs>1306466176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -88098,7 +87765,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621696</BitOffs>
+            <BitOffs>1306474112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -88111,7 +87778,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621704</BitOffs>
+            <BitOffs>1306474120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -88124,7 +87791,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621712</BitOffs>
+            <BitOffs>1306474128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -88147,7 +87814,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621728</BitOffs>
+            <BitOffs>1306474144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -88160,7 +87827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621760</BitOffs>
+            <BitOffs>1306474176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -88173,7 +87840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621824</BitOffs>
+            <BitOffs>1306474240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -88186,7 +87853,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621840</BitOffs>
+            <BitOffs>1306474256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88198,7 +87865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306641216</BitOffs>
+            <BitOffs>1306493632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -88210,7 +87877,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306967104</BitOffs>
+            <BitOffs>1306819520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -88223,7 +87890,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975040</BitOffs>
+            <BitOffs>1306827456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -88236,7 +87903,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975048</BitOffs>
+            <BitOffs>1306827464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -88249,7 +87916,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975056</BitOffs>
+            <BitOffs>1306827472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -88272,7 +87939,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975072</BitOffs>
+            <BitOffs>1306827488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -88285,7 +87952,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975104</BitOffs>
+            <BitOffs>1306827520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -88298,7 +87965,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975168</BitOffs>
+            <BitOffs>1306827584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -88311,7 +87978,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975184</BitOffs>
+            <BitOffs>1306827600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88323,7 +87990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306994560</BitOffs>
+            <BitOffs>1306846976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -88335,7 +88002,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307320448</BitOffs>
+            <BitOffs>1307172864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -88348,7 +88015,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328384</BitOffs>
+            <BitOffs>1307180800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -88361,7 +88028,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328392</BitOffs>
+            <BitOffs>1307180808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -88374,7 +88041,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328400</BitOffs>
+            <BitOffs>1307180816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -88397,7 +88064,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328416</BitOffs>
+            <BitOffs>1307180832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -88410,7 +88077,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328448</BitOffs>
+            <BitOffs>1307180864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -88423,7 +88090,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328512</BitOffs>
+            <BitOffs>1307180928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -88436,7 +88103,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328528</BitOffs>
+            <BitOffs>1307180944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88448,7 +88115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307347904</BitOffs>
+            <BitOffs>1307200320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -88460,7 +88127,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307673792</BitOffs>
+            <BitOffs>1307526208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -88473,7 +88140,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681728</BitOffs>
+            <BitOffs>1307534144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -88486,7 +88153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681736</BitOffs>
+            <BitOffs>1307534152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -88499,7 +88166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681744</BitOffs>
+            <BitOffs>1307534160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -88522,7 +88189,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681760</BitOffs>
+            <BitOffs>1307534176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -88535,7 +88202,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681792</BitOffs>
+            <BitOffs>1307534208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -88548,7 +88215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681856</BitOffs>
+            <BitOffs>1307534272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -88561,7 +88228,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681872</BitOffs>
+            <BitOffs>1307534288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -88573,7 +88240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307699712</BitOffs>
+            <BitOffs>1307552128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -88586,7 +88253,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707648</BitOffs>
+            <BitOffs>1307560064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -88599,7 +88266,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707656</BitOffs>
+            <BitOffs>1307560072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -88612,7 +88279,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707664</BitOffs>
+            <BitOffs>1307560080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -88635,7 +88302,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707680</BitOffs>
+            <BitOffs>1307560096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -88648,7 +88315,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707712</BitOffs>
+            <BitOffs>1307560128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -88661,7 +88328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707776</BitOffs>
+            <BitOffs>1307560192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -88674,7 +88341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707792</BitOffs>
+            <BitOffs>1307560208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -88687,7 +88354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733568</BitOffs>
+            <BitOffs>1307585984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -88700,7 +88367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733576</BitOffs>
+            <BitOffs>1307585992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -88713,7 +88380,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733584</BitOffs>
+            <BitOffs>1307586000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -88736,7 +88403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733600</BitOffs>
+            <BitOffs>1307586016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -88749,7 +88416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733632</BitOffs>
+            <BitOffs>1307586048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -88762,7 +88429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733696</BitOffs>
+            <BitOffs>1307586112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -88775,7 +88442,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733712</BitOffs>
+            <BitOffs>1307586128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -88787,7 +88454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307751552</BitOffs>
+            <BitOffs>1307603968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -88800,7 +88467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759488</BitOffs>
+            <BitOffs>1307611904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -88813,7 +88480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759496</BitOffs>
+            <BitOffs>1307611912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -88826,7 +88493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759504</BitOffs>
+            <BitOffs>1307611920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -88849,7 +88516,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759520</BitOffs>
+            <BitOffs>1307611936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -88862,7 +88529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759552</BitOffs>
+            <BitOffs>1307611968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -88875,7 +88542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759616</BitOffs>
+            <BitOffs>1307612032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -88888,7 +88555,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759632</BitOffs>
+            <BitOffs>1307612048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -88900,7 +88567,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307777472</BitOffs>
+            <BitOffs>1307629888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -88913,7 +88580,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785408</BitOffs>
+            <BitOffs>1307637824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -88926,7 +88593,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785416</BitOffs>
+            <BitOffs>1307637832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -88939,7 +88606,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785424</BitOffs>
+            <BitOffs>1307637840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -88962,7 +88629,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785440</BitOffs>
+            <BitOffs>1307637856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -88975,7 +88642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785472</BitOffs>
+            <BitOffs>1307637888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -88988,7 +88655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785536</BitOffs>
+            <BitOffs>1307637952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -89001,7 +88668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785552</BitOffs>
+            <BitOffs>1307637968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -89013,7 +88680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307803392</BitOffs>
+            <BitOffs>1307655808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -89026,7 +88693,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811328</BitOffs>
+            <BitOffs>1307663744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -89039,7 +88706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811336</BitOffs>
+            <BitOffs>1307663752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -89052,7 +88719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811344</BitOffs>
+            <BitOffs>1307663760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -89075,7 +88742,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811360</BitOffs>
+            <BitOffs>1307663776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -89088,7 +88755,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811392</BitOffs>
+            <BitOffs>1307663808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -89101,7 +88768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811456</BitOffs>
+            <BitOffs>1307663872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -89114,7 +88781,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811472</BitOffs>
+            <BitOffs>1307663888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -89126,7 +88793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307829312</BitOffs>
+            <BitOffs>1307681728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -89139,7 +88806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837248</BitOffs>
+            <BitOffs>1307689664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -89152,7 +88819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837256</BitOffs>
+            <BitOffs>1307689672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -89165,7 +88832,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837264</BitOffs>
+            <BitOffs>1307689680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -89188,7 +88855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837280</BitOffs>
+            <BitOffs>1307689696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -89201,7 +88868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837312</BitOffs>
+            <BitOffs>1307689728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -89214,7 +88881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837376</BitOffs>
+            <BitOffs>1307689792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -89227,7 +88894,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837392</BitOffs>
+            <BitOffs>1307689808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -89239,7 +88906,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307855232</BitOffs>
+            <BitOffs>1307707648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -89252,7 +88919,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863168</BitOffs>
+            <BitOffs>1307715584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -89265,7 +88932,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863176</BitOffs>
+            <BitOffs>1307715592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -89278,7 +88945,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863184</BitOffs>
+            <BitOffs>1307715600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -89301,7 +88968,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863200</BitOffs>
+            <BitOffs>1307715616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -89314,7 +88981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863232</BitOffs>
+            <BitOffs>1307715648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -89327,7 +88994,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863296</BitOffs>
+            <BitOffs>1307715712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -89340,7 +89007,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863312</BitOffs>
+            <BitOffs>1307715728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89352,7 +89019,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307882688</BitOffs>
+            <BitOffs>1307735104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -89364,7 +89031,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308208576</BitOffs>
+            <BitOffs>1308060992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -89377,7 +89044,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216512</BitOffs>
+            <BitOffs>1308068928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -89390,7 +89057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216520</BitOffs>
+            <BitOffs>1308068936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -89403,7 +89070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216528</BitOffs>
+            <BitOffs>1308068944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -89426,7 +89093,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216544</BitOffs>
+            <BitOffs>1308068960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -89439,7 +89106,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216576</BitOffs>
+            <BitOffs>1308068992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -89452,7 +89119,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216640</BitOffs>
+            <BitOffs>1308069056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -89465,7 +89132,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216656</BitOffs>
+            <BitOffs>1308069072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89477,7 +89144,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308236032</BitOffs>
+            <BitOffs>1308088448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -89489,7 +89156,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308561920</BitOffs>
+            <BitOffs>1308414336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -89502,7 +89169,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569856</BitOffs>
+            <BitOffs>1308422272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -89515,7 +89182,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569864</BitOffs>
+            <BitOffs>1308422280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -89528,7 +89195,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569872</BitOffs>
+            <BitOffs>1308422288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -89551,7 +89218,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569888</BitOffs>
+            <BitOffs>1308422304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -89564,7 +89231,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569920</BitOffs>
+            <BitOffs>1308422336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -89577,7 +89244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569984</BitOffs>
+            <BitOffs>1308422400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -89590,7 +89257,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308570000</BitOffs>
+            <BitOffs>1308422416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89602,7 +89269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308589376</BitOffs>
+            <BitOffs>1308441792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -89614,7 +89281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308915264</BitOffs>
+            <BitOffs>1308767680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -89627,7 +89294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923200</BitOffs>
+            <BitOffs>1308775616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -89640,7 +89307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923208</BitOffs>
+            <BitOffs>1308775624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -89653,7 +89320,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923216</BitOffs>
+            <BitOffs>1308775632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -89676,7 +89343,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923232</BitOffs>
+            <BitOffs>1308775648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -89689,7 +89356,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923264</BitOffs>
+            <BitOffs>1308775680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -89702,7 +89369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923328</BitOffs>
+            <BitOffs>1308775744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -89715,7 +89382,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923344</BitOffs>
+            <BitOffs>1308775760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89727,7 +89394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308942720</BitOffs>
+            <BitOffs>1308795136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -89739,7 +89406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309268608</BitOffs>
+            <BitOffs>1309121024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -89752,7 +89419,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276544</BitOffs>
+            <BitOffs>1309128960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -89765,7 +89432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276552</BitOffs>
+            <BitOffs>1309128968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -89778,7 +89445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276560</BitOffs>
+            <BitOffs>1309128976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -89801,7 +89468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276576</BitOffs>
+            <BitOffs>1309128992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -89814,7 +89481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276608</BitOffs>
+            <BitOffs>1309129024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -89827,7 +89494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276672</BitOffs>
+            <BitOffs>1309129088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -89840,7 +89507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276688</BitOffs>
+            <BitOffs>1309129104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -89852,7 +89519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309294528</BitOffs>
+            <BitOffs>1309146944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -89865,7 +89532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302464</BitOffs>
+            <BitOffs>1309154880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -89878,7 +89545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302472</BitOffs>
+            <BitOffs>1309154888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -89891,7 +89558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302480</BitOffs>
+            <BitOffs>1309154896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -89914,7 +89581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302496</BitOffs>
+            <BitOffs>1309154912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -89927,7 +89594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302528</BitOffs>
+            <BitOffs>1309154944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -89940,7 +89607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302592</BitOffs>
+            <BitOffs>1309155008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -89953,7 +89620,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302608</BitOffs>
+            <BitOffs>1309155024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89965,7 +89632,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309321984</BitOffs>
+            <BitOffs>1309174400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -89977,7 +89644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309647872</BitOffs>
+            <BitOffs>1309500288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -89990,7 +89657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655808</BitOffs>
+            <BitOffs>1309508224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -90003,7 +89670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655816</BitOffs>
+            <BitOffs>1309508232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -90016,7 +89683,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655824</BitOffs>
+            <BitOffs>1309508240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -90039,7 +89706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655840</BitOffs>
+            <BitOffs>1309508256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -90052,7 +89719,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655872</BitOffs>
+            <BitOffs>1309508288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -90065,7 +89732,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655936</BitOffs>
+            <BitOffs>1309508352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -90078,7 +89745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655952</BitOffs>
+            <BitOffs>1309508368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90090,7 +89757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309675328</BitOffs>
+            <BitOffs>1309527744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -90102,7 +89769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310001216</BitOffs>
+            <BitOffs>1309853632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -90115,7 +89782,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009152</BitOffs>
+            <BitOffs>1309861568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -90128,7 +89795,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009160</BitOffs>
+            <BitOffs>1309861576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -90141,7 +89808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009168</BitOffs>
+            <BitOffs>1309861584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -90164,7 +89831,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009184</BitOffs>
+            <BitOffs>1309861600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -90177,7 +89844,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009216</BitOffs>
+            <BitOffs>1309861632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -90190,7 +89857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009280</BitOffs>
+            <BitOffs>1309861696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -90203,7 +89870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009296</BitOffs>
+            <BitOffs>1309861712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -90215,7 +89882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310027136</BitOffs>
+            <BitOffs>1309879552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -90228,7 +89895,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035072</BitOffs>
+            <BitOffs>1309887488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -90241,7 +89908,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035080</BitOffs>
+            <BitOffs>1309887496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -90254,7 +89921,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035088</BitOffs>
+            <BitOffs>1309887504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -90277,7 +89944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035104</BitOffs>
+            <BitOffs>1309887520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -90290,7 +89957,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035136</BitOffs>
+            <BitOffs>1309887552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -90303,7 +89970,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035200</BitOffs>
+            <BitOffs>1309887616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -90316,7 +89983,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035216</BitOffs>
+            <BitOffs>1309887632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -90328,7 +89995,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310053056</BitOffs>
+            <BitOffs>1309905472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -90341,7 +90008,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310060992</BitOffs>
+            <BitOffs>1309913408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -90354,7 +90021,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061000</BitOffs>
+            <BitOffs>1309913416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -90367,7 +90034,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061008</BitOffs>
+            <BitOffs>1309913424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -90390,7 +90057,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061024</BitOffs>
+            <BitOffs>1309913440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -90403,7 +90070,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061056</BitOffs>
+            <BitOffs>1309913472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -90416,7 +90083,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061120</BitOffs>
+            <BitOffs>1309913536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -90429,7 +90096,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061136</BitOffs>
+            <BitOffs>1309913552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -90441,7 +90108,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310078976</BitOffs>
+            <BitOffs>1309931392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -90454,7 +90121,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310086912</BitOffs>
+            <BitOffs>1309939328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -90467,7 +90134,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310086920</BitOffs>
+            <BitOffs>1309939336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -90480,7 +90147,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310086928</BitOffs>
+            <BitOffs>1309939344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -90503,7 +90170,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310086944</BitOffs>
+            <BitOffs>1309939360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -90516,7 +90183,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310086976</BitOffs>
+            <BitOffs>1309939392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -90529,7 +90196,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310087040</BitOffs>
+            <BitOffs>1309939456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -90542,7 +90209,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310087056</BitOffs>
+            <BitOffs>1309939472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -90554,7 +90221,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310104896</BitOffs>
+            <BitOffs>1309957312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -90567,7 +90234,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112832</BitOffs>
+            <BitOffs>1309965248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -90580,7 +90247,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112840</BitOffs>
+            <BitOffs>1309965256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -90593,7 +90260,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112848</BitOffs>
+            <BitOffs>1309965264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -90616,7 +90283,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112864</BitOffs>
+            <BitOffs>1309965280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -90629,7 +90296,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112896</BitOffs>
+            <BitOffs>1309965312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -90642,7 +90309,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112960</BitOffs>
+            <BitOffs>1309965376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -90655,7 +90322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112976</BitOffs>
+            <BitOffs>1309965392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -90667,7 +90334,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310130816</BitOffs>
+            <BitOffs>1309983232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -90680,7 +90347,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138752</BitOffs>
+            <BitOffs>1309991168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -90693,7 +90360,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138760</BitOffs>
+            <BitOffs>1309991176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -90706,7 +90373,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138768</BitOffs>
+            <BitOffs>1309991184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -90729,7 +90396,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138784</BitOffs>
+            <BitOffs>1309991200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -90742,7 +90409,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138816</BitOffs>
+            <BitOffs>1309991232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -90755,7 +90422,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138880</BitOffs>
+            <BitOffs>1309991296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -90768,7 +90435,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138896</BitOffs>
+            <BitOffs>1309991312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -90780,7 +90447,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310156736</BitOffs>
+            <BitOffs>1310009152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -90793,7 +90460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164672</BitOffs>
+            <BitOffs>1310017088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -90806,7 +90473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164680</BitOffs>
+            <BitOffs>1310017096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -90819,7 +90486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164688</BitOffs>
+            <BitOffs>1310017104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -90842,7 +90509,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164704</BitOffs>
+            <BitOffs>1310017120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -90855,7 +90522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164736</BitOffs>
+            <BitOffs>1310017152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -90868,7 +90535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164800</BitOffs>
+            <BitOffs>1310017216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -90881,7 +90548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164816</BitOffs>
+            <BitOffs>1310017232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90893,7 +90560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310184192</BitOffs>
+            <BitOffs>1310036608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -90905,7 +90572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310510080</BitOffs>
+            <BitOffs>1310362496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -90918,7 +90585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518016</BitOffs>
+            <BitOffs>1310370432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -90931,7 +90598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518024</BitOffs>
+            <BitOffs>1310370440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -90944,7 +90611,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518032</BitOffs>
+            <BitOffs>1310370448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -90967,7 +90634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518048</BitOffs>
+            <BitOffs>1310370464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -90980,7 +90647,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518080</BitOffs>
+            <BitOffs>1310370496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -90993,7 +90660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518144</BitOffs>
+            <BitOffs>1310370560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -91006,7 +90673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518160</BitOffs>
+            <BitOffs>1310370576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91018,7 +90685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310537536</BitOffs>
+            <BitOffs>1310389952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -91030,7 +90697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310863424</BitOffs>
+            <BitOffs>1310715840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -91043,7 +90710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871360</BitOffs>
+            <BitOffs>1310723776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -91056,7 +90723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871368</BitOffs>
+            <BitOffs>1310723784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -91069,7 +90736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871376</BitOffs>
+            <BitOffs>1310723792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -91092,7 +90759,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871392</BitOffs>
+            <BitOffs>1310723808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -91105,7 +90772,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871424</BitOffs>
+            <BitOffs>1310723840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -91118,7 +90785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871488</BitOffs>
+            <BitOffs>1310723904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -91131,7 +90798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871504</BitOffs>
+            <BitOffs>1310723920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91143,7 +90810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310890880</BitOffs>
+            <BitOffs>1310743296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -91155,7 +90822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311216768</BitOffs>
+            <BitOffs>1311069184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -91168,7 +90835,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224704</BitOffs>
+            <BitOffs>1311077120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -91181,7 +90848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224712</BitOffs>
+            <BitOffs>1311077128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -91194,7 +90861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224720</BitOffs>
+            <BitOffs>1311077136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -91217,7 +90884,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224736</BitOffs>
+            <BitOffs>1311077152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -91230,7 +90897,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224768</BitOffs>
+            <BitOffs>1311077184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -91243,7 +90910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224832</BitOffs>
+            <BitOffs>1311077248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -91256,7 +90923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224848</BitOffs>
+            <BitOffs>1311077264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91268,7 +90935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311244224</BitOffs>
+            <BitOffs>1311096640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -91280,7 +90947,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311570112</BitOffs>
+            <BitOffs>1311422528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -91293,7 +90960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578048</BitOffs>
+            <BitOffs>1311430464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -91306,7 +90973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578056</BitOffs>
+            <BitOffs>1311430472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -91319,7 +90986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578064</BitOffs>
+            <BitOffs>1311430480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -91342,7 +91009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578080</BitOffs>
+            <BitOffs>1311430496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -91355,7 +91022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578112</BitOffs>
+            <BitOffs>1311430528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -91368,7 +91035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578176</BitOffs>
+            <BitOffs>1311430592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -91381,7 +91048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578192</BitOffs>
+            <BitOffs>1311430608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91393,7 +91060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311597568</BitOffs>
+            <BitOffs>1311449984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -91405,7 +91072,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311923456</BitOffs>
+            <BitOffs>1311775872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -91418,7 +91085,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931392</BitOffs>
+            <BitOffs>1311783808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -91431,7 +91098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931400</BitOffs>
+            <BitOffs>1311783816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -91444,7 +91111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931408</BitOffs>
+            <BitOffs>1311783824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -91467,7 +91134,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931424</BitOffs>
+            <BitOffs>1311783840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -91480,7 +91147,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931456</BitOffs>
+            <BitOffs>1311783872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -91493,7 +91160,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931520</BitOffs>
+            <BitOffs>1311783936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -91506,7 +91173,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931536</BitOffs>
+            <BitOffs>1311783952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91518,7 +91185,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311950912</BitOffs>
+            <BitOffs>1311803328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -91530,7 +91197,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312276800</BitOffs>
+            <BitOffs>1312129216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -91543,7 +91210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284736</BitOffs>
+            <BitOffs>1312137152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -91556,7 +91223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284744</BitOffs>
+            <BitOffs>1312137160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -91569,7 +91236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284752</BitOffs>
+            <BitOffs>1312137168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -91592,7 +91259,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284768</BitOffs>
+            <BitOffs>1312137184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -91605,7 +91272,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284800</BitOffs>
+            <BitOffs>1312137216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -91618,7 +91285,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284864</BitOffs>
+            <BitOffs>1312137280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -91631,7 +91298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284880</BitOffs>
+            <BitOffs>1312137296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91643,7 +91310,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312304256</BitOffs>
+            <BitOffs>1312156672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -91655,7 +91322,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312630144</BitOffs>
+            <BitOffs>1312482560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -91668,7 +91335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638080</BitOffs>
+            <BitOffs>1312490496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -91681,7 +91348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638088</BitOffs>
+            <BitOffs>1312490504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -91694,7 +91361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638096</BitOffs>
+            <BitOffs>1312490512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -91717,7 +91384,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638112</BitOffs>
+            <BitOffs>1312490528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -91730,7 +91397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638144</BitOffs>
+            <BitOffs>1312490560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -91743,7 +91410,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638208</BitOffs>
+            <BitOffs>1312490624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -91756,7 +91423,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638224</BitOffs>
+            <BitOffs>1312490640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91768,7 +91435,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312657600</BitOffs>
+            <BitOffs>1312510016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -91780,7 +91447,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312983488</BitOffs>
+            <BitOffs>1312835904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -91793,7 +91460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991424</BitOffs>
+            <BitOffs>1312843840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -91806,7 +91473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991432</BitOffs>
+            <BitOffs>1312843848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -91819,7 +91486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991440</BitOffs>
+            <BitOffs>1312843856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -91842,7 +91509,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991456</BitOffs>
+            <BitOffs>1312843872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -91855,7 +91522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991488</BitOffs>
+            <BitOffs>1312843904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -91868,7 +91535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991552</BitOffs>
+            <BitOffs>1312843968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -91881,7 +91548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991568</BitOffs>
+            <BitOffs>1312843984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91893,7 +91560,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313010944</BitOffs>
+            <BitOffs>1312863360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -91905,7 +91572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313336832</BitOffs>
+            <BitOffs>1313189248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -91918,7 +91585,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344768</BitOffs>
+            <BitOffs>1313197184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -91931,7 +91598,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344776</BitOffs>
+            <BitOffs>1313197192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -91944,7 +91611,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344784</BitOffs>
+            <BitOffs>1313197200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -91967,7 +91634,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344800</BitOffs>
+            <BitOffs>1313197216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -91980,7 +91647,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344832</BitOffs>
+            <BitOffs>1313197248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -91993,7 +91660,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344896</BitOffs>
+            <BitOffs>1313197312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -92006,7 +91673,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344912</BitOffs>
+            <BitOffs>1313197328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92018,7 +91685,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313364288</BitOffs>
+            <BitOffs>1313216704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -92030,7 +91697,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313690176</BitOffs>
+            <BitOffs>1313542592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -92043,7 +91710,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698112</BitOffs>
+            <BitOffs>1313550528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -92056,7 +91723,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698120</BitOffs>
+            <BitOffs>1313550536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -92069,7 +91736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698128</BitOffs>
+            <BitOffs>1313550544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -92092,7 +91759,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698144</BitOffs>
+            <BitOffs>1313550560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -92105,7 +91772,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698176</BitOffs>
+            <BitOffs>1313550592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -92118,7 +91785,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698240</BitOffs>
+            <BitOffs>1313550656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -92131,7 +91798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698256</BitOffs>
+            <BitOffs>1313550672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92143,7 +91810,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313717632</BitOffs>
+            <BitOffs>1313570048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -92155,7 +91822,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314043520</BitOffs>
+            <BitOffs>1313895936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -92168,7 +91835,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051456</BitOffs>
+            <BitOffs>1313903872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -92181,7 +91848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051464</BitOffs>
+            <BitOffs>1313903880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -92194,7 +91861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051472</BitOffs>
+            <BitOffs>1313903888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -92217,7 +91884,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051488</BitOffs>
+            <BitOffs>1313903904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -92230,7 +91897,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051520</BitOffs>
+            <BitOffs>1313903936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -92243,7 +91910,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051584</BitOffs>
+            <BitOffs>1313904000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -92256,7 +91923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051600</BitOffs>
+            <BitOffs>1313904016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92268,7 +91935,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314070976</BitOffs>
+            <BitOffs>1313923392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -92280,7 +91947,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314396864</BitOffs>
+            <BitOffs>1314249280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -92293,7 +91960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404800</BitOffs>
+            <BitOffs>1314257216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -92306,7 +91973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404808</BitOffs>
+            <BitOffs>1314257224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -92319,7 +91986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404816</BitOffs>
+            <BitOffs>1314257232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -92342,7 +92009,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404832</BitOffs>
+            <BitOffs>1314257248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -92355,7 +92022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404864</BitOffs>
+            <BitOffs>1314257280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -92368,7 +92035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404928</BitOffs>
+            <BitOffs>1314257344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -92381,7 +92048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404944</BitOffs>
+            <BitOffs>1314257360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92393,7 +92060,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314424320</BitOffs>
+            <BitOffs>1314276736</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -92553,7 +92220,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1276379520</BitOffs>
+            <BitOffs>1276379392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -92566,7 +92233,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1276388504</BitOffs>
+            <BitOffs>1276388376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -92578,7 +92245,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1276405440</BitOffs>
+            <BitOffs>1276405312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -92591,7 +92258,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1276414424</BitOffs>
+            <BitOffs>1276414296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -92603,7 +92270,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1276431360</BitOffs>
+            <BitOffs>1276431232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -92616,7 +92283,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1276440344</BitOffs>
+            <BitOffs>1276440216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92628,7 +92295,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1284766912</BitOffs>
+            <BitOffs>1284619328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92640,7 +92307,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1285101888</BitOffs>
+            <BitOffs>1284954304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -92652,7 +92319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286734400</BitOffs>
+            <BitOffs>1286586816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -92665,7 +92332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286743384</BitOffs>
+            <BitOffs>1286595800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -92677,7 +92344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286760320</BitOffs>
+            <BitOffs>1286612736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -92690,7 +92357,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286769304</BitOffs>
+            <BitOffs>1286621720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -92702,7 +92369,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286786240</BitOffs>
+            <BitOffs>1286638656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -92715,7 +92382,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1286795224</BitOffs>
+            <BitOffs>1286647640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower01</Name>
@@ -92740,7 +92407,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287123664</BitOffs>
+            <BitOffs>1286976080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower02</Name>
@@ -92765,7 +92432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287123672</BitOffs>
+            <BitOffs>1286976088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.bLEDPower03</Name>
@@ -92790,7 +92457,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287123680</BitOffs>
+            <BitOffs>1286976096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bFanOn</Name>
@@ -92814,7 +92481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287123688</BitOffs>
+            <BitOffs>1286976104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92826,7 +92493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287125312</BitOffs>
+            <BitOffs>1286977728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92838,7 +92505,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287452736</BitOffs>
+            <BitOffs>1287305152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92850,7 +92517,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1287780160</BitOffs>
+            <BitOffs>1287632576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92862,7 +92529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288107584</BitOffs>
+            <BitOffs>1287960000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92874,7 +92541,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288435008</BitOffs>
+            <BitOffs>1288287424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92886,7 +92553,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1288762432</BitOffs>
+            <BitOffs>1288614848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -92898,7 +92565,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290422656</BitOffs>
+            <BitOffs>1290275072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -92911,7 +92578,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290431640</BitOffs>
+            <BitOffs>1290284056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -92923,7 +92590,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290448576</BitOffs>
+            <BitOffs>1290300992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -92936,7 +92603,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290457560</BitOffs>
+            <BitOffs>1290309976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -92948,7 +92615,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290474496</BitOffs>
+            <BitOffs>1290326912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -92961,7 +92628,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290483480</BitOffs>
+            <BitOffs>1290335896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bLEDPower</Name>
@@ -92986,7 +92653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290664528</BitOffs>
+            <BitOffs>1290516944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -92998,7 +92665,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1290843328</BitOffs>
+            <BitOffs>1290695744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93010,7 +92677,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291170752</BitOffs>
+            <BitOffs>1291023168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93022,7 +92689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291498176</BitOffs>
+            <BitOffs>1291350592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93034,7 +92701,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1291825600</BitOffs>
+            <BitOffs>1291678016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93046,7 +92713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1292153024</BitOffs>
+            <BitOffs>1292005440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.iIlluminatorINT</Name>
@@ -93058,7 +92725,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174656</BitOffs>
+            <BitOffs>1293027072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.bGigePower</Name>
@@ -93078,7 +92745,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174672</BitOffs>
+            <BitOffs>1293027088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige.fbSetIllPercent.iRaw</Name>
@@ -93091,7 +92758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293175744</BitOffs>
+            <BitOffs>1293028160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93103,7 +92770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293178368</BitOffs>
+            <BitOffs>1293030784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO.q_stRequestedBP</Name>
@@ -93119,7 +92786,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293508128</BitOffs>
+            <BitOffs>1293360544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -93131,7 +92798,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296301312</BitOffs>
+            <BitOffs>1296153728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93144,7 +92811,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296310296</BitOffs>
+            <BitOffs>1296162712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93156,7 +92823,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296327232</BitOffs>
+            <BitOffs>1296179648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93169,7 +92836,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296336216</BitOffs>
+            <BitOffs>1296188632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93181,7 +92848,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296353152</BitOffs>
+            <BitOffs>1296205568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93194,7 +92861,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1296362136</BitOffs>
+            <BitOffs>1296214552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -93206,7 +92873,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299929664</BitOffs>
+            <BitOffs>1299782080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93219,7 +92886,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938648</BitOffs>
+            <BitOffs>1299791064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93231,7 +92898,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299955584</BitOffs>
+            <BitOffs>1299808000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93244,7 +92911,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964568</BitOffs>
+            <BitOffs>1299816984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93256,7 +92923,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299981504</BitOffs>
+            <BitOffs>1299833920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93269,7 +92936,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990488</BitOffs>
+            <BitOffs>1299842904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -93281,7 +92948,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303559040</BitOffs>
+            <BitOffs>1303411456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93294,7 +92961,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303568024</BitOffs>
+            <BitOffs>1303420440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93306,7 +92973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303584960</BitOffs>
+            <BitOffs>1303437376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93319,7 +92986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593944</BitOffs>
+            <BitOffs>1303446360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93331,7 +92998,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303610880</BitOffs>
+            <BitOffs>1303463296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93344,7 +93011,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619864</BitOffs>
+            <BitOffs>1303472280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -93364,7 +93031,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304952040</BitOffs>
+            <BitOffs>1304804456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -93384,27 +93051,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1305598312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: FaultHWO
-        io: i
-        field: DESC Hardware Output Status
-     </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1305598056</BitOffs>
+            <BitOffs>1305450728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
@@ -93416,7 +93063,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306259392</BitOffs>
+            <BitOffs>1306111808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -93429,7 +93076,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306268376</BitOffs>
+            <BitOffs>1306120792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93441,7 +93088,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306286848</BitOffs>
+            <BitOffs>1306139264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -93453,7 +93100,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306612736</BitOffs>
+            <BitOffs>1306465152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -93466,7 +93113,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306621720</BitOffs>
+            <BitOffs>1306474136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93478,7 +93125,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306640192</BitOffs>
+            <BitOffs>1306492608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -93490,7 +93137,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306966080</BitOffs>
+            <BitOffs>1306818496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -93503,7 +93150,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306975064</BitOffs>
+            <BitOffs>1306827480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93515,7 +93162,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1306993536</BitOffs>
+            <BitOffs>1306845952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -93527,7 +93174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307319424</BitOffs>
+            <BitOffs>1307171840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -93540,7 +93187,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307328408</BitOffs>
+            <BitOffs>1307180824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93552,7 +93199,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307346880</BitOffs>
+            <BitOffs>1307199296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -93564,7 +93211,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307672768</BitOffs>
+            <BitOffs>1307525184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -93577,7 +93224,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307681752</BitOffs>
+            <BitOffs>1307534168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -93589,7 +93236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307698688</BitOffs>
+            <BitOffs>1307551104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -93602,7 +93249,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307707672</BitOffs>
+            <BitOffs>1307560088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -93614,7 +93261,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307724608</BitOffs>
+            <BitOffs>1307577024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -93627,7 +93274,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307733592</BitOffs>
+            <BitOffs>1307586008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -93639,7 +93286,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307750528</BitOffs>
+            <BitOffs>1307602944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -93652,7 +93299,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307759512</BitOffs>
+            <BitOffs>1307611928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -93664,7 +93311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307776448</BitOffs>
+            <BitOffs>1307628864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -93677,7 +93324,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307785432</BitOffs>
+            <BitOffs>1307637848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.PlcToNc</Name>
@@ -93689,7 +93336,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307802368</BitOffs>
+            <BitOffs>1307654784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bBrakeRelease</Name>
@@ -93702,7 +93349,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307811352</BitOffs>
+            <BitOffs>1307663768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.PlcToNc</Name>
@@ -93714,7 +93361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307828288</BitOffs>
+            <BitOffs>1307680704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bBrakeRelease</Name>
@@ -93727,7 +93374,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307837272</BitOffs>
+            <BitOffs>1307689688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.PlcToNc</Name>
@@ -93739,7 +93386,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307854208</BitOffs>
+            <BitOffs>1307706624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bBrakeRelease</Name>
@@ -93752,7 +93399,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307863192</BitOffs>
+            <BitOffs>1307715608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93764,7 +93411,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1307881664</BitOffs>
+            <BitOffs>1307734080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.PlcToNc</Name>
@@ -93776,7 +93423,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308207552</BitOffs>
+            <BitOffs>1308059968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bBrakeRelease</Name>
@@ -93789,7 +93436,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308216536</BitOffs>
+            <BitOffs>1308068952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93801,7 +93448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308235008</BitOffs>
+            <BitOffs>1308087424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.PlcToNc</Name>
@@ -93813,7 +93460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308560896</BitOffs>
+            <BitOffs>1308413312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bBrakeRelease</Name>
@@ -93826,7 +93473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308569880</BitOffs>
+            <BitOffs>1308422296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93838,7 +93485,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308588352</BitOffs>
+            <BitOffs>1308440768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.PlcToNc</Name>
@@ -93850,7 +93497,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308914240</BitOffs>
+            <BitOffs>1308766656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bBrakeRelease</Name>
@@ -93863,7 +93510,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308923224</BitOffs>
+            <BitOffs>1308775640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93875,7 +93522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1308941696</BitOffs>
+            <BitOffs>1308794112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.PlcToNc</Name>
@@ -93887,7 +93534,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309267584</BitOffs>
+            <BitOffs>1309120000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bBrakeRelease</Name>
@@ -93900,7 +93547,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309276568</BitOffs>
+            <BitOffs>1309128984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.PlcToNc</Name>
@@ -93912,7 +93559,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309293504</BitOffs>
+            <BitOffs>1309145920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bBrakeRelease</Name>
@@ -93925,7 +93572,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309302488</BitOffs>
+            <BitOffs>1309154904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93937,7 +93584,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309320960</BitOffs>
+            <BitOffs>1309173376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.PlcToNc</Name>
@@ -93949,7 +93596,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309646848</BitOffs>
+            <BitOffs>1309499264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bBrakeRelease</Name>
@@ -93962,7 +93609,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309655832</BitOffs>
+            <BitOffs>1309508248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -93974,7 +93621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1309674304</BitOffs>
+            <BitOffs>1309526720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.PlcToNc</Name>
@@ -93986,7 +93633,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310000192</BitOffs>
+            <BitOffs>1309852608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bBrakeRelease</Name>
@@ -93999,7 +93646,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310009176</BitOffs>
+            <BitOffs>1309861592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.PlcToNc</Name>
@@ -94011,7 +93658,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310026112</BitOffs>
+            <BitOffs>1309878528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bBrakeRelease</Name>
@@ -94024,7 +93671,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310035096</BitOffs>
+            <BitOffs>1309887512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.PlcToNc</Name>
@@ -94036,7 +93683,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310052032</BitOffs>
+            <BitOffs>1309904448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bBrakeRelease</Name>
@@ -94049,7 +93696,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310061016</BitOffs>
+            <BitOffs>1309913432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.PlcToNc</Name>
@@ -94061,7 +93708,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310077952</BitOffs>
+            <BitOffs>1309930368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bBrakeRelease</Name>
@@ -94074,7 +93721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310086936</BitOffs>
+            <BitOffs>1309939352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.PlcToNc</Name>
@@ -94086,7 +93733,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310103872</BitOffs>
+            <BitOffs>1309956288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bBrakeRelease</Name>
@@ -94099,7 +93746,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310112856</BitOffs>
+            <BitOffs>1309965272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.PlcToNc</Name>
@@ -94111,7 +93758,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310129792</BitOffs>
+            <BitOffs>1309982208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bBrakeRelease</Name>
@@ -94124,7 +93771,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310138776</BitOffs>
+            <BitOffs>1309991192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.PlcToNc</Name>
@@ -94136,7 +93783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310155712</BitOffs>
+            <BitOffs>1310008128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bBrakeRelease</Name>
@@ -94149,7 +93796,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310164696</BitOffs>
+            <BitOffs>1310017112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94161,7 +93808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310183168</BitOffs>
+            <BitOffs>1310035584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.PlcToNc</Name>
@@ -94173,7 +93820,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310509056</BitOffs>
+            <BitOffs>1310361472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bBrakeRelease</Name>
@@ -94186,7 +93833,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310518040</BitOffs>
+            <BitOffs>1310370456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94198,7 +93845,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310536512</BitOffs>
+            <BitOffs>1310388928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.PlcToNc</Name>
@@ -94210,7 +93857,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310862400</BitOffs>
+            <BitOffs>1310714816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bBrakeRelease</Name>
@@ -94223,7 +93870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310871384</BitOffs>
+            <BitOffs>1310723800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94235,7 +93882,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1310889856</BitOffs>
+            <BitOffs>1310742272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.PlcToNc</Name>
@@ -94247,7 +93894,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311215744</BitOffs>
+            <BitOffs>1311068160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bBrakeRelease</Name>
@@ -94260,7 +93907,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311224728</BitOffs>
+            <BitOffs>1311077144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94272,7 +93919,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311243200</BitOffs>
+            <BitOffs>1311095616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.PlcToNc</Name>
@@ -94284,7 +93931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311569088</BitOffs>
+            <BitOffs>1311421504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bBrakeRelease</Name>
@@ -94297,7 +93944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311578072</BitOffs>
+            <BitOffs>1311430488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94309,7 +93956,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311596544</BitOffs>
+            <BitOffs>1311448960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.PlcToNc</Name>
@@ -94321,7 +93968,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311922432</BitOffs>
+            <BitOffs>1311774848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bBrakeRelease</Name>
@@ -94334,7 +93981,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311931416</BitOffs>
+            <BitOffs>1311783832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94346,7 +93993,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1311949888</BitOffs>
+            <BitOffs>1311802304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.PlcToNc</Name>
@@ -94358,7 +94005,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312275776</BitOffs>
+            <BitOffs>1312128192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bBrakeRelease</Name>
@@ -94371,7 +94018,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312284760</BitOffs>
+            <BitOffs>1312137176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94383,7 +94030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312303232</BitOffs>
+            <BitOffs>1312155648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.PlcToNc</Name>
@@ -94395,7 +94042,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312629120</BitOffs>
+            <BitOffs>1312481536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bBrakeRelease</Name>
@@ -94408,7 +94055,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312638104</BitOffs>
+            <BitOffs>1312490520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94420,7 +94067,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312656576</BitOffs>
+            <BitOffs>1312508992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.PlcToNc</Name>
@@ -94432,7 +94079,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312982464</BitOffs>
+            <BitOffs>1312834880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bBrakeRelease</Name>
@@ -94445,7 +94092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1312991448</BitOffs>
+            <BitOffs>1312843864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94457,7 +94104,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313009920</BitOffs>
+            <BitOffs>1312862336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.PlcToNc</Name>
@@ -94469,7 +94116,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313335808</BitOffs>
+            <BitOffs>1313188224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bBrakeRelease</Name>
@@ -94482,7 +94129,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313344792</BitOffs>
+            <BitOffs>1313197208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94494,7 +94141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313363264</BitOffs>
+            <BitOffs>1313215680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.PlcToNc</Name>
@@ -94506,7 +94153,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313689152</BitOffs>
+            <BitOffs>1313541568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bBrakeRelease</Name>
@@ -94519,7 +94166,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313698136</BitOffs>
+            <BitOffs>1313550552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94531,7 +94178,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1313716608</BitOffs>
+            <BitOffs>1313569024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.PlcToNc</Name>
@@ -94543,7 +94190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1314042496</BitOffs>
+            <BitOffs>1313894912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bBrakeRelease</Name>
@@ -94556,7 +94203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1314051480</BitOffs>
+            <BitOffs>1313903896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94568,7 +94215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1314069952</BitOffs>
+            <BitOffs>1313922368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.PlcToNc</Name>
@@ -94580,7 +94227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1314395840</BitOffs>
+            <BitOffs>1314248256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bBrakeRelease</Name>
@@ -94593,7 +94240,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1314404824</BitOffs>
+            <BitOffs>1314257240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -94605,7 +94252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1314423296</BitOffs>
+            <BitOffs>1314275712</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -102385,8 +102032,8 @@ Emergency Stop for MR1K1</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbCoatingStates</Name>
-            <BitSize>1541440</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS2D</BaseType>
+            <BitSize>1541312</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -102399,33 +102046,18 @@ Emergency Stop for MR1K1</Comment>
             <Name>PRG_MR1K1_BEND.fbYSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1276621376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.fbXSetup</Name>
-            <BitSize>92352</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1276713728</BitOffs>
+            <BitOffs>1276621248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND.astCoatingStatesY</Name>
+            <Comment>fbXSetup: FB_StateSetupHelper;</Comment>
             <BitSize>54720</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1276806080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K1_BEND.astCoatingStatesX</Name>
-            <BitSize>54720</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>15</Elements>
-            </ArrayInfo>
-            <BitOffs>1276860800</BitOffs>
+            <BitOffs>1276713600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorM1K1</Name>
@@ -102441,19 +102073,19 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1276915520</BitOffs>
+            <BitOffs>1276768320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1277303040</BitOffs>
+            <BitOffs>1277155840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMinBendUSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1277303104</BitOffs>
+            <BitOffs>1277155904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendDSRMSErrorM1K1</Name>
@@ -102468,19 +102100,19 @@ MR1K1 US BENDER ENC RMS</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277303168</BitOffs>
+            <BitOffs>1277155968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMaxBendDSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1277690688</BitOffs>
+            <BitOffs>1277543488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fMinBendDSRMSErrorM1K1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1277690752</BitOffs>
+            <BitOffs>1277543552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncRefBendUSM1K1</Name>
@@ -102498,7 +102130,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277690816</BitOffs>
+            <BitOffs>1277543616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncRefBendDSM1K1</Name>
@@ -102515,7 +102147,7 @@ MR1K1 BEND US ENC REF</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277690848</BitOffs>
+            <BitOffs>1277543648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncCntBendUSM1K1</Name>
@@ -102533,7 +102165,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277690880</BitOffs>
+            <BitOffs>1277543680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.nEncCntBendDSM1K1</Name>
@@ -102550,7 +102182,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277690912</BitOffs>
+            <BitOffs>1277543712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_1</Name>
@@ -102569,7 +102201,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277690976</BitOffs>
+            <BitOffs>1277543776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_2</Name>
@@ -102586,7 +102218,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277691008</BitOffs>
+            <BitOffs>1277543808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1US_RTD_3</Name>
@@ -102603,7 +102235,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277691040</BitOffs>
+            <BitOffs>1277543840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_1</Name>
@@ -102621,7 +102253,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277691072</BitOffs>
+            <BitOffs>1277543872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_2</Name>
@@ -102638,7 +102270,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277691104</BitOffs>
+            <BitOffs>1277543904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fM1K1DS_RTD_3</Name>
@@ -102655,32 +102287,32 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1277691136</BitOffs>
+            <BitOffs>1277543936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbLogHandler</Name>
             <Comment> Logging</Comment>
             <BitSize>5798336</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogHandler</BaseType>
-            <BitOffs>1277691200</BitOffs>
+            <BitOffs>1277544000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.fbBendUSRMSErrorMR1K1</Name>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
-            <BitOffs>1283489536</BitOffs>
+            <BitOffs>1283342336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchDone</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1283489552</BitOffs>
+            <BitOffs>1283342352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.bM1K2PitchBusy</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1283489560</BitOffs>
+            <BitOffs>1283342360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYleftM1K2</Name>
@@ -102697,7 +102329,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283489568</BitOffs>
+            <BitOffs>1283342368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K1_BEND_BENDER.ffBenderRange</Name>
@@ -102722,7 +102354,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>1026</Value>
               </SubItem>
             </Default>
-            <BitOffs>1283489600</BitOffs>
+            <BitOffs>1283342400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.M1K2</Name>
@@ -102745,7 +102377,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283515904</BitOffs>
+            <BitOffs>1283368320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYRMSErrorM1K2</Name>
@@ -102760,19 +102392,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283539456</BitOffs>
+            <BitOffs>1283391872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1283926976</BitOffs>
+            <BitOffs>1283779392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinYRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1283927040</BitOffs>
+            <BitOffs>1283779456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbXRMSErrorM1K2</Name>
@@ -102786,19 +102418,19 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1283927104</BitOffs>
+            <BitOffs>1283779520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1284314624</BitOffs>
+            <BitOffs>1284167040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinXRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1284314688</BitOffs>
+            <BitOffs>1284167104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbPitchRMSErrorM1K2</Name>
@@ -102812,26 +102444,26 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1284314752</BitOffs>
+            <BitOffs>1284167168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMaxPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1284702272</BitOffs>
+            <BitOffs>1284554688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fMinPitchRMSErrorM1K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1284702336</BitOffs>
+            <BitOffs>1284554752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbM1K2PitchControl</Name>
             <Comment> Pitch Control</Comment>
             <BitSize>397888</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PitchControl</BaseType>
-            <BitOffs>1284702400</BitOffs>
+            <BitOffs>1284554816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbMotionStage_m5</Name>
@@ -102839,7 +102471,7 @@ M1K1 BEND US ENC CNT</Comment>
  Using stepper only for now</Comment>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1285100288</BitOffs>
+            <BitOffs>1284952704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fYRoll_urad</Name>
@@ -102856,7 +102488,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427712</BitOffs>
+            <BitOffs>1285280128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntYrightM1K2</Name>
@@ -102872,7 +102504,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427776</BitOffs>
+            <BitOffs>1285280192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXupM1K2</Name>
@@ -102888,7 +102520,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427808</BitOffs>
+            <BitOffs>1285280224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntXdwnM1K2</Name>
@@ -102904,7 +102536,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427840</BitOffs>
+            <BitOffs>1285280256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncCntPitchM1K2</Name>
@@ -102920,7 +102552,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427872</BitOffs>
+            <BitOffs>1285280288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYleftM1K2</Name>
@@ -102937,7 +102569,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427904</BitOffs>
+            <BitOffs>1285280320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefYrightM1K2</Name>
@@ -102953,7 +102585,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427936</BitOffs>
+            <BitOffs>1285280352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXupM1K2</Name>
@@ -102969,7 +102601,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285427968</BitOffs>
+            <BitOffs>1285280384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefXdwnM1K2</Name>
@@ -102985,7 +102617,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285428000</BitOffs>
+            <BitOffs>1285280416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.nEncRefPitchM1K2</Name>
@@ -103001,7 +102633,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285428032</BitOffs>
+            <BitOffs>1285280448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.eStateSet</Name>
@@ -103016,7 +102648,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285428064</BitOffs>
+            <BitOffs>1285280480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.eStateGet</Name>
@@ -103031,20 +102663,20 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285428080</BitOffs>
+            <BitOffs>1285280496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.mcReadParameterPitchM1K2</Name>
             <BitSize>4992</BitSize>
             <BaseType Namespace="Tc2_MC2">MC_ReadParameter</BaseType>
-            <BitOffs>1285428096</BitOffs>
+            <BitOffs>1285280512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncRefPitchM1K2_urad</Name>
             <Comment> Current Pitch encoder offset in urad</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1285433088</BitOffs>
+            <BitOffs>1285285504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fEncLeverArm_mm</Name>
@@ -103054,7 +102686,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>391</Value>
             </Default>
-            <BitOffs>1285433152</BitOffs>
+            <BitOffs>1285285568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1</Name>
@@ -103067,7 +102699,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1285433216</BitOffs>
+            <BitOffs>1285285632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_1_val</Name>
@@ -103083,7 +102715,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285433728</BitOffs>
+            <BitOffs>1285286144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2</Name>
@@ -103095,7 +102727,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1285433792</BitOffs>
+            <BitOffs>1285286208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Flow_2_val</Name>
@@ -103111,7 +102743,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285434304</BitOffs>
+            <BitOffs>1285286720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1</Name>
@@ -103123,7 +102755,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_M1K2_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1285434368</BitOffs>
+            <BitOffs>1285286784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fM1K2_Press_1_val</Name>
@@ -103139,7 +102771,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1285434880</BitOffs>
+            <BitOffs>1285287296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbCoatingStates</Name>
@@ -103151,13 +102783,13 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>pv: MR1K2:SWITCH:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1285434944</BitOffs>
+            <BitOffs>1285287360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.fbYSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1286976256</BitOffs>
+            <BitOffs>1286828672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR1K2_SWITCH.astCoatingStatesY</Name>
@@ -103167,7 +102799,7 @@ M1K1 BEND US ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1287068608</BitOffs>
+            <BitOffs>1286921024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.eStateSet</Name>
@@ -103182,43 +102814,43 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1287123696</BitOffs>
+            <BitOffs>1286976112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287123712</BitOffs>
+            <BitOffs>1286976128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_pi</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287451136</BitOffs>
+            <BitOffs>1287303552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_m_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1287778560</BitOffs>
+            <BitOffs>1287630976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_g_h</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1288105984</BitOffs>
+            <BitOffs>1287958400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_r</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1288433408</BitOffs>
+            <BitOffs>1288285824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbMotionStage_s_io</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1288760832</BitOffs>
+            <BitOffs>1288613248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.mpi_upeurad</Name>
@@ -103233,7 +102865,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289088512</BitOffs>
+            <BitOffs>1288940928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.gpi_upeurad</Name>
@@ -103248,7 +102880,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289088576</BitOffs>
+            <BitOffs>1288940992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD1</Name>
@@ -103271,7 +102903,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088640</BitOffs>
+            <BitOffs>1288941056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD2</Name>
@@ -103293,7 +102925,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289088896</BitOffs>
+            <BitOffs>1288941312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD3</Name>
@@ -103315,7 +102947,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089152</BitOffs>
+            <BitOffs>1288941568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD4</Name>
@@ -103337,7 +102969,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EP3204-0002-EP2]^RTD RTDInputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089408</BitOffs>
+            <BitOffs>1288941824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD5</Name>
@@ -103359,7 +102991,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089664</BitOffs>
+            <BitOffs>1288942080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD6</Name>
@@ -103381,7 +103013,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289089920</BitOffs>
+            <BitOffs>1288942336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD7</Name>
@@ -103403,7 +103035,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090176</BitOffs>
+            <BitOffs>1288942592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD8</Name>
@@ -103425,7 +103057,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E15]^RTD Inputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090432</BitOffs>
+            <BitOffs>1288942848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD9</Name>
@@ -103447,7 +103079,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 1^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090688</BitOffs>
+            <BitOffs>1288943104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD10</Name>
@@ -103469,7 +103101,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 2^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289090944</BitOffs>
+            <BitOffs>1288943360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD11</Name>
@@ -103491,7 +103123,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 3^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091200</BitOffs>
+            <BitOffs>1288943616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.RTD12</Name>
@@ -103513,7 +103145,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[SP1K1-EL3204-E16]^RTD Inputs Channel 4^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1289091456</BitOffs>
+            <BitOffs>1288943872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_read</Name>
@@ -103529,7 +103161,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289091712</BitOffs>
+            <BitOffs>1288944128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fipi_set</Name>
@@ -103544,7 +103176,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289091776</BitOffs>
+            <BitOffs>1288944192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_FFO</Name>
@@ -103564,7 +103196,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>4368</Value>
               </SubItem>
             </Default>
-            <BitOffs>1289091840</BitOffs>
+            <BitOffs>1288944256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.sd_io_e_pmps</Name>
@@ -103573,7 +103205,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>74000.29</Value>
             </Default>
-            <BitOffs>1289117760</BitOffs>
+            <BitOffs>1288970176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1</Name>
@@ -103586,7 +103218,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1289117824</BitOffs>
+            <BitOffs>1288970240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_1_val</Name>
@@ -103602,7 +103234,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289118336</BitOffs>
+            <BitOffs>1288970752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2</Name>
@@ -103614,7 +103246,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 2^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1289118400</BitOffs>
+            <BitOffs>1288970816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Flow_2_val</Name>
@@ -103630,7 +103262,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289118912</BitOffs>
+            <BitOffs>1288971328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1</Name>
@@ -103642,7 +103274,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3054_SP1K1_FWM_PRSM]^AI Standard Channel 3^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1289118976</BitOffs>
+            <BitOffs>1288971392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fSP1K1_Press_1_val</Name>
@@ -103658,7 +103290,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1289119488</BitOffs>
+            <BitOffs>1288971904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.stDefaultGH</Name>
@@ -103694,7 +103326,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Bool>true</Bool>
               </SubItem>
             </Default>
-            <BitOffs>1289119552</BitOffs>
+            <BitOffs>1288971968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGratingStates</Name>
@@ -103706,7 +103338,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>pv: SP1K1:MONO:GRATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1289123200</BitOffs>
+            <BitOffs>1288975616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.eStateGet</Name>
@@ -103721,7 +103353,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1290664512</BitOffs>
+            <BitOffs>1290516928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.bInit</Name>
@@ -103730,7 +103362,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1290664536</BitOffs>
+            <BitOffs>1290516952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.delta</Name>
@@ -103739,13 +103371,13 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1290664544</BitOffs>
+            <BitOffs>1290516960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.fbGHSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1290664576</BitOffs>
+            <BitOffs>1290516992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SP1K1_MONO.astGratingStates</Name>
@@ -103755,7 +103387,7 @@ M1K1 BEND US ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1290756928</BitOffs>
+            <BitOffs>1290609344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.FFO</Name>
@@ -103775,37 +103407,37 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>3664</Value>
               </SubItem>
             </Default>
-            <BitOffs>1290815808</BitOffs>
+            <BitOffs>1290668224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbPitch</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1290841728</BitOffs>
+            <BitOffs>1290694144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbRoll</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1291169152</BitOffs>
+            <BitOffs>1291021568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbVertical</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1291496576</BitOffs>
+            <BitOffs>1291348992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGap</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1291824000</BitOffs>
+            <BitOffs>1291676416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbYag</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1292151424</BitOffs>
+            <BitOffs>1292003840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbStates</Name>
@@ -103820,7 +103452,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1292478848</BitOffs>
+            <BitOffs>1292331264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_TOP</Name>
@@ -103841,7 +103473,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_1]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1293173568</BitOffs>
+            <BitOffs>1293025984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_Crystal_BOTTOM</Name>
@@ -103862,7 +103494,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_2]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1293173824</BitOffs>
+            <BitOffs>1293026240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_YAG</Name>
@@ -103883,7 +103515,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_4]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174080</BitOffs>
+            <BitOffs>1293026496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.RTD_HeatSync</Name>
@@ -103904,7 +103536,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bOverrange := TIIB[EL3201_SL1K2_3]^RTD^Status^Overrange</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174336</BitOffs>
+            <BitOffs>1293026752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbGige</Name>
@@ -103923,7 +103555,7 @@ M1K1 BEND US ENC CNT</Comment>
                               .bGigePower := TIIB[EL2004_SL1K2]^Channel 3^Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1293174592</BitOffs>
+            <BitOffs>1293027008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fbFlowMeter</Name>
@@ -103953,7 +103585,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>.iRaw := TIIB[EL3052_SL1K2_FWM]^AI Standard Channel 1^Value</Value>
               </Property>
             </Properties>
-            <BitOffs>1293175936</BitOffs>
+            <BitOffs>1293028352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fSmallDelta</Name>
@@ -103963,7 +103595,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.01</Value>
             </Default>
-            <BitOffs>1293176448</BitOffs>
+            <BitOffs>1293028864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fBigDelta</Name>
@@ -103972,7 +103604,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>10</Value>
             </Default>
-            <BitOffs>1293176512</BitOffs>
+            <BitOffs>1293028928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fMaxVelocity</Name>
@@ -103981,7 +103613,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.5</Value>
             </Default>
-            <BitOffs>1293176576</BitOffs>
+            <BitOffs>1293028992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fHighAccel</Name>
@@ -103990,7 +103622,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.8</Value>
             </Default>
-            <BitOffs>1293176640</BitOffs>
+            <BitOffs>1293029056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_SL1K2_EXIT.fLowAccel</Name>
@@ -103999,25 +103631,25 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0.1</Value>
             </Default>
-            <BitOffs>1293176704</BitOffs>
+            <BitOffs>1293029120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ST1K1_ZOS.fbZOS</Name>
             <BitSize>327424</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>1293176768</BitOffs>
+            <BitOffs>1293029184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fbArbiterIO</Name>
             <BitSize>145024</BitSize>
             <BaseType Namespace="PMPS">FB_SubSysToArbiter_IO</BaseType>
-            <BitOffs>1293505408</BitOffs>
+            <BitOffs>1293357824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.fb_vetoArbiter</Name>
             <BitSize>28352</BitSize>
             <BaseType Namespace="PMPS">FB_VetoArbiter</BaseType>
-            <BitOffs>1293650432</BitOffs>
+            <BitOffs>1293502848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ff2_ff1_link_optics</Name>
@@ -104041,7 +103673,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>65535</Value>
               </SubItem>
             </Default>
-            <BitOffs>1293678784</BitOffs>
+            <BitOffs>1293531200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX01</Name>
@@ -104066,7 +103698,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62729</Value>
               </SubItem>
             </Default>
-            <BitOffs>1293704704</BitOffs>
+            <BitOffs>1293557120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX02</Name>
@@ -104090,7 +103722,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62736</Value>
               </SubItem>
             </Default>
-            <BitOffs>1293730624</BitOffs>
+            <BitOffs>1293583040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_2_PMPS_POST.ffRIX05</Name>
@@ -104114,7 +103746,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62737</Value>
               </SubItem>
             </Default>
-            <BitOffs>1293756544</BitOffs>
+            <BitOffs>1293608960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeam</Name>
@@ -104139,7 +103771,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1293782464</BitOffs>
+            <BitOffs>1293634880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bSafeBenderRange</Name>
@@ -104155,7 +103787,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808384</BitOffs>
+            <BitOffs>1293660800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bLRG_Grating_IN</Name>
@@ -104171,7 +103803,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808392</BitOffs>
+            <BitOffs>1293660808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOS_IN</Name>
@@ -104187,7 +103819,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808400</BitOffs>
+            <BitOffs>1293660816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bZOB_on_Lower_Stopper</Name>
@@ -104203,7 +103835,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808408</BitOffs>
+            <BitOffs>1293660824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bMR1K1_Inserted</Name>
@@ -104219,7 +103851,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808416</BitOffs>
+            <BitOffs>1293660832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.bBeamPermitted</Name>
@@ -104235,7 +103867,7 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808424</BitOffs>
+            <BitOffs>1293660840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.nMachineMode</Name>
@@ -104253,110 +103885,110 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293808432</BitOffs>
+            <BitOffs>1293660848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808448</BitOffs>
+            <BitOffs>1293660864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808512</BitOffs>
+            <BitOffs>1293660928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808576</BitOffs>
+            <BitOffs>1293660992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808640</BitOffs>
+            <BitOffs>1293661056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.HZos</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808704</BitOffs>
+            <BitOffs>1293661120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808768</BitOffs>
+            <BitOffs>1293661184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808832</BitOffs>
+            <BitOffs>1293661248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808896</BitOffs>
+            <BitOffs>1293661312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293808960</BitOffs>
+            <BitOffs>1293661376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809024</BitOffs>
+            <BitOffs>1293661440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hbm3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809088</BitOffs>
+            <BitOffs>1293661504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hb0m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809152</BitOffs>
+            <BitOffs>1293661568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hm3</Name>
             <Comment>fixed calc</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809216</BitOffs>
+            <BitOffs>1293661632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hpiv</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809280</BitOffs>
+            <BitOffs>1293661696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m1</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809344</BitOffs>
+            <BitOffs>1293661760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809408</BitOffs>
+            <BitOffs>1293661824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta_m3</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809472</BitOffs>
+            <BitOffs>1293661888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Delta</Name>
@@ -104372,13 +104004,13 @@ M1K1 BEND US ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1293809536</BitOffs>
+            <BitOffs>1293661952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Ans</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1293809600</BitOffs>
+            <BitOffs>1293662016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.ffZeroOrderBeamExitSlits</Name>
@@ -104402,7 +104034,7 @@ M1K1 BEND US ENC CNT</Comment>
                 <Value>62726</Value>
               </SubItem>
             </Default>
-            <BitOffs>1293809664</BitOffs>
+            <BitOffs>1293662080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Hi2</Name>
@@ -104412,7 +104044,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>1.4</Value>
             </Default>
-            <BitOffs>1293835584</BitOffs>
+            <BitOffs>1293688000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zi2</Name>
@@ -104422,7 +104054,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>731.613</Value>
             </Default>
-            <BitOffs>1293835648</BitOffs>
+            <BitOffs>1293688064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Theta0</Name>
@@ -104431,7 +104063,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>0</Value>
             </Default>
-            <BitOffs>1293835712</BitOffs>
+            <BitOffs>1293688128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zm1</Name>
@@ -104441,7 +104073,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>733.772</Value>
             </Default>
-            <BitOffs>1293835776</BitOffs>
+            <BitOffs>1293688192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zmon</Name>
@@ -104451,7 +104083,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>739.622</Value>
             </Default>
-            <BitOffs>1293835840</BitOffs>
+            <BitOffs>1293688256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zpiv</Name>
@@ -104461,7 +104093,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>739.762</Value>
             </Default>
-            <BitOffs>1293835904</BitOffs>
+            <BitOffs>1293688320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Zzos</Name>
@@ -104471,7 +104103,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>741.422</Value>
             </Default>
-            <BitOffs>1293835968</BitOffs>
+            <BitOffs>1293688384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm1Offset</Name>
@@ -104480,7 +104112,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>18081.1</Value>
             </Default>
-            <BitOffs>1293836032</BitOffs>
+            <BitOffs>1293688448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm2Offset</Name>
@@ -104489,7 +104121,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>-90603</Value>
             </Default>
-            <BitOffs>1293836096</BitOffs>
+            <BitOffs>1293688512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_ZeroOrder_PMPS.Pm3Offset</Name>
@@ -104499,7 +104131,7 @@ M1K1 BEND US ENC CNT</Comment>
             <Default>
               <Value>-63300</Value>
             </Default>
-            <BitOffs>1293836160</BitOffs>
+            <BitOffs>1293688576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXRMSErrorM2K2</Name>
@@ -104513,19 +104145,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1293836864</BitOffs>
+            <BitOffs>1293689280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294224384</BitOffs>
+            <BitOffs>1294076800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294224448</BitOffs>
+            <BitOffs>1294076864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbYRMSErrorM2K2</Name>
@@ -104538,19 +104170,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1294224512</BitOffs>
+            <BitOffs>1294076928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294612032</BitOffs>
+            <BitOffs>1294464448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinYRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294612096</BitOffs>
+            <BitOffs>1294464512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbrXRMSErrorM2K2</Name>
@@ -104563,19 +104195,19 @@ MR2K2 X ENC RMS</Comment>
                 <Value>	pv: MR2K2:FLAT:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1294612160</BitOffs>
+            <BitOffs>1294464576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMaxrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294999680</BitOffs>
+            <BitOffs>1294852096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fMinrXRMSErrorM2K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1294999744</BitOffs>
+            <BitOffs>1294852160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefXM2K2</Name>
@@ -104593,7 +104225,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294999808</BitOffs>
+            <BitOffs>1294852224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefYM2K2</Name>
@@ -104610,7 +104242,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294999840</BitOffs>
+            <BitOffs>1294852256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncRefrXM2K2</Name>
@@ -104627,7 +104259,7 @@ MR2K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294999872</BitOffs>
+            <BitOffs>1294852288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntXM2K2</Name>
@@ -104645,7 +104277,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294999904</BitOffs>
+            <BitOffs>1294852320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntYM2K2</Name>
@@ -104662,7 +104294,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294999936</BitOffs>
+            <BitOffs>1294852352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.nEncCntrXM2K2</Name>
@@ -104679,7 +104311,7 @@ M2K2 FLAT X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1294999968</BitOffs>
+            <BitOffs>1294852384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.eStateSet</Name>
@@ -104694,7 +104326,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1295000016</BitOffs>
+            <BitOffs>1294852432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.eStateGet</Name>
@@ -104709,7 +104341,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1295000032</BitOffs>
+            <BitOffs>1294852448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoolingPanel</Name>
@@ -104730,7 +104362,7 @@ M2K2 FLAT X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1295000064</BitOffs>
+            <BitOffs>1294852480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates</Name>
@@ -104742,13 +104374,13 @@ M2K2 FLAT X ENC CNT</Comment>
                 <Value>pv: MR2K2:FLAT:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1295001856</BitOffs>
+            <BitOffs>1294854272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbXSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1296543168</BitOffs>
+            <BitOffs>1296395584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.astCoatingStatesX</Name>
@@ -104758,7 +104390,7 @@ M2K2 FLAT X ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1296635520</BitOffs>
+            <BitOffs>1296487936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbXRMSErrorM3K2</Name>
@@ -104772,19 +104404,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1296690240</BitOffs>
+            <BitOffs>1296542656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1297077760</BitOffs>
+            <BitOffs>1296930176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinXRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1297077824</BitOffs>
+            <BitOffs>1296930240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbYRMSErrorM3K2</Name>
@@ -104797,19 +104429,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1297077888</BitOffs>
+            <BitOffs>1296930304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1297465408</BitOffs>
+            <BitOffs>1297317824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1297465472</BitOffs>
+            <BitOffs>1297317888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbrYRMSErrorM3K2</Name>
@@ -104822,19 +104454,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1297465536</BitOffs>
+            <BitOffs>1297317952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1297853056</BitOffs>
+            <BitOffs>1297705472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinrYRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1297853120</BitOffs>
+            <BitOffs>1297705536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbUSRMSErrorM3K2</Name>
@@ -104847,19 +104479,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1297853184</BitOffs>
+            <BitOffs>1297705600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1298240704</BitOffs>
+            <BitOffs>1298093120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinUSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1298240768</BitOffs>
+            <BitOffs>1298093184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbdSRMSErrorM3K2</Name>
@@ -104872,19 +104504,19 @@ MR3K2 X ENC RMS</Comment>
                 <Value>	pv: MR3K2:KBH:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1298240832</BitOffs>
+            <BitOffs>1298093248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMaxDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1298628352</BitOffs>
+            <BitOffs>1298480768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fMinDSRMSErrorM3K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1298628416</BitOffs>
+            <BitOffs>1298480832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefXM3K2</Name>
@@ -104902,7 +104534,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628480</BitOffs>
+            <BitOffs>1298480896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefYM3K2</Name>
@@ -104919,7 +104551,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628512</BitOffs>
+            <BitOffs>1298480928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefrYM3K2</Name>
@@ -104936,7 +104568,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628544</BitOffs>
+            <BitOffs>1298480960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefUSM3K2</Name>
@@ -104953,7 +104585,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628576</BitOffs>
+            <BitOffs>1298480992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncRefDSM3K2</Name>
@@ -104970,7 +104602,7 @@ MR3K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628608</BitOffs>
+            <BitOffs>1298481024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntXM3K2</Name>
@@ -104988,7 +104620,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628640</BitOffs>
+            <BitOffs>1298481056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntYM3K2</Name>
@@ -105005,7 +104637,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628672</BitOffs>
+            <BitOffs>1298481088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntrYM3K2</Name>
@@ -105022,7 +104654,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628704</BitOffs>
+            <BitOffs>1298481120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntUSM3K2</Name>
@@ -105039,7 +104671,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628736</BitOffs>
+            <BitOffs>1298481152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.nEncCntDSM3K2</Name>
@@ -105056,7 +104688,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628768</BitOffs>
+            <BitOffs>1298481184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_1</Name>
@@ -105075,7 +104707,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628800</BitOffs>
+            <BitOffs>1298481216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2US_RTD_2</Name>
@@ -105092,7 +104724,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628832</BitOffs>
+            <BitOffs>1298481248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
@@ -105110,7 +104742,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628864</BitOffs>
+            <BitOffs>1298481280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -105127,7 +104759,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628896</BitOffs>
+            <BitOffs>1298481312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.eStateSet</Name>
@@ -105142,7 +104774,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628960</BitOffs>
+            <BitOffs>1298481376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.eStateGet</Name>
@@ -105157,7 +104789,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628976</BitOffs>
+            <BitOffs>1298481392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
@@ -105178,7 +104810,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628992</BitOffs>
+            <BitOffs>1298481408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates</Name>
@@ -105198,13 +104830,13 @@ M3K2 KBH X ENC CNT</Comment>
                 <Value>pv: MR3K2:KBH:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1298630208</BitOffs>
+            <BitOffs>1298482624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbYSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1300171520</BitOffs>
+            <BitOffs>1300023936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.astCoatingStatesY</Name>
@@ -105214,7 +104846,7 @@ M3K2 KBH X ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1300263872</BitOffs>
+            <BitOffs>1300116288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD</Name>
@@ -105237,7 +104869,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1300318592</BitOffs>
+            <BitOffs>1300171008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD</Name>
@@ -105260,7 +104892,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1300318848</BitOffs>
+            <BitOffs>1300171264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
@@ -105274,19 +104906,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:X</Value>
               </Property>
             </Properties>
-            <BitOffs>1300319104</BitOffs>
+            <BitOffs>1300171520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1300706624</BitOffs>
+            <BitOffs>1300559040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1300706688</BitOffs>
+            <BitOffs>1300559104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
@@ -105299,19 +104931,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:Y</Value>
               </Property>
             </Properties>
-            <BitOffs>1300706752</BitOffs>
+            <BitOffs>1300559168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1301094272</BitOffs>
+            <BitOffs>1300946688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1301094336</BitOffs>
+            <BitOffs>1300946752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
@@ -105324,19 +104956,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
               </Property>
             </Properties>
-            <BitOffs>1301094400</BitOffs>
+            <BitOffs>1300946816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1301481920</BitOffs>
+            <BitOffs>1301334336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1301481984</BitOffs>
+            <BitOffs>1301334400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
@@ -105349,19 +104981,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
               </Property>
             </Properties>
-            <BitOffs>1301482048</BitOffs>
+            <BitOffs>1301334464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1301869568</BitOffs>
+            <BitOffs>1301721984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1301869632</BitOffs>
+            <BitOffs>1301722048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
@@ -105374,19 +105006,19 @@ MR4K2 X ENC RMS</Comment>
                 <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
               </Property>
             </Properties>
-            <BitOffs>1301869696</BitOffs>
+            <BitOffs>1301722112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1302257216</BitOffs>
+            <BitOffs>1302109632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1302257280</BitOffs>
+            <BitOffs>1302109696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -105404,7 +105036,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257344</BitOffs>
+            <BitOffs>1302109760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -105421,7 +105053,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257376</BitOffs>
+            <BitOffs>1302109792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -105438,7 +105070,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257408</BitOffs>
+            <BitOffs>1302109824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -105455,7 +105087,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257440</BitOffs>
+            <BitOffs>1302109856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -105472,7 +105104,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257472</BitOffs>
+            <BitOffs>1302109888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -105490,7 +105122,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257504</BitOffs>
+            <BitOffs>1302109920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -105507,7 +105139,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257536</BitOffs>
+            <BitOffs>1302109952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -105524,7 +105156,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257568</BitOffs>
+            <BitOffs>1302109984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -105541,7 +105173,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257600</BitOffs>
+            <BitOffs>1302110016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -105558,7 +105190,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257632</BitOffs>
+            <BitOffs>1302110048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -105577,7 +105209,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257664</BitOffs>
+            <BitOffs>1302110080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -105594,7 +105226,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257696</BitOffs>
+            <BitOffs>1302110112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -105611,7 +105243,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257728</BitOffs>
+            <BitOffs>1302110144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -105629,7 +105261,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257760</BitOffs>
+            <BitOffs>1302110176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD</Name>
@@ -105652,7 +105284,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257792</BitOffs>
+            <BitOffs>1302110208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD</Name>
@@ -105675,7 +105307,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302258048</BitOffs>
+            <BitOffs>1302110464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
@@ -105696,7 +105328,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302258368</BitOffs>
+            <BitOffs>1302110784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates</Name>
@@ -105716,7 +105348,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Value>pv: MR4K2:KBV:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1302259584</BitOffs>
+            <BitOffs>1302112000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.eStateSet</Name>
@@ -105731,7 +105363,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1303800896</BitOffs>
+            <BitOffs>1303653312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.eStateGet</Name>
@@ -105746,13 +105378,13 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1303800912</BitOffs>
+            <BitOffs>1303653328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1303800960</BitOffs>
+            <BitOffs>1303653376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.astCoatingStatesX</Name>
@@ -105762,7 +105394,7 @@ M4K2 KBV X ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1303893312</BitOffs>
+            <BitOffs>1303745728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -105797,7 +105429,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303953088</BitOffs>
+            <BitOffs>1303805504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -105812,7 +105444,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955584</BitOffs>
+            <BitOffs>1303808000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -105826,7 +105458,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955648</BitOffs>
+            <BitOffs>1303808064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -105841,7 +105473,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955712</BitOffs>
+            <BitOffs>1303808128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -105856,7 +105488,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955776</BitOffs>
+            <BitOffs>1303808192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -105871,7 +105503,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955840</BitOffs>
+            <BitOffs>1303808256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -105886,7 +105518,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955904</BitOffs>
+            <BitOffs>1303808320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -105902,7 +105534,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956032</BitOffs>
+            <BitOffs>1303808448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -105916,7 +105548,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956096</BitOffs>
+            <BitOffs>1303808512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -105930,7 +105562,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956160</BitOffs>
+            <BitOffs>1303808576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -105944,7 +105576,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303956224</BitOffs>
+            <BitOffs>1303808640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -105959,7 +105591,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958784</BitOffs>
+            <BitOffs>1303811200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -105974,7 +105606,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958848</BitOffs>
+            <BitOffs>1303811264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -105989,7 +105621,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958912</BitOffs>
+            <BitOffs>1303811328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -106005,7 +105637,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958976</BitOffs>
+            <BitOffs>1303811392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -106019,7 +105651,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959040</BitOffs>
+            <BitOffs>1303811456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -106033,7 +105665,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959104</BitOffs>
+            <BitOffs>1303811520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -106048,7 +105680,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959168</BitOffs>
+            <BitOffs>1303811584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -106063,7 +105695,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959232</BitOffs>
+            <BitOffs>1303811648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -106079,7 +105711,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959360</BitOffs>
+            <BitOffs>1303811776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -106093,7 +105725,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959424</BitOffs>
+            <BitOffs>1303811840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -106107,7 +105739,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959488</BitOffs>
+            <BitOffs>1303811904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -106122,7 +105754,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959552</BitOffs>
+            <BitOffs>1303811968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -106137,7 +105769,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959616</BitOffs>
+            <BitOffs>1303812032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -106152,7 +105784,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959680</BitOffs>
+            <BitOffs>1303812096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -106167,7 +105799,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959744</BitOffs>
+            <BitOffs>1303812160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -106182,7 +105814,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959808</BitOffs>
+            <BitOffs>1303812224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -106197,7 +105829,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959872</BitOffs>
+            <BitOffs>1303812288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.fRollLeverArm_um</Name>
@@ -106212,7 +105844,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959968</BitOffs>
+            <BitOffs>1303812384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
@@ -106228,7 +105860,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960000</BitOffs>
+            <BitOffs>1303812416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
@@ -106242,7 +105874,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960064</BitOffs>
+            <BitOffs>1303812480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
@@ -106256,7 +105888,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960128</BitOffs>
+            <BitOffs>1303812544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
@@ -106270,7 +105902,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960192</BitOffs>
+            <BitOffs>1303812608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -106288,7 +105920,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960256</BitOffs>
+            <BitOffs>1303812672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -106306,7 +105938,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304456000</BitOffs>
+            <BitOffs>1304308416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -106335,7 +105967,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304951744</BitOffs>
+            <BitOffs>1304804160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2</Name>
@@ -106364,7 +105996,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1305598016</BitOffs>
+            <BitOffs>1305450432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.rPhotonEnergy</Name>
@@ -106375,7 +106007,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306244288</BitOffs>
+            <BitOffs>1306096704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetY</Name>
@@ -106416,7 +106048,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306244736</BitOffs>
+            <BitOffs>1306097152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetX</Name>
@@ -106457,7 +106089,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306248384</BitOffs>
+            <BitOffs>1306100800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBX</Name>
@@ -106498,7 +106130,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306252032</BitOffs>
+            <BitOffs>1306104448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBY</Name>
@@ -106539,200 +106171,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306255680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
-            <BitSize>646272</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.bAutoReset</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.42.126.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1305597760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_States.stDefaultOffsetY</Name>
-            <BitSize>3648</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fDelta</Name>
-                <Value>2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fAccel</Name>
-                <Value>5050</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fDecel</Name>
-                <Value>5050</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bMoveOk</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bValid</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bUseRawCounts</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306244416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_States.stDefaultOffsetX</Name>
-            <BitSize>3648</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fDelta</Name>
-                <Value>10000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fAccel</Name>
-                <Value>1000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fDecel</Name>
-                <Value>1000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bMoveOk</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bValid</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bUseRawCounts</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306248064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_States.stDefaultKBX</Name>
-            <BitSize>3648</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fDelta</Name>
-                <Value>5</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fAccel</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fDecel</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bMoveOk</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bValid</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bUseRawCounts</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306251712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_States.stDefaultKBY</Name>
-            <BitSize>3648</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fDelta</Name>
-                <Value>5</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fAccel</Name>
-                <Value>10</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.fDecel</Name>
-                <Value>10</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bMoveOk</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bValid</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.bUseRawCounts</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306255360</BitOffs>
+            <BitOffs>1306108096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -106770,7 +106209,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306259328</BitOffs>
+            <BitOffs>1306111744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
@@ -106781,7 +106220,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306285248</BitOffs>
+            <BitOffs>1306137664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -106819,7 +106258,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306612672</BitOffs>
+            <BitOffs>1306465088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
@@ -106830,7 +106269,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306638592</BitOffs>
+            <BitOffs>1306491008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -106868,7 +106307,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306966016</BitOffs>
+            <BitOffs>1306818432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
@@ -106879,7 +106318,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306991936</BitOffs>
+            <BitOffs>1306844352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -106917,7 +106356,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307319360</BitOffs>
+            <BitOffs>1307171776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
@@ -106928,7 +106367,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307345280</BitOffs>
+            <BitOffs>1307197696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -106965,7 +106404,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307672704</BitOffs>
+            <BitOffs>1307525120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -107003,7 +106442,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307698624</BitOffs>
+            <BitOffs>1307551040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
@@ -107041,7 +106480,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307750464</BitOffs>
+            <BitOffs>1307602880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
@@ -107079,7 +106518,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307776384</BitOffs>
+            <BitOffs>1307628800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10</Name>
@@ -107116,7 +106555,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307802304</BitOffs>
+            <BitOffs>1307654720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11</Name>
@@ -107148,7 +106587,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307828224</BitOffs>
+            <BitOffs>1307680640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12</Name>
@@ -107186,7 +106625,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307854144</BitOffs>
+            <BitOffs>1307706560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12</Name>
@@ -107197,7 +106636,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307880064</BitOffs>
+            <BitOffs>1307732480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13</Name>
@@ -107234,7 +106673,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1308207488</BitOffs>
+            <BitOffs>1308059904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13</Name>
@@ -107245,7 +106684,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1308233408</BitOffs>
+            <BitOffs>1308085824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14</Name>
@@ -107283,7 +106722,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1308560832</BitOffs>
+            <BitOffs>1308413248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14</Name>
@@ -107294,7 +106733,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1308586752</BitOffs>
+            <BitOffs>1308439168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15</Name>
@@ -107331,7 +106770,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1308914176</BitOffs>
+            <BitOffs>1308766592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15</Name>
@@ -107342,7 +106781,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1308940096</BitOffs>
+            <BitOffs>1308792512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16</Name>
@@ -107380,7 +106819,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1309267520</BitOffs>
+            <BitOffs>1309119936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17</Name>
@@ -107413,7 +106852,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1309293440</BitOffs>
+            <BitOffs>1309145856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17</Name>
@@ -107424,7 +106863,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1309319360</BitOffs>
+            <BitOffs>1309171776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18</Name>
@@ -107458,7 +106897,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1309646784</BitOffs>
+            <BitOffs>1309499200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18</Name>
@@ -107469,7 +106908,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1309672704</BitOffs>
+            <BitOffs>1309525120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19</Name>
@@ -107503,7 +106942,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310000128</BitOffs>
+            <BitOffs>1309852544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20</Name>
@@ -107537,7 +106976,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310026048</BitOffs>
+            <BitOffs>1309878464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21</Name>
@@ -107571,7 +107010,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310051968</BitOffs>
+            <BitOffs>1309904384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22</Name>
@@ -107605,7 +107044,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310077888</BitOffs>
+            <BitOffs>1309930304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23</Name>
@@ -107639,7 +107078,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310103808</BitOffs>
+            <BitOffs>1309956224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24</Name>
@@ -107668,7 +107107,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310129728</BitOffs>
+            <BitOffs>1309982144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25</Name>
@@ -107700,7 +107139,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310155648</BitOffs>
+            <BitOffs>1310008064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25</Name>
@@ -107711,7 +107150,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310181568</BitOffs>
+            <BitOffs>1310033984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26</Name>
@@ -107743,7 +107182,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310508992</BitOffs>
+            <BitOffs>1310361408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26</Name>
@@ -107754,7 +107193,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310534912</BitOffs>
+            <BitOffs>1310387328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27</Name>
@@ -107786,7 +107225,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310862336</BitOffs>
+            <BitOffs>1310714752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27</Name>
@@ -107797,7 +107236,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1310888256</BitOffs>
+            <BitOffs>1310740672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28</Name>
@@ -107829,7 +107268,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1311215680</BitOffs>
+            <BitOffs>1311068096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28</Name>
@@ -107840,7 +107279,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1311241600</BitOffs>
+            <BitOffs>1311094016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29</Name>
@@ -107872,7 +107311,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1311569024</BitOffs>
+            <BitOffs>1311421440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29</Name>
@@ -107883,7 +107322,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1311594944</BitOffs>
+            <BitOffs>1311447360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30</Name>
@@ -107915,7 +107354,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1311922368</BitOffs>
+            <BitOffs>1311774784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30</Name>
@@ -107926,7 +107365,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1311948288</BitOffs>
+            <BitOffs>1311800704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31</Name>
@@ -107958,7 +107397,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1312275712</BitOffs>
+            <BitOffs>1312128128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31</Name>
@@ -107969,7 +107408,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1312301632</BitOffs>
+            <BitOffs>1312154048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32</Name>
@@ -108001,7 +107440,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1312629056</BitOffs>
+            <BitOffs>1312481472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32</Name>
@@ -108012,7 +107451,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1312654976</BitOffs>
+            <BitOffs>1312507392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33</Name>
@@ -108044,7 +107483,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1312982400</BitOffs>
+            <BitOffs>1312834816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33</Name>
@@ -108055,7 +107494,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1313008320</BitOffs>
+            <BitOffs>1312860736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34</Name>
@@ -108087,7 +107526,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1313335744</BitOffs>
+            <BitOffs>1313188160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34</Name>
@@ -108098,7 +107537,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1313361664</BitOffs>
+            <BitOffs>1313214080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35</Name>
@@ -108130,7 +107569,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1313689088</BitOffs>
+            <BitOffs>1313541504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35</Name>
@@ -108141,7 +107580,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1313715008</BitOffs>
+            <BitOffs>1313567424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36</Name>
@@ -108173,7 +107612,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314042432</BitOffs>
+            <BitOffs>1313894848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36</Name>
@@ -108184,7 +107623,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314068352</BitOffs>
+            <BitOffs>1313920768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37</Name>
@@ -108216,7 +107655,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314395776</BitOffs>
+            <BitOffs>1314248192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37</Name>
@@ -108227,7 +107666,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314421696</BitOffs>
+            <BitOffs>1314274112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.dummyBool</Name>
@@ -108238,7 +107677,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749120</BitOffs>
+            <BitOffs>1314601536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -108253,7 +107692,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749136</BitOffs>
+            <BitOffs>1314601552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -108268,7 +107707,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749144</BitOffs>
+            <BitOffs>1314601560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -108298,7 +107737,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749152</BitOffs>
+            <BitOffs>1314601568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -108328,7 +107767,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749216</BitOffs>
+            <BitOffs>1314601632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -108343,7 +107782,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749280</BitOffs>
+            <BitOffs>1314601696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -108358,7 +107797,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749296</BitOffs>
+            <BitOffs>1314601712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -108373,7 +107812,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749312</BitOffs>
+            <BitOffs>1314601728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -108387,7 +107826,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749320</BitOffs>
+            <BitOffs>1314601736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -108402,7 +107841,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749344</BitOffs>
+            <BitOffs>1314601760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -108417,7 +107856,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749376</BitOffs>
+            <BitOffs>1314601792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -108538,7 +107977,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314749408</BitOffs>
+            <BitOffs>1314601824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -108552,7 +107991,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758880</BitOffs>
+            <BitOffs>1314611296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -108566,7 +108005,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314758912</BitOffs>
+            <BitOffs>1314611328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -108587,7 +108026,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314762560</BitOffs>
+            <BitOffs>1314614976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -108659,7 +108098,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314780480</BitOffs>
+            <BitOffs>1314632896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -108731,7 +108170,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314780608</BitOffs>
+            <BitOffs>1314633024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -108803,7 +108242,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314780736</BitOffs>
+            <BitOffs>1314633152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -108875,7 +108314,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314780864</BitOffs>
+            <BitOffs>1314633280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -108947,7 +108386,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314780992</BitOffs>
+            <BitOffs>1314633408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -109019,7 +108458,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314781120</BitOffs>
+            <BitOffs>1314633536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -109091,7 +108530,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314781248</BitOffs>
+            <BitOffs>1314633664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -109163,7 +108602,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314781376</BitOffs>
+            <BitOffs>1314633792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -109189,7 +108628,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314814400</BitOffs>
+            <BitOffs>1314666816</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -109282,7 +108721,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-11-11T08:48:44</Value>
+          <Value>2024-11-19T11:17:57</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
@@ -109290,7 +108729,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>164003840</Value>
+          <Value>163987456</Value>
         </Property>
       </Properties>
     </Module>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82277,7 +82277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82298,7 +82298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82396,7 +82396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82414,7 +82414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82572,7 +82572,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -82669,7 +82669,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82724,7 +82724,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -83201,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -92400,7 +92400,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -94592,7 +94592,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -108983,7 +108983,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165609472</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109069,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-11-05T15:47:38</Value>
+          <Value>2024-11-05T16:03:18</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{E6887738-6106-B3EA-6F44-1758ABE554CA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -10419,31 +10419,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164353168</GetCodeOffs>
+        <GetCodeOffs>164383680</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164353240</GetCodeOffs>
+        <GetCodeOffs>164383752</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353256</GetCodeOffs>
+        <GetCodeOffs>164383768</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353216</GetCodeOffs>
+        <GetCodeOffs>164383728</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353248</GetCodeOffs>
+        <GetCodeOffs>164383760</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11695,15 +11695,15 @@ External Setpoint Generation:
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353040</GetCodeOffs>
-        <SetCodeOffs>164353088</SetCodeOffs>
+        <GetCodeOffs>164383552</GetCodeOffs>
+        <SetCodeOffs>164383600</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353120</GetCodeOffs>
-        <SetCodeOffs>164353144</SetCodeOffs>
+        <GetCodeOffs>164383632</GetCodeOffs>
+        <SetCodeOffs>164383656</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11944,31 +11944,31 @@ External Setpoint Generation:
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>164353352</GetCodeOffs>
+        <GetCodeOffs>164383864</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164353312</GetCodeOffs>
+        <GetCodeOffs>164383824</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353488</GetCodeOffs>
+        <GetCodeOffs>164384000</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164353496</GetCodeOffs>
+        <GetCodeOffs>164384008</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353408</GetCodeOffs>
+        <GetCodeOffs>164383920</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -11980,7 +11980,7 @@ External Setpoint Generation:
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164353504</GetCodeOffs>
+        <GetCodeOffs>164384016</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -12573,7 +12573,7 @@ External Setpoint Generation:
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164353560</GetCodeOffs>
+        <GetCodeOffs>164384072</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -29737,14 +29737,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164359904</GetCodeOffs>
+        <GetCodeOffs>164390416</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164359808</GetCodeOffs>
+        <GetCodeOffs>164390320</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -30840,7 +30840,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164360056</GetCodeOffs>
+        <GetCodeOffs>164390568</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -31499,7 +31499,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164360168</GetCodeOffs>
+        <GetCodeOffs>164390680</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -41537,7 +41537,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>164366856</GetCodeOffs>
+        <GetCodeOffs>164397368</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -43465,31 +43465,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164366256</GetCodeOffs>
+        <GetCodeOffs>164396768</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>164366344</GetCodeOffs>
+        <GetCodeOffs>164396856</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164366272</GetCodeOffs>
+        <GetCodeOffs>164396784</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>164366320</GetCodeOffs>
+        <GetCodeOffs>164396832</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>164366360</GetCodeOffs>
+        <GetCodeOffs>164396872</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82270,14 +82270,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306000192</BitOffs>
+            <BitOffs>1306244320</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82291,14 +82291,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1306000384</BitOffs>
+            <BitOffs>1306244512</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82315,7 +82315,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303947648</BitOffs>
+            <BitOffs>1303948032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K2</Name>
@@ -82326,7 +82326,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303950160</BitOffs>
+            <BitOffs>1303950544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -82340,7 +82340,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314507296</BitOffs>
+            <BitOffs>1314751456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -82354,7 +82354,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314507328</BitOffs>
+            <BitOffs>1314751488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -82368,7 +82368,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514496</BitOffs>
+            <BitOffs>1314758656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -82389,14 +82389,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514816</BitOffs>
+            <BitOffs>1314758976</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82407,14 +82407,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307466880</BitOffs>
+            <BitOffs>1307725632</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82516,7 +82516,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307465792</BitOffs>
+            <BitOffs>1307724544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_StatsTask</Name>
@@ -82530,7 +82530,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514528</BitOffs>
+            <BitOffs>1314758688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_StatsTask</Name>
@@ -82544,7 +82544,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514560</BitOffs>
+            <BitOffs>1314758720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__StatsTask</Name>
@@ -82565,20 +82565,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314515712</BitOffs>
+            <BitOffs>1314759872</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265016832</BitOffs>
+            <BitOffs>1265797632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -82613,7 +82613,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955904</BitOffs>
+            <BitOffs>1303956288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -82627,7 +82627,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514592</BitOffs>
+            <BitOffs>1314758752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -82641,7 +82641,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514624</BitOffs>
+            <BitOffs>1314758784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -82662,14 +82662,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314516608</BitOffs>
+            <BitOffs>1314760768</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82685,7 +82685,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133632</BitOffs>
+            <BitOffs>1265017536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -82701,7 +82701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133696</BitOffs>
+            <BitOffs>1265017600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -82717,14 +82717,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265133760</BitOffs>
+            <BitOffs>1265017664</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -82868,7 +82868,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265133824</BitOffs>
+            <BitOffs>1265017728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -82877,7 +82877,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265134472</BitOffs>
+            <BitOffs>1265018376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -82886,14 +82886,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265134480</BitOffs>
+            <BitOffs>1265018384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265134488</BitOffs>
+            <BitOffs>1265018392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -82902,20 +82902,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265134496</BitOffs>
+            <BitOffs>1265018400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134528</BitOffs>
+            <BitOffs>1265018432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134592</BitOffs>
+            <BitOffs>1265018496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -82924,19 +82924,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265134656</BitOffs>
+            <BitOffs>1265018560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265134720</BitOffs>
+            <BitOffs>1265018624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265134784</BitOffs>
+            <BitOffs>1265018688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -82951,25 +82951,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265134848</BitOffs>
+            <BitOffs>1265018752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265134912</BitOffs>
+            <BitOffs>1265018816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135168</BitOffs>
+            <BitOffs>1265019072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265135232</BitOffs>
+            <BitOffs>1265019136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -82978,19 +82978,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265135296</BitOffs>
+            <BitOffs>1265019200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135360</BitOffs>
+            <BitOffs>1265019264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265135424</BitOffs>
+            <BitOffs>1265019328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -83005,67 +83005,67 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265135488</BitOffs>
+            <BitOffs>1265019392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265135552</BitOffs>
+            <BitOffs>1265019456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265136576</BitOffs>
+            <BitOffs>1265020480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136640</BitOffs>
+            <BitOffs>1265020544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136704</BitOffs>
+            <BitOffs>1265020608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265136768</BitOffs>
+            <BitOffs>1265020672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265136832</BitOffs>
+            <BitOffs>1265020736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265247424</BitOffs>
+            <BitOffs>1265131328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265522624</BitOffs>
+            <BitOffs>1265406528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265633216</BitOffs>
+            <BitOffs>1265517120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265908416</BitOffs>
+            <BitOffs>1265792320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -83077,7 +83077,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265908928</BitOffs>
+            <BitOffs>1265792832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -83089,14 +83089,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265909504</BitOffs>
+            <BitOffs>1265793408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265910336</BitOffs>
+            <BitOffs>1265794240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -83112,7 +83112,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265910592</BitOffs>
+            <BitOffs>1265794496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -83127,7 +83127,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265910624</BitOffs>
+            <BitOffs>1265794528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -83145,7 +83145,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314509376</BitOffs>
+            <BitOffs>1314753536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_DaqTask</Name>
@@ -83159,7 +83159,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514656</BitOffs>
+            <BitOffs>1314758816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_DaqTask</Name>
@@ -83173,7 +83173,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514688</BitOffs>
+            <BitOffs>1314758848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__DaqTask</Name>
@@ -83194,14 +83194,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314517504</BitOffs>
+            <BitOffs>1314761664</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -86490,18 +86490,6 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1296362256</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.bM3K2US_RTD_3_Err</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298628992</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_1_Err</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
@@ -86511,19 +86499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_2_Err</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298629008</BitOffs>
+            <BitOffs>1298628928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.bM3K2DS_RTD_3_Err</Name>
@@ -86535,7 +86511,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629016</BitOffs>
+            <BitOffs>1298628936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable1</Name>
@@ -86552,7 +86528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629024</BitOffs>
+            <BitOffs>1298628944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.M3K2KBHbSTOEnable2</Name>
@@ -86568,7 +86544,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629032</BitOffs>
+            <BitOffs>1298628952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -86581,7 +86557,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629312</BitOffs>
+            <BitOffs>1298629248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -86594,7 +86570,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1298629824</BitOffs>
+            <BitOffs>1298629760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -86606,7 +86582,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299930752</BitOffs>
+            <BitOffs>1299930688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -86619,7 +86595,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938688</BitOffs>
+            <BitOffs>1299938624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -86632,7 +86608,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938696</BitOffs>
+            <BitOffs>1299938632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -86645,7 +86621,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938704</BitOffs>
+            <BitOffs>1299938640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -86668,7 +86644,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938720</BitOffs>
+            <BitOffs>1299938656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -86681,7 +86657,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938752</BitOffs>
+            <BitOffs>1299938688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -86694,7 +86670,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938816</BitOffs>
+            <BitOffs>1299938752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -86707,7 +86683,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938832</BitOffs>
+            <BitOffs>1299938768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -86719,7 +86695,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299956672</BitOffs>
+            <BitOffs>1299956608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -86732,7 +86708,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964608</BitOffs>
+            <BitOffs>1299964544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -86745,7 +86721,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964616</BitOffs>
+            <BitOffs>1299964552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -86758,7 +86734,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964624</BitOffs>
+            <BitOffs>1299964560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -86781,7 +86757,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964640</BitOffs>
+            <BitOffs>1299964576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -86794,7 +86770,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964672</BitOffs>
+            <BitOffs>1299964608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -86807,7 +86783,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964736</BitOffs>
+            <BitOffs>1299964672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -86820,7 +86796,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964752</BitOffs>
+            <BitOffs>1299964688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -86832,7 +86808,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299982592</BitOffs>
+            <BitOffs>1299982528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -86845,7 +86821,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990528</BitOffs>
+            <BitOffs>1299990464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -86858,7 +86834,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990536</BitOffs>
+            <BitOffs>1299990472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -86871,7 +86847,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990544</BitOffs>
+            <BitOffs>1299990480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -86894,7 +86870,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990560</BitOffs>
+            <BitOffs>1299990496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -86907,7 +86883,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990592</BitOffs>
+            <BitOffs>1299990528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -86920,7 +86896,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990656</BitOffs>
+            <BitOffs>1299990592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -86933,7 +86909,247 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990672</BitOffs>
+            <BitOffs>1299990608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302257992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1302258272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_1_Err</Name>
@@ -86946,7 +87162,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300171600</BitOffs>
+            <BitOffs>1302258304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_2_Err</Name>
@@ -86958,7 +87174,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1300171608</BitOffs>
+            <BitOffs>1302258312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2US_RTD_3_Err</Name>
@@ -86970,7 +87186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257440</BitOffs>
+            <BitOffs>1302258320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_1_Err</Name>
@@ -86982,7 +87198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257448</BitOffs>
+            <BitOffs>1302258328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_2_Err</Name>
@@ -86994,7 +87210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257456</BitOffs>
+            <BitOffs>1302258336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.bM4K2DS_RTD_3_Err</Name>
@@ -87006,127 +87222,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bError</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: ERR
-        io: input
-        field: ONAM True
-        field: ZNAM False
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bUnderrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.bOverrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD.iRaw</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bError</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: ERR
-        io: input
-        field: ONAM True
-        field: ZNAM False
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bUnderrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.bOverrange</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD.iRaw</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257952</BitOffs>
+            <BitOffs>1302258344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable1</Name>
@@ -87143,7 +87239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257984</BitOffs>
+            <BitOffs>1302258352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.M4K2KBVbSTOEnable2</Name>
@@ -87159,27 +87255,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302257992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
-            <Comment> M1K1 US RTDs</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M1K1US1_M1K1US2]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1302258032</BitOffs>
+            <BitOffs>1302258360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbFlow_1.iRaw</Name>
@@ -87192,7 +87268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258304</BitOffs>
+            <BitOffs>1302258624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel.fbPress_1.iRaw</Name>
@@ -87205,7 +87281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1302258816</BitOffs>
+            <BitOffs>1302259136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].Axis.NcToPlc</Name>
@@ -87217,7 +87293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303559744</BitOffs>
+            <BitOffs>1303560064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bLimitForwardEnable</Name>
@@ -87230,7 +87306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567680</BitOffs>
+            <BitOffs>1303568000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bLimitBackwardEnable</Name>
@@ -87243,7 +87319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567688</BitOffs>
+            <BitOffs>1303568008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bHome</Name>
@@ -87256,7 +87332,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567696</BitOffs>
+            <BitOffs>1303568016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bHardwareEnable</Name>
@@ -87279,7 +87355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567712</BitOffs>
+            <BitOffs>1303568032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderULINT</Name>
@@ -87292,7 +87368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567744</BitOffs>
+            <BitOffs>1303568064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderUINT</Name>
@@ -87305,7 +87381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567808</BitOffs>
+            <BitOffs>1303568128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].nRawEncoderINT</Name>
@@ -87318,7 +87394,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567824</BitOffs>
+            <BitOffs>1303568144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].Axis.NcToPlc</Name>
@@ -87330,7 +87406,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303585664</BitOffs>
+            <BitOffs>1303585984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bLimitForwardEnable</Name>
@@ -87343,7 +87419,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593600</BitOffs>
+            <BitOffs>1303593920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bLimitBackwardEnable</Name>
@@ -87356,7 +87432,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593608</BitOffs>
+            <BitOffs>1303593928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bHome</Name>
@@ -87369,7 +87445,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593616</BitOffs>
+            <BitOffs>1303593936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bHardwareEnable</Name>
@@ -87392,7 +87468,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593632</BitOffs>
+            <BitOffs>1303593952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderULINT</Name>
@@ -87405,7 +87481,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593664</BitOffs>
+            <BitOffs>1303593984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderUINT</Name>
@@ -87418,7 +87494,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593728</BitOffs>
+            <BitOffs>1303594048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].nRawEncoderINT</Name>
@@ -87431,7 +87507,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593744</BitOffs>
+            <BitOffs>1303594064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].Axis.NcToPlc</Name>
@@ -87443,7 +87519,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303611584</BitOffs>
+            <BitOffs>1303611904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bLimitForwardEnable</Name>
@@ -87456,7 +87532,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619520</BitOffs>
+            <BitOffs>1303619840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bLimitBackwardEnable</Name>
@@ -87469,7 +87545,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619528</BitOffs>
+            <BitOffs>1303619848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bHome</Name>
@@ -87482,7 +87558,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619536</BitOffs>
+            <BitOffs>1303619856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bHardwareEnable</Name>
@@ -87505,7 +87581,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619552</BitOffs>
+            <BitOffs>1303619872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderULINT</Name>
@@ -87518,7 +87594,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619584</BitOffs>
+            <BitOffs>1303619904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderUINT</Name>
@@ -87531,7 +87607,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619648</BitOffs>
+            <BitOffs>1303619968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].nRawEncoderINT</Name>
@@ -87544,7 +87620,27 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619664</BitOffs>
+            <BitOffs>1303619984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_1</Name>
+            <Comment> M1K1 US RTDs</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>TIIB[EL3202-0010_M1K1US1_M1K1US2]^RTD Inputs Channel 1^Value</Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303800928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_2</Name>
@@ -87563,7 +87659,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303952672</BitOffs>
+            <BitOffs>1303800944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1US_RTD_3</Name>
@@ -87582,20 +87678,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303952688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1303955136</BitOffs>
+            <BitOffs>1303953056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_1</Name>
@@ -87615,7 +87698,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955584</BitOffs>
+            <BitOffs>1303953072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K1.M1K1_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1303955520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_2</Name>
@@ -87634,7 +87730,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955600</BitOffs>
+            <BitOffs>1303955968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_RTD.nM1K1DS_RTD_3</Name>
@@ -87653,7 +87749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955616</BitOffs>
+            <BitOffs>1303955984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_1</Name>
@@ -87673,20 +87769,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1303958336</BitOffs>
+            <BitOffs>1303956000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_RTD_2</Name>
@@ -87705,26 +87788,20 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958912</BitOffs>
+            <BitOffs>1303956016</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_M3K2.nM3K2US_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>GVL_M1K2.M1K2_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
             <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value</Value>
-              </Property>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
             </Properties>
-            <BitOffs>1303958928</BitOffs>
+            <BitOffs>1303958720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_1</Name>
@@ -87744,26 +87821,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M3K2.nM3K2DS_RTD_2</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303958960</BitOffs>
+            <BitOffs>1303959296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_RTD_3</Name>
@@ -87782,7 +87840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958976</BitOffs>
+            <BitOffs>1303959312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_1</Name>
@@ -87802,7 +87860,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958992</BitOffs>
+            <BitOffs>1303959328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_2</Name>
@@ -87821,7 +87879,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959008</BitOffs>
+            <BitOffs>1303959344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_RTD_3</Name>
@@ -87840,7 +87898,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959024</BitOffs>
+            <BitOffs>1303959936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_RTD_1</Name>
@@ -87860,45 +87918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M4K2.nM4K2DS_RTD_2</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 1^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M4K2.nM4K2DS_RTD_3</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>TIIB[EL3202-0010_M4K2DS2_M4K2DS3]^RTD Inputs Channel 2^Value</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959648</BitOffs>
+            <BitOffs>1303959952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sio_current</Name>
@@ -87913,7 +87933,22 @@ Emergency Stop for MR1K1</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959664</BitOffs>
+            <BitOffs>1306244704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.sio_load</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306244720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
@@ -87925,7 +87960,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306001664</BitOffs>
+            <BitOffs>1306260416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -87938,7 +87973,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009600</BitOffs>
+            <BitOffs>1306268352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -87951,7 +87986,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009608</BitOffs>
+            <BitOffs>1306268360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -87964,7 +87999,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009616</BitOffs>
+            <BitOffs>1306268368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -87987,7 +88022,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009632</BitOffs>
+            <BitOffs>1306268384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -88000,7 +88035,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009664</BitOffs>
+            <BitOffs>1306268416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -88013,7 +88048,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009728</BitOffs>
+            <BitOffs>1306268480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -88026,7 +88061,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306009744</BitOffs>
+            <BitOffs>1306268496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88038,7 +88073,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306029120</BitOffs>
+            <BitOffs>1306287872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -88050,7 +88085,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306355008</BitOffs>
+            <BitOffs>1306613760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -88063,7 +88098,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362944</BitOffs>
+            <BitOffs>1306621696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -88076,7 +88111,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362952</BitOffs>
+            <BitOffs>1306621704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -88089,7 +88124,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362960</BitOffs>
+            <BitOffs>1306621712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -88112,7 +88147,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306362976</BitOffs>
+            <BitOffs>1306621728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -88125,7 +88160,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363008</BitOffs>
+            <BitOffs>1306621760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -88138,7 +88173,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363072</BitOffs>
+            <BitOffs>1306621824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -88151,7 +88186,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306363088</BitOffs>
+            <BitOffs>1306621840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88163,7 +88198,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306382464</BitOffs>
+            <BitOffs>1306641216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -88175,7 +88210,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306708352</BitOffs>
+            <BitOffs>1306967104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -88188,7 +88223,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716288</BitOffs>
+            <BitOffs>1306975040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -88201,7 +88236,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716296</BitOffs>
+            <BitOffs>1306975048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -88214,7 +88249,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716304</BitOffs>
+            <BitOffs>1306975056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -88237,7 +88272,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716320</BitOffs>
+            <BitOffs>1306975072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -88250,7 +88285,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716352</BitOffs>
+            <BitOffs>1306975104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -88263,7 +88298,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716416</BitOffs>
+            <BitOffs>1306975168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -88276,7 +88311,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306716432</BitOffs>
+            <BitOffs>1306975184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88288,7 +88323,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1306735808</BitOffs>
+            <BitOffs>1306994560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -88300,7 +88335,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307061696</BitOffs>
+            <BitOffs>1307320448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -88313,7 +88348,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069632</BitOffs>
+            <BitOffs>1307328384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -88326,7 +88361,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069640</BitOffs>
+            <BitOffs>1307328392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -88339,7 +88374,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069648</BitOffs>
+            <BitOffs>1307328400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -88362,7 +88397,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069664</BitOffs>
+            <BitOffs>1307328416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -88375,7 +88410,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069696</BitOffs>
+            <BitOffs>1307328448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -88388,7 +88423,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069760</BitOffs>
+            <BitOffs>1307328512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -88401,7 +88436,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307069776</BitOffs>
+            <BitOffs>1307328528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -88413,7 +88448,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307089152</BitOffs>
+            <BitOffs>1307347904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -88425,7 +88460,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307415040</BitOffs>
+            <BitOffs>1307673792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -88438,7 +88473,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422976</BitOffs>
+            <BitOffs>1307681728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -88451,7 +88486,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422984</BitOffs>
+            <BitOffs>1307681736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -88464,7 +88499,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307422992</BitOffs>
+            <BitOffs>1307681744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -88487,7 +88522,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423008</BitOffs>
+            <BitOffs>1307681760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -88500,7 +88535,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423040</BitOffs>
+            <BitOffs>1307681792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -88513,7 +88548,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423104</BitOffs>
+            <BitOffs>1307681856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -88526,7 +88561,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307423120</BitOffs>
+            <BitOffs>1307681872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -88538,7 +88573,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307440960</BitOffs>
+            <BitOffs>1307699712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -88551,7 +88586,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448896</BitOffs>
+            <BitOffs>1307707648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -88564,7 +88599,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448904</BitOffs>
+            <BitOffs>1307707656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -88577,7 +88612,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448912</BitOffs>
+            <BitOffs>1307707664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -88600,7 +88635,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448928</BitOffs>
+            <BitOffs>1307707680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -88613,7 +88648,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307448960</BitOffs>
+            <BitOffs>1307707712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -88626,7 +88661,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307449024</BitOffs>
+            <BitOffs>1307707776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -88639,7 +88674,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307449040</BitOffs>
+            <BitOffs>1307707792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -88652,7 +88687,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474816</BitOffs>
+            <BitOffs>1307733568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -88665,7 +88700,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474824</BitOffs>
+            <BitOffs>1307733576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -88678,7 +88713,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474832</BitOffs>
+            <BitOffs>1307733584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -88701,7 +88736,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474848</BitOffs>
+            <BitOffs>1307733600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -88714,7 +88749,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474880</BitOffs>
+            <BitOffs>1307733632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -88727,7 +88762,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474944</BitOffs>
+            <BitOffs>1307733696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -88740,7 +88775,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307474960</BitOffs>
+            <BitOffs>1307733712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -88752,7 +88787,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307492800</BitOffs>
+            <BitOffs>1307751552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -88765,7 +88800,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500736</BitOffs>
+            <BitOffs>1307759488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -88778,7 +88813,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500744</BitOffs>
+            <BitOffs>1307759496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -88791,7 +88826,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500752</BitOffs>
+            <BitOffs>1307759504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -88814,7 +88849,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500768</BitOffs>
+            <BitOffs>1307759520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -88827,7 +88862,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500800</BitOffs>
+            <BitOffs>1307759552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -88840,7 +88875,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500864</BitOffs>
+            <BitOffs>1307759616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -88853,7 +88888,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307500880</BitOffs>
+            <BitOffs>1307759632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -88865,7 +88900,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307518720</BitOffs>
+            <BitOffs>1307777472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -88878,7 +88913,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526656</BitOffs>
+            <BitOffs>1307785408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -88891,7 +88926,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526664</BitOffs>
+            <BitOffs>1307785416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -88904,7 +88939,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526672</BitOffs>
+            <BitOffs>1307785424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -88927,7 +88962,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526688</BitOffs>
+            <BitOffs>1307785440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -88940,7 +88975,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526720</BitOffs>
+            <BitOffs>1307785472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -88953,7 +88988,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526784</BitOffs>
+            <BitOffs>1307785536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -88966,7 +89001,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307526800</BitOffs>
+            <BitOffs>1307785552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.Axis.NcToPlc</Name>
@@ -88978,7 +89013,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307544640</BitOffs>
+            <BitOffs>1307803392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitForwardEnable</Name>
@@ -88991,7 +89026,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552576</BitOffs>
+            <BitOffs>1307811328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bLimitBackwardEnable</Name>
@@ -89004,7 +89039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552584</BitOffs>
+            <BitOffs>1307811336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHome</Name>
@@ -89017,7 +89052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552592</BitOffs>
+            <BitOffs>1307811344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.bHardwareEnable</Name>
@@ -89040,7 +89075,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552608</BitOffs>
+            <BitOffs>1307811360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderULINT</Name>
@@ -89053,7 +89088,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552640</BitOffs>
+            <BitOffs>1307811392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderUINT</Name>
@@ -89066,7 +89101,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552704</BitOffs>
+            <BitOffs>1307811456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M10.nRawEncoderINT</Name>
@@ -89079,7 +89114,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307552720</BitOffs>
+            <BitOffs>1307811472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.Axis.NcToPlc</Name>
@@ -89091,7 +89126,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307570560</BitOffs>
+            <BitOffs>1307829312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitForwardEnable</Name>
@@ -89104,7 +89139,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578496</BitOffs>
+            <BitOffs>1307837248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bLimitBackwardEnable</Name>
@@ -89117,7 +89152,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578504</BitOffs>
+            <BitOffs>1307837256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHome</Name>
@@ -89130,7 +89165,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578512</BitOffs>
+            <BitOffs>1307837264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.bHardwareEnable</Name>
@@ -89153,7 +89188,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578528</BitOffs>
+            <BitOffs>1307837280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderULINT</Name>
@@ -89166,7 +89201,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578560</BitOffs>
+            <BitOffs>1307837312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderUINT</Name>
@@ -89179,7 +89214,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578624</BitOffs>
+            <BitOffs>1307837376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M11.nRawEncoderINT</Name>
@@ -89192,7 +89227,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307578640</BitOffs>
+            <BitOffs>1307837392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.Axis.NcToPlc</Name>
@@ -89204,7 +89239,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307596480</BitOffs>
+            <BitOffs>1307855232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitForwardEnable</Name>
@@ -89217,7 +89252,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604416</BitOffs>
+            <BitOffs>1307863168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bLimitBackwardEnable</Name>
@@ -89230,7 +89265,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604424</BitOffs>
+            <BitOffs>1307863176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHome</Name>
@@ -89243,7 +89278,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604432</BitOffs>
+            <BitOffs>1307863184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.bHardwareEnable</Name>
@@ -89266,7 +89301,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604448</BitOffs>
+            <BitOffs>1307863200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderULINT</Name>
@@ -89279,7 +89314,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604480</BitOffs>
+            <BitOffs>1307863232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderUINT</Name>
@@ -89292,7 +89327,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604544</BitOffs>
+            <BitOffs>1307863296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M12.nRawEncoderINT</Name>
@@ -89305,7 +89340,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307604560</BitOffs>
+            <BitOffs>1307863312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89317,7 +89352,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307623936</BitOffs>
+            <BitOffs>1307882688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.Axis.NcToPlc</Name>
@@ -89329,7 +89364,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307949824</BitOffs>
+            <BitOffs>1308208576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitForwardEnable</Name>
@@ -89342,7 +89377,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957760</BitOffs>
+            <BitOffs>1308216512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bLimitBackwardEnable</Name>
@@ -89355,7 +89390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957768</BitOffs>
+            <BitOffs>1308216520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHome</Name>
@@ -89368,7 +89403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957776</BitOffs>
+            <BitOffs>1308216528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.bHardwareEnable</Name>
@@ -89391,7 +89426,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957792</BitOffs>
+            <BitOffs>1308216544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderULINT</Name>
@@ -89404,7 +89439,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957824</BitOffs>
+            <BitOffs>1308216576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderUINT</Name>
@@ -89417,7 +89452,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957888</BitOffs>
+            <BitOffs>1308216640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M13.nRawEncoderINT</Name>
@@ -89430,7 +89465,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307957904</BitOffs>
+            <BitOffs>1308216656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89442,7 +89477,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1307977280</BitOffs>
+            <BitOffs>1308236032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.Axis.NcToPlc</Name>
@@ -89454,7 +89489,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308303168</BitOffs>
+            <BitOffs>1308561920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitForwardEnable</Name>
@@ -89467,7 +89502,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311104</BitOffs>
+            <BitOffs>1308569856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bLimitBackwardEnable</Name>
@@ -89480,7 +89515,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311112</BitOffs>
+            <BitOffs>1308569864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHome</Name>
@@ -89493,7 +89528,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311120</BitOffs>
+            <BitOffs>1308569872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.bHardwareEnable</Name>
@@ -89516,7 +89551,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311136</BitOffs>
+            <BitOffs>1308569888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderULINT</Name>
@@ -89529,7 +89564,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311168</BitOffs>
+            <BitOffs>1308569920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderUINT</Name>
@@ -89542,7 +89577,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311232</BitOffs>
+            <BitOffs>1308569984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M14.nRawEncoderINT</Name>
@@ -89555,7 +89590,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308311248</BitOffs>
+            <BitOffs>1308570000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89567,7 +89602,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308330624</BitOffs>
+            <BitOffs>1308589376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.Axis.NcToPlc</Name>
@@ -89579,7 +89614,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308656512</BitOffs>
+            <BitOffs>1308915264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitForwardEnable</Name>
@@ -89592,7 +89627,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664448</BitOffs>
+            <BitOffs>1308923200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bLimitBackwardEnable</Name>
@@ -89605,7 +89640,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664456</BitOffs>
+            <BitOffs>1308923208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHome</Name>
@@ -89618,7 +89653,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664464</BitOffs>
+            <BitOffs>1308923216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.bHardwareEnable</Name>
@@ -89641,7 +89676,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664480</BitOffs>
+            <BitOffs>1308923232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderULINT</Name>
@@ -89654,7 +89689,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664512</BitOffs>
+            <BitOffs>1308923264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderUINT</Name>
@@ -89667,7 +89702,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664576</BitOffs>
+            <BitOffs>1308923328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M15.nRawEncoderINT</Name>
@@ -89680,7 +89715,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308664592</BitOffs>
+            <BitOffs>1308923344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89692,7 +89727,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1308683968</BitOffs>
+            <BitOffs>1308942720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.Axis.NcToPlc</Name>
@@ -89704,7 +89739,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309009856</BitOffs>
+            <BitOffs>1309268608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitForwardEnable</Name>
@@ -89717,7 +89752,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017792</BitOffs>
+            <BitOffs>1309276544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bLimitBackwardEnable</Name>
@@ -89730,7 +89765,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017800</BitOffs>
+            <BitOffs>1309276552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHome</Name>
@@ -89743,7 +89778,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017808</BitOffs>
+            <BitOffs>1309276560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.bHardwareEnable</Name>
@@ -89766,7 +89801,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017824</BitOffs>
+            <BitOffs>1309276576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderULINT</Name>
@@ -89779,7 +89814,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017856</BitOffs>
+            <BitOffs>1309276608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderUINT</Name>
@@ -89792,7 +89827,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017920</BitOffs>
+            <BitOffs>1309276672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M16.nRawEncoderINT</Name>
@@ -89805,7 +89840,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309017936</BitOffs>
+            <BitOffs>1309276688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.Axis.NcToPlc</Name>
@@ -89817,7 +89852,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309035776</BitOffs>
+            <BitOffs>1309294528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitForwardEnable</Name>
@@ -89830,7 +89865,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043712</BitOffs>
+            <BitOffs>1309302464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bLimitBackwardEnable</Name>
@@ -89843,7 +89878,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043720</BitOffs>
+            <BitOffs>1309302472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHome</Name>
@@ -89856,7 +89891,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043728</BitOffs>
+            <BitOffs>1309302480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.bHardwareEnable</Name>
@@ -89879,7 +89914,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043744</BitOffs>
+            <BitOffs>1309302496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderULINT</Name>
@@ -89892,7 +89927,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043776</BitOffs>
+            <BitOffs>1309302528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderUINT</Name>
@@ -89905,7 +89940,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043840</BitOffs>
+            <BitOffs>1309302592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M17.nRawEncoderINT</Name>
@@ -89918,7 +89953,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309043856</BitOffs>
+            <BitOffs>1309302608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -89930,7 +89965,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309063232</BitOffs>
+            <BitOffs>1309321984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.Axis.NcToPlc</Name>
@@ -89942,7 +89977,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309389120</BitOffs>
+            <BitOffs>1309647872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitForwardEnable</Name>
@@ -89955,7 +89990,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397056</BitOffs>
+            <BitOffs>1309655808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bLimitBackwardEnable</Name>
@@ -89968,7 +90003,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397064</BitOffs>
+            <BitOffs>1309655816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHome</Name>
@@ -89981,7 +90016,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397072</BitOffs>
+            <BitOffs>1309655824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.bHardwareEnable</Name>
@@ -90004,7 +90039,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397088</BitOffs>
+            <BitOffs>1309655840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderULINT</Name>
@@ -90017,7 +90052,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397120</BitOffs>
+            <BitOffs>1309655872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderUINT</Name>
@@ -90030,7 +90065,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397184</BitOffs>
+            <BitOffs>1309655936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M18.nRawEncoderINT</Name>
@@ -90043,7 +90078,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309397200</BitOffs>
+            <BitOffs>1309655952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90055,7 +90090,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309416576</BitOffs>
+            <BitOffs>1309675328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.Axis.NcToPlc</Name>
@@ -90067,7 +90102,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309742464</BitOffs>
+            <BitOffs>1310001216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitForwardEnable</Name>
@@ -90080,7 +90115,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750400</BitOffs>
+            <BitOffs>1310009152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bLimitBackwardEnable</Name>
@@ -90093,7 +90128,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750408</BitOffs>
+            <BitOffs>1310009160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHome</Name>
@@ -90106,7 +90141,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750416</BitOffs>
+            <BitOffs>1310009168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.bHardwareEnable</Name>
@@ -90129,7 +90164,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750432</BitOffs>
+            <BitOffs>1310009184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderULINT</Name>
@@ -90142,7 +90177,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750464</BitOffs>
+            <BitOffs>1310009216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderUINT</Name>
@@ -90155,7 +90190,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750528</BitOffs>
+            <BitOffs>1310009280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M19.nRawEncoderINT</Name>
@@ -90168,7 +90203,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309750544</BitOffs>
+            <BitOffs>1310009296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.Axis.NcToPlc</Name>
@@ -90180,7 +90215,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309768384</BitOffs>
+            <BitOffs>1310027136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitForwardEnable</Name>
@@ -90193,7 +90228,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776320</BitOffs>
+            <BitOffs>1310035072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bLimitBackwardEnable</Name>
@@ -90206,7 +90241,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776328</BitOffs>
+            <BitOffs>1310035080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHome</Name>
@@ -90219,7 +90254,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776336</BitOffs>
+            <BitOffs>1310035088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.bHardwareEnable</Name>
@@ -90242,7 +90277,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776352</BitOffs>
+            <BitOffs>1310035104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderULINT</Name>
@@ -90255,7 +90290,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776384</BitOffs>
+            <BitOffs>1310035136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderUINT</Name>
@@ -90268,7 +90303,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776448</BitOffs>
+            <BitOffs>1310035200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M20.nRawEncoderINT</Name>
@@ -90281,7 +90316,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309776464</BitOffs>
+            <BitOffs>1310035216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.Axis.NcToPlc</Name>
@@ -90293,7 +90328,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309794304</BitOffs>
+            <BitOffs>1310053056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitForwardEnable</Name>
@@ -90306,7 +90341,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802240</BitOffs>
+            <BitOffs>1310060992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bLimitBackwardEnable</Name>
@@ -90319,7 +90354,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802248</BitOffs>
+            <BitOffs>1310061000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHome</Name>
@@ -90332,7 +90367,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802256</BitOffs>
+            <BitOffs>1310061008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.bHardwareEnable</Name>
@@ -90355,7 +90390,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802272</BitOffs>
+            <BitOffs>1310061024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderULINT</Name>
@@ -90368,7 +90403,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802304</BitOffs>
+            <BitOffs>1310061056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderUINT</Name>
@@ -90381,7 +90416,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802368</BitOffs>
+            <BitOffs>1310061120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M21.nRawEncoderINT</Name>
@@ -90394,7 +90429,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309802384</BitOffs>
+            <BitOffs>1310061136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.Axis.NcToPlc</Name>
@@ -90406,7 +90441,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309820224</BitOffs>
+            <BitOffs>1310078976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitForwardEnable</Name>
@@ -90419,7 +90454,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828160</BitOffs>
+            <BitOffs>1310086912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bLimitBackwardEnable</Name>
@@ -90432,7 +90467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828168</BitOffs>
+            <BitOffs>1310086920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHome</Name>
@@ -90445,7 +90480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828176</BitOffs>
+            <BitOffs>1310086928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.bHardwareEnable</Name>
@@ -90468,7 +90503,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828192</BitOffs>
+            <BitOffs>1310086944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderULINT</Name>
@@ -90481,7 +90516,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828224</BitOffs>
+            <BitOffs>1310086976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderUINT</Name>
@@ -90494,7 +90529,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828288</BitOffs>
+            <BitOffs>1310087040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M22.nRawEncoderINT</Name>
@@ -90507,7 +90542,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309828304</BitOffs>
+            <BitOffs>1310087056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.Axis.NcToPlc</Name>
@@ -90519,7 +90554,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309846144</BitOffs>
+            <BitOffs>1310104896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitForwardEnable</Name>
@@ -90532,7 +90567,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854080</BitOffs>
+            <BitOffs>1310112832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bLimitBackwardEnable</Name>
@@ -90545,7 +90580,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854088</BitOffs>
+            <BitOffs>1310112840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHome</Name>
@@ -90558,7 +90593,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854096</BitOffs>
+            <BitOffs>1310112848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.bHardwareEnable</Name>
@@ -90581,7 +90616,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854112</BitOffs>
+            <BitOffs>1310112864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderULINT</Name>
@@ -90594,7 +90629,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854144</BitOffs>
+            <BitOffs>1310112896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderUINT</Name>
@@ -90607,7 +90642,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854208</BitOffs>
+            <BitOffs>1310112960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M23.nRawEncoderINT</Name>
@@ -90620,7 +90655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309854224</BitOffs>
+            <BitOffs>1310112976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.Axis.NcToPlc</Name>
@@ -90632,7 +90667,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309872064</BitOffs>
+            <BitOffs>1310130816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitForwardEnable</Name>
@@ -90645,7 +90680,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880000</BitOffs>
+            <BitOffs>1310138752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bLimitBackwardEnable</Name>
@@ -90658,7 +90693,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880008</BitOffs>
+            <BitOffs>1310138760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHome</Name>
@@ -90671,7 +90706,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880016</BitOffs>
+            <BitOffs>1310138768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.bHardwareEnable</Name>
@@ -90694,7 +90729,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880032</BitOffs>
+            <BitOffs>1310138784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderULINT</Name>
@@ -90707,7 +90742,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880064</BitOffs>
+            <BitOffs>1310138816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderUINT</Name>
@@ -90720,7 +90755,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880128</BitOffs>
+            <BitOffs>1310138880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M24.nRawEncoderINT</Name>
@@ -90733,7 +90768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309880144</BitOffs>
+            <BitOffs>1310138896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.Axis.NcToPlc</Name>
@@ -90745,7 +90780,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309897984</BitOffs>
+            <BitOffs>1310156736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitForwardEnable</Name>
@@ -90758,7 +90793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905920</BitOffs>
+            <BitOffs>1310164672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bLimitBackwardEnable</Name>
@@ -90771,7 +90806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905928</BitOffs>
+            <BitOffs>1310164680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHome</Name>
@@ -90784,7 +90819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905936</BitOffs>
+            <BitOffs>1310164688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.bHardwareEnable</Name>
@@ -90807,7 +90842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905952</BitOffs>
+            <BitOffs>1310164704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderULINT</Name>
@@ -90820,7 +90855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309905984</BitOffs>
+            <BitOffs>1310164736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderUINT</Name>
@@ -90833,7 +90868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309906048</BitOffs>
+            <BitOffs>1310164800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M25.nRawEncoderINT</Name>
@@ -90846,7 +90881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309906064</BitOffs>
+            <BitOffs>1310164816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90858,7 +90893,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1309925440</BitOffs>
+            <BitOffs>1310184192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.Axis.NcToPlc</Name>
@@ -90870,7 +90905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310251328</BitOffs>
+            <BitOffs>1310510080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitForwardEnable</Name>
@@ -90883,7 +90918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259264</BitOffs>
+            <BitOffs>1310518016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bLimitBackwardEnable</Name>
@@ -90896,7 +90931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259272</BitOffs>
+            <BitOffs>1310518024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHome</Name>
@@ -90909,7 +90944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259280</BitOffs>
+            <BitOffs>1310518032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.bHardwareEnable</Name>
@@ -90932,7 +90967,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259296</BitOffs>
+            <BitOffs>1310518048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderULINT</Name>
@@ -90945,7 +90980,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259328</BitOffs>
+            <BitOffs>1310518080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderUINT</Name>
@@ -90958,7 +90993,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259392</BitOffs>
+            <BitOffs>1310518144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M26.nRawEncoderINT</Name>
@@ -90971,7 +91006,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310259408</BitOffs>
+            <BitOffs>1310518160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -90983,7 +91018,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310278784</BitOffs>
+            <BitOffs>1310537536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.Axis.NcToPlc</Name>
@@ -90995,7 +91030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310604672</BitOffs>
+            <BitOffs>1310863424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitForwardEnable</Name>
@@ -91008,7 +91043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612608</BitOffs>
+            <BitOffs>1310871360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bLimitBackwardEnable</Name>
@@ -91021,7 +91056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612616</BitOffs>
+            <BitOffs>1310871368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHome</Name>
@@ -91034,7 +91069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612624</BitOffs>
+            <BitOffs>1310871376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.bHardwareEnable</Name>
@@ -91057,7 +91092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612640</BitOffs>
+            <BitOffs>1310871392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderULINT</Name>
@@ -91070,7 +91105,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612672</BitOffs>
+            <BitOffs>1310871424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderUINT</Name>
@@ -91083,7 +91118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612736</BitOffs>
+            <BitOffs>1310871488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M27.nRawEncoderINT</Name>
@@ -91096,7 +91131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310612752</BitOffs>
+            <BitOffs>1310871504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91108,7 +91143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310632128</BitOffs>
+            <BitOffs>1310890880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.Axis.NcToPlc</Name>
@@ -91120,7 +91155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310958016</BitOffs>
+            <BitOffs>1311216768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitForwardEnable</Name>
@@ -91133,7 +91168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965952</BitOffs>
+            <BitOffs>1311224704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bLimitBackwardEnable</Name>
@@ -91146,7 +91181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965960</BitOffs>
+            <BitOffs>1311224712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHome</Name>
@@ -91159,7 +91194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965968</BitOffs>
+            <BitOffs>1311224720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.bHardwareEnable</Name>
@@ -91182,7 +91217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310965984</BitOffs>
+            <BitOffs>1311224736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderULINT</Name>
@@ -91195,7 +91230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966016</BitOffs>
+            <BitOffs>1311224768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderUINT</Name>
@@ -91208,7 +91243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966080</BitOffs>
+            <BitOffs>1311224832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M28.nRawEncoderINT</Name>
@@ -91221,7 +91256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310966096</BitOffs>
+            <BitOffs>1311224848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91233,7 +91268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1310985472</BitOffs>
+            <BitOffs>1311244224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.Axis.NcToPlc</Name>
@@ -91245,7 +91280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311311360</BitOffs>
+            <BitOffs>1311570112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitForwardEnable</Name>
@@ -91258,7 +91293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319296</BitOffs>
+            <BitOffs>1311578048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bLimitBackwardEnable</Name>
@@ -91271,7 +91306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319304</BitOffs>
+            <BitOffs>1311578056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHome</Name>
@@ -91284,7 +91319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319312</BitOffs>
+            <BitOffs>1311578064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.bHardwareEnable</Name>
@@ -91307,7 +91342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319328</BitOffs>
+            <BitOffs>1311578080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderULINT</Name>
@@ -91320,7 +91355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319360</BitOffs>
+            <BitOffs>1311578112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderUINT</Name>
@@ -91333,7 +91368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319424</BitOffs>
+            <BitOffs>1311578176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M29.nRawEncoderINT</Name>
@@ -91346,7 +91381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311319440</BitOffs>
+            <BitOffs>1311578192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91358,7 +91393,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311338816</BitOffs>
+            <BitOffs>1311597568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.Axis.NcToPlc</Name>
@@ -91370,7 +91405,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311664704</BitOffs>
+            <BitOffs>1311923456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitForwardEnable</Name>
@@ -91383,7 +91418,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672640</BitOffs>
+            <BitOffs>1311931392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bLimitBackwardEnable</Name>
@@ -91396,7 +91431,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672648</BitOffs>
+            <BitOffs>1311931400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHome</Name>
@@ -91409,7 +91444,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672656</BitOffs>
+            <BitOffs>1311931408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.bHardwareEnable</Name>
@@ -91432,7 +91467,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672672</BitOffs>
+            <BitOffs>1311931424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderULINT</Name>
@@ -91445,7 +91480,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672704</BitOffs>
+            <BitOffs>1311931456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderUINT</Name>
@@ -91458,7 +91493,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672768</BitOffs>
+            <BitOffs>1311931520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M30.nRawEncoderINT</Name>
@@ -91471,7 +91506,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311672784</BitOffs>
+            <BitOffs>1311931536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91483,7 +91518,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1311692160</BitOffs>
+            <BitOffs>1311950912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.Axis.NcToPlc</Name>
@@ -91495,7 +91530,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312018048</BitOffs>
+            <BitOffs>1312276800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitForwardEnable</Name>
@@ -91508,7 +91543,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312025984</BitOffs>
+            <BitOffs>1312284736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bLimitBackwardEnable</Name>
@@ -91521,7 +91556,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312025992</BitOffs>
+            <BitOffs>1312284744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHome</Name>
@@ -91534,7 +91569,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026000</BitOffs>
+            <BitOffs>1312284752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.bHardwareEnable</Name>
@@ -91557,7 +91592,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026016</BitOffs>
+            <BitOffs>1312284768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderULINT</Name>
@@ -91570,7 +91605,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026048</BitOffs>
+            <BitOffs>1312284800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderUINT</Name>
@@ -91583,7 +91618,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026112</BitOffs>
+            <BitOffs>1312284864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M31.nRawEncoderINT</Name>
@@ -91596,7 +91631,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312026128</BitOffs>
+            <BitOffs>1312284880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91608,7 +91643,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312045504</BitOffs>
+            <BitOffs>1312304256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.Axis.NcToPlc</Name>
@@ -91620,7 +91655,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312371392</BitOffs>
+            <BitOffs>1312630144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitForwardEnable</Name>
@@ -91633,7 +91668,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379328</BitOffs>
+            <BitOffs>1312638080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bLimitBackwardEnable</Name>
@@ -91646,7 +91681,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379336</BitOffs>
+            <BitOffs>1312638088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHome</Name>
@@ -91659,7 +91694,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379344</BitOffs>
+            <BitOffs>1312638096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.bHardwareEnable</Name>
@@ -91682,7 +91717,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379360</BitOffs>
+            <BitOffs>1312638112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderULINT</Name>
@@ -91695,7 +91730,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379392</BitOffs>
+            <BitOffs>1312638144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderUINT</Name>
@@ -91708,7 +91743,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379456</BitOffs>
+            <BitOffs>1312638208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M32.nRawEncoderINT</Name>
@@ -91721,7 +91756,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312379472</BitOffs>
+            <BitOffs>1312638224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91733,7 +91768,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312398848</BitOffs>
+            <BitOffs>1312657600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.Axis.NcToPlc</Name>
@@ -91745,7 +91780,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312724736</BitOffs>
+            <BitOffs>1312983488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitForwardEnable</Name>
@@ -91758,7 +91793,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732672</BitOffs>
+            <BitOffs>1312991424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bLimitBackwardEnable</Name>
@@ -91771,7 +91806,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732680</BitOffs>
+            <BitOffs>1312991432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHome</Name>
@@ -91784,7 +91819,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732688</BitOffs>
+            <BitOffs>1312991440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.bHardwareEnable</Name>
@@ -91807,7 +91842,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732704</BitOffs>
+            <BitOffs>1312991456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderULINT</Name>
@@ -91820,7 +91855,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732736</BitOffs>
+            <BitOffs>1312991488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderUINT</Name>
@@ -91833,7 +91868,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732800</BitOffs>
+            <BitOffs>1312991552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M33.nRawEncoderINT</Name>
@@ -91846,7 +91881,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312732816</BitOffs>
+            <BitOffs>1312991568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91858,7 +91893,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1312752192</BitOffs>
+            <BitOffs>1313010944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.Axis.NcToPlc</Name>
@@ -91870,7 +91905,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313078080</BitOffs>
+            <BitOffs>1313336832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitForwardEnable</Name>
@@ -91883,7 +91918,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086016</BitOffs>
+            <BitOffs>1313344768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bLimitBackwardEnable</Name>
@@ -91896,7 +91931,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086024</BitOffs>
+            <BitOffs>1313344776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHome</Name>
@@ -91909,7 +91944,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086032</BitOffs>
+            <BitOffs>1313344784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.bHardwareEnable</Name>
@@ -91932,7 +91967,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086048</BitOffs>
+            <BitOffs>1313344800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderULINT</Name>
@@ -91945,7 +91980,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086080</BitOffs>
+            <BitOffs>1313344832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderUINT</Name>
@@ -91958,7 +91993,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086144</BitOffs>
+            <BitOffs>1313344896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M34.nRawEncoderINT</Name>
@@ -91971,7 +92006,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313086160</BitOffs>
+            <BitOffs>1313344912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -91983,7 +92018,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313105536</BitOffs>
+            <BitOffs>1313364288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.Axis.NcToPlc</Name>
@@ -91995,7 +92030,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313431424</BitOffs>
+            <BitOffs>1313690176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitForwardEnable</Name>
@@ -92008,7 +92043,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439360</BitOffs>
+            <BitOffs>1313698112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bLimitBackwardEnable</Name>
@@ -92021,7 +92056,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439368</BitOffs>
+            <BitOffs>1313698120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHome</Name>
@@ -92034,7 +92069,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439376</BitOffs>
+            <BitOffs>1313698128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.bHardwareEnable</Name>
@@ -92057,7 +92092,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439392</BitOffs>
+            <BitOffs>1313698144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderULINT</Name>
@@ -92070,7 +92105,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439424</BitOffs>
+            <BitOffs>1313698176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderUINT</Name>
@@ -92083,7 +92118,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439488</BitOffs>
+            <BitOffs>1313698240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M35.nRawEncoderINT</Name>
@@ -92096,7 +92131,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313439504</BitOffs>
+            <BitOffs>1313698256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92108,7 +92143,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313458880</BitOffs>
+            <BitOffs>1313717632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.Axis.NcToPlc</Name>
@@ -92120,7 +92155,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313784768</BitOffs>
+            <BitOffs>1314043520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitForwardEnable</Name>
@@ -92133,7 +92168,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792704</BitOffs>
+            <BitOffs>1314051456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bLimitBackwardEnable</Name>
@@ -92146,7 +92181,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792712</BitOffs>
+            <BitOffs>1314051464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHome</Name>
@@ -92159,7 +92194,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792720</BitOffs>
+            <BitOffs>1314051472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.bHardwareEnable</Name>
@@ -92182,7 +92217,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792736</BitOffs>
+            <BitOffs>1314051488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderULINT</Name>
@@ -92195,7 +92230,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792768</BitOffs>
+            <BitOffs>1314051520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderUINT</Name>
@@ -92208,7 +92243,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792832</BitOffs>
+            <BitOffs>1314051584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M36.nRawEncoderINT</Name>
@@ -92221,7 +92256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313792848</BitOffs>
+            <BitOffs>1314051600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92233,7 +92268,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1313812224</BitOffs>
+            <BitOffs>1314070976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.Axis.NcToPlc</Name>
@@ -92245,7 +92280,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314138112</BitOffs>
+            <BitOffs>1314396864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitForwardEnable</Name>
@@ -92258,7 +92293,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146048</BitOffs>
+            <BitOffs>1314404800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bLimitBackwardEnable</Name>
@@ -92271,7 +92306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146056</BitOffs>
+            <BitOffs>1314404808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHome</Name>
@@ -92284,7 +92319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146064</BitOffs>
+            <BitOffs>1314404816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.bHardwareEnable</Name>
@@ -92307,7 +92342,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146080</BitOffs>
+            <BitOffs>1314404832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderULINT</Name>
@@ -92320,7 +92355,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146112</BitOffs>
+            <BitOffs>1314404864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderUINT</Name>
@@ -92333,7 +92368,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146176</BitOffs>
+            <BitOffs>1314404928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M37.nRawEncoderINT</Name>
@@ -92346,7 +92381,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314146192</BitOffs>
+            <BitOffs>1314404944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -92358,29 +92393,14 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1314165568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.sio_load</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490368</BitOffs>
+            <BitOffs>1314424320</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -93186,7 +93206,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299929728</BitOffs>
+            <BitOffs>1299929664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93199,7 +93219,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299938712</BitOffs>
+            <BitOffs>1299938648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93211,7 +93231,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299955648</BitOffs>
+            <BitOffs>1299955584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93224,7 +93244,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299964632</BitOffs>
+            <BitOffs>1299964568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93236,7 +93256,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299981568</BitOffs>
+            <BitOffs>1299981504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93249,7 +93269,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1299990552</BitOffs>
+            <BitOffs>1299990488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].Axis.PlcToNc</Name>
@@ -93261,7 +93281,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303558720</BitOffs>
+            <BitOffs>1303559040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[1].bBrakeRelease</Name>
@@ -93274,7 +93294,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303567704</BitOffs>
+            <BitOffs>1303568024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].Axis.PlcToNc</Name>
@@ -93286,7 +93306,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303584640</BitOffs>
+            <BitOffs>1303584960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[2].bBrakeRelease</Name>
@@ -93299,7 +93319,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303593624</BitOffs>
+            <BitOffs>1303593944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].Axis.PlcToNc</Name>
@@ -93311,7 +93331,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303610560</BitOffs>
+            <BitOffs>1303610880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates.astMotionStageMax[3].bBrakeRelease</Name>
@@ -93324,7 +93344,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1303619544</BitOffs>
+            <BitOffs>1303619864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1.q_xFastFaultOut</Name>
@@ -93344,1208 +93364,7 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1304951784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306000640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306009624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306028096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306353984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306362968</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306381440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306707328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306716312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1306734784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307060672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307069656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307088128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307414016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307423000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307439936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307448920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307465856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M7.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307474840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307491776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M8.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307500760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307517696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307526680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307543616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307552600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307569536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307578520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307595456</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307604440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307622912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307948800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307957784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1307976256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308302144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308311128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308329600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308655488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308664472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1308682944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309008832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309017816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309034752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309043736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309062208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309388096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309397080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309415552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309741440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309750424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309767360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309776344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309793280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309802264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309819200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309828184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309845120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309854104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309871040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309880024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309896960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309905944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1309924416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310250304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310259288</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310277760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310603648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310612632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310631104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310956992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310965976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1310984448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311310336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311319320</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311337792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311663680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311672664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1311691136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312017024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312026008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312044480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312370368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312379352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312397824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312723712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312732696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1312751168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313077056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313086040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313104512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313430400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313439384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313457856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313783744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313792728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1313811200</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37.Axis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314137088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37.bBrakeRelease</Name>
-            <Comment> NC Brake Output: TRUE to release brake</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314146072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-            <BitSize>1024</BitSize>
-            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Output</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1314164544</BitOffs>
+            <BitOffs>1304952040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput2.q_xFastFaultOut</Name>
@@ -94565,14 +93384,1215 @@ Emergency Stop for MR1K1</Comment>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>1323772520</BitOffs>
+            <BitOffs>1305598312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306259392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306268376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306286848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306612736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306621720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306640192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306966080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306975064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1306993536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307319424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307328408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307346880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307672768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307681752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307698688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307707672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307724608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M7.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307733592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307750528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307759512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307776448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307785432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307802368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307811352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307828288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307837272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307854208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307863192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m12.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1307881664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308207552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308216536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m13.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308235008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308560896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308569880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m14.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308588352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308914240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308923224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m15.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1308941696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309267584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309276568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309293504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309302488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m17.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309320960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309646848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309655832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m18.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1309674304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310000192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310009176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310026112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310035096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310052032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310061016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310077952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310086936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310103872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310112856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310129792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310138776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310155712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310164696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM25.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310183168</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310509056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310518040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM26.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310536512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310862400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310871384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM27.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1310889856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311215744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311224728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM28.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311243200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311569088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311578072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM29.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311596544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311922432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311931416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM30.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1311949888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312275776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312284760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM31.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312303232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312629120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312638104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM32.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312656576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312982464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1312991448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM33.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313009920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313335808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313344792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM34.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313363264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313689152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313698136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM35.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1313716608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314042496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314051480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM36.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314069952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37.Axis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314395840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37.bBrakeRelease</Name>
+            <Comment> NC Brake Output: TRUE to release brake</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314404824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM37.fbDriveVirtual.MasterAxis.PlcToNc</Name>
+            <BitSize>1024</BitSize>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Output</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1314423296</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -101823,10 +101843,29 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264978656</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265019440</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265129472</BitOffs>
+            <BitOffs>1265910272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -101839,26 +101878,7 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265129600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265135536</BitOffs>
+            <BitOffs>1265910400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -104694,7 +104714,6 @@ M2K2 FLAT X ENC CNT</Comment>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K2_FLAT.fbCoatingStates</Name>
-            <Comment>	This state implemtation is waiting on an upgrade to the state mover library because its encoder is inverted.</Comment>
             <BitSize>1541312</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_PositionStatePMPS1D</BaseType>
             <Properties>
@@ -105056,23 +105075,6 @@ M3K2 KBH X ENC CNT</Comment>
             <BitOffs>1298628832</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.fM3K2US_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K2:KBH:RTD:CHIN:L
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298628864</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_1</Name>
             <Comment> M3K2 DS RTDs</Comment>
             <BitSize>32</BitSize>
@@ -105088,24 +105090,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K2:KBH:RTD:CHIN:R
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1298628928</BitOffs>
+            <BitOffs>1298628864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fM3K2DS_RTD_3</Name>
@@ -105122,7 +105107,7 @@ M3K2 KBH X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1298628960</BitOffs>
+            <BitOffs>1298628896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.eStateSet</Name>
@@ -105137,7 +105122,22 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298629040</BitOffs>
+            <BitOffs>1298628960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR3K2:KBH:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1298628976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoolingPanel</Name>
@@ -105158,7 +105158,7 @@ M3K2 KBH X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1298629056</BitOffs>
+            <BitOffs>1298628992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K2_KBH.fbCoatingStates</Name>
@@ -105178,22 +105178,195 @@ M3K2 KBH X ENC CNT</Comment>
                 <Value>pv: MR3K2:KBH:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1298630272</BitOffs>
+            <BitOffs>1298630208</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR3K2_KBH.eStateGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Name>PRG_MR3K2_KBH.fbYSetup</Name>
+            <BitSize>92352</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
+            <BitOffs>1300171520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.astCoatingStatesY</Name>
+            <BitSize>54720</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>15</Elements>
+            </ArrayInfo>
+            <BitOffs>1300263872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Right_RTD</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
             <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2DS2_M3K2DS3]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-      pv: MR3K2:KBH:COATING:STATE:GET
-      io: i
+        pv: MR3K2:KBH:RTD:CHIN:R
+        field: EGU C
+        io: i
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1300171584</BitOffs>
+            <BitOffs>1300318592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K2_KBH.fbM3K2_Chin_Left_RTD</Name>
+            <BitSize>256</BitSize>
+            <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.iRaw := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Value;
+                              .bUnderrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Underrange;
+                              .bOverrange := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Overrange;
+                              .bError := TIIB[EL3202-0010_M3K2US3_M3K2DS1]^RTD Inputs Channel 1^Status^Error</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K2:KBV:RTD:CHIN:L
+        field: EGU C
+        io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300318848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR4K2 X ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:X</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300319104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1300706624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1300706688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
+            <Comment>MR4K2 Y ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1300706752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301094272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301094336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
+            <Comment>MR4K2 rX ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1301094400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301481920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301481984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
+            <Comment>MR4K2 US ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1301482048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301869568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1301869632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
+            <Comment>MR4K2 DS ENC RMS</Comment>
+            <BitSize>387520</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
+              </Property>
+            </Properties>
+            <BitOffs>1301869696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1302257216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <BitOffs>1302257280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefXM4K2</Name>
@@ -105211,149 +105384,7 @@ MR4K2 X ENC REF</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1300171616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.fbYSetup</Name>
-            <BitSize>92352</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1300171648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K2_KBH.astCoatingStatesY</Name>
-            <BitSize>54720</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_PositionState</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>15</Elements>
-            </ArrayInfo>
-            <BitOffs>1300264000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbXRMSErrorM4K2</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR4K2 X ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:X</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1300318720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1300706240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1300706304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbYRMSErrorM4K2</Name>
-            <Comment>MR4K2 Y ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:Y</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1300706368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxYRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301093888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinYRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301093952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbrXRMSErrorM4K2</Name>
-            <Comment>MR4K2 rX ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:PITCH</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1301094016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxrXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301481536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinrXRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301481600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbUSRMSErrorM4K2</Name>
-            <Comment>MR4K2 US ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:US</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1301481664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxUSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301869184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinUSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1301869248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fbdSRMSErrorM4K2</Name>
-            <Comment>MR4K2 DS ENC RMS</Comment>
-            <BitSize>387520</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:ENC:BEND:DS</Value>
-              </Property>
-            </Properties>
-            <BitOffs>1301869312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMaxDSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1302256832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fMinDSRMSErrorM4K2</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <BitOffs>1302256896</BitOffs>
+            <BitOffs>1302257344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefYM4K2</Name>
@@ -105370,7 +105401,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302256960</BitOffs>
+            <BitOffs>1302257376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefrXM4K2</Name>
@@ -105387,7 +105418,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302256992</BitOffs>
+            <BitOffs>1302257408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefUSM4K2</Name>
@@ -105404,7 +105435,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257024</BitOffs>
+            <BitOffs>1302257440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncRefDSM4K2</Name>
@@ -105421,7 +105452,7 @@ MR4K2 X ENC RMS</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257056</BitOffs>
+            <BitOffs>1302257472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntXM4K2</Name>
@@ -105439,7 +105470,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257088</BitOffs>
+            <BitOffs>1302257504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntYM4K2</Name>
@@ -105456,7 +105487,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257120</BitOffs>
+            <BitOffs>1302257536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntrXM4K2</Name>
@@ -105473,7 +105504,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257152</BitOffs>
+            <BitOffs>1302257568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntUSM4K2</Name>
@@ -105490,7 +105521,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257184</BitOffs>
+            <BitOffs>1302257600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.nEncCntDSM4K2</Name>
@@ -105507,7 +105538,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257216</BitOffs>
+            <BitOffs>1302257632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_1</Name>
@@ -105526,7 +105557,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257248</BitOffs>
+            <BitOffs>1302257664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_2</Name>
@@ -105543,7 +105574,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257280</BitOffs>
+            <BitOffs>1302257696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2US_RTD_3</Name>
@@ -105560,7 +105591,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257312</BitOffs>
+            <BitOffs>1302257728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_1</Name>
@@ -105578,44 +105609,10 @@ M4K2 KBV X ENC CNT</Comment>
         </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257344</BitOffs>
+            <BitOffs>1302257760</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_2</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K2:KBV:RTD:BEND:DS:2
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.fM4K2DS_RTD_3</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K2:KBV:RTD:BEND:DS:3
-            field: ASLO 0.01
-            field: EGU C
-            io: i
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302257408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Right_RTD</Name>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Right_RTD</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
             <Properties>
@@ -105635,10 +105632,10 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257472</BitOffs>
+            <BitOffs>1302257792</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR4K2_KBV.nM4K2_Chin_Left_RTD</Name>
+            <Name>PRG_MR4K2_KBV.fbM4K2_Chin_Left_RTD</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="LCLS_General">FB_TempSensor</BaseType>
             <Properties>
@@ -105658,37 +105655,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302257728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.eStateSet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: MR4K2:KBV:COATING:STATE:SET
-      io: io
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302258000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K2_KBV.eStateGet</Name>
-            <BitSize>16</BitSize>
-            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-      pv: MR4K2:KBV:COATING:STATE:GET
-      io: i
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>1302258016</BitOffs>
+            <BitOffs>1302258048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoolingPanel</Name>
@@ -105709,7 +105676,7 @@ M4K2 KBV X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1302258048</BitOffs>
+            <BitOffs>1302258368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbCoatingStates</Name>
@@ -105729,13 +105696,43 @@ M4K2 KBV X ENC CNT</Comment>
                 <Value>pv: MR4K2:KBV:COATING</Value>
               </Property>
             </Properties>
-            <BitOffs>1302259264</BitOffs>
+            <BitOffs>1302259584</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.eStateSet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR4K2:KBV:COATING:STATE:SET
+      io: io
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1303800896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K2_KBV.eStateGet</Name>
+            <BitSize>16</BitSize>
+            <BaseType>E_B4C_Rh_CoatingStates</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+      pv: MR4K2:KBV:COATING:STATE:GET
+      io: i
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>1303800912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.fbXSetup</Name>
             <BitSize>92352</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_StateSetupHelper</BaseType>
-            <BitOffs>1303800576</BitOffs>
+            <BitOffs>1303800960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K2_KBV.astCoatingStatesX</Name>
@@ -105745,7 +105742,7 @@ M4K2 KBV X ENC CNT</Comment>
               <LBound>1</LBound>
               <Elements>15</Elements>
             </ArrayInfo>
-            <BitOffs>1303892928</BitOffs>
+            <BitOffs>1303893312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1.M1K1_Pitch</Name>
@@ -105780,7 +105777,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303952704</BitOffs>
+            <BitOffs>1303953088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_ENC_REF</Name>
@@ -105795,7 +105792,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955200</BitOffs>
+            <BitOffs>1303955584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_ENC_REF</Name>
@@ -105809,7 +105806,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955264</BitOffs>
+            <BitOffs>1303955648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_UpperLimit</Name>
@@ -105824,7 +105821,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955328</BitOffs>
+            <BitOffs>1303955712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendUS_PMPS_LowerLimit</Name>
@@ -105839,7 +105836,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955392</BitOffs>
+            <BitOffs>1303955776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_UpperLimit</Name>
@@ -105854,7 +105851,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955456</BitOffs>
+            <BitOffs>1303955840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_BENDER_Constants.nM1K1bendDS_PMPS_LowerLimit</Name>
@@ -105869,7 +105866,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955520</BitOffs>
+            <BitOffs>1303955904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYUP_ENC_REF</Name>
@@ -105885,7 +105882,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955648</BitOffs>
+            <BitOffs>1303956032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nYDWN_ENC_REF</Name>
@@ -105899,7 +105896,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955712</BitOffs>
+            <BitOffs>1303956096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXUP_ENC_REF</Name>
@@ -105913,7 +105910,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955776</BitOffs>
+            <BitOffs>1303956160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K1_Constants.nXDWN_ENC_REF</Name>
@@ -105927,7 +105924,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303955840</BitOffs>
+            <BitOffs>1303956224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2X_ENC_REF</Name>
@@ -105942,7 +105939,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958400</BitOffs>
+            <BitOffs>1303958784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2Y_ENC_REF</Name>
@@ -105957,7 +105954,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958464</BitOffs>
+            <BitOffs>1303958848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K2.nM2K2rX_ENC_REF</Name>
@@ -105972,7 +105969,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958528</BitOffs>
+            <BitOffs>1303958912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2X_ENC_REF</Name>
@@ -105988,7 +105985,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958592</BitOffs>
+            <BitOffs>1303958976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2Y_ENC_REF</Name>
@@ -106002,7 +105999,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958656</BitOffs>
+            <BitOffs>1303959040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2rY_ENC_REF</Name>
@@ -106016,7 +106013,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958720</BitOffs>
+            <BitOffs>1303959104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2US_ENC_REF</Name>
@@ -106031,7 +106028,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958784</BitOffs>
+            <BitOffs>1303959168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K2.nM3K2DS_ENC_REF</Name>
@@ -106046,7 +106043,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303958848</BitOffs>
+            <BitOffs>1303959232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2X_ENC_REF</Name>
@@ -106062,7 +106059,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959040</BitOffs>
+            <BitOffs>1303959360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2Y_ENC_REF</Name>
@@ -106076,7 +106073,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959104</BitOffs>
+            <BitOffs>1303959424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2rX_ENC_REF</Name>
@@ -106090,7 +106087,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959168</BitOffs>
+            <BitOffs>1303959488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_ENC_REF</Name>
@@ -106105,7 +106102,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959232</BitOffs>
+            <BitOffs>1303959552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_ENC_REF</Name>
@@ -106120,7 +106117,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959296</BitOffs>
+            <BitOffs>1303959616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_UpperLimit</Name>
@@ -106135,7 +106132,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959360</BitOffs>
+            <BitOffs>1303959680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2US_PMPS_LowerLimit</Name>
@@ -106150,7 +106147,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959424</BitOffs>
+            <BitOffs>1303959744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_UpperLimit</Name>
@@ -106165,7 +106162,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959488</BitOffs>
+            <BitOffs>1303959808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K2.nM4K2DS_PMPS_LowerLimit</Name>
@@ -106174,64 +106171,6 @@ M4K2 KBV X ENC CNT</Comment>
             <BaseType>ULINT</BaseType>
             <Default>
               <Value>19800000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
-            <Comment> Encoder reference values in counts = nm
- Enc reference values after alignment 3-13-20</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>99171678</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>101371326</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>19501048</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1303959808</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Default>
-              <Value>20872028</Value>
             </Default>
             <Properties>
               <Property>
@@ -106253,18 +106192,65 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959936</BitOffs>
+            <BitOffs>1303959968</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_PMPS.rPhotonEnergy</Name>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>GVL_M1K2_Constants.nYLEFT_ENC_REF</Name>
+            <Comment> Encoder reference values in counts = nm
+ Enc reference values after alignment 3-13-20</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>99171678</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303959968</BitOffs>
+            <BitOffs>1303960000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.nYRIGHT_ENC_REF</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>101371326</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303960064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.nXUP_ENC_REF</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>19501048</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303960128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K2_Constants.nXDWN_ENC_REF</Name>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Default>
+              <Value>20872028</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1303960192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter1</Name>
@@ -106282,7 +106268,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1303960000</BitOffs>
+            <BitOffs>1303960256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbArbiter2</Name>
@@ -106300,7 +106286,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304455744</BitOffs>
+            <BitOffs>1304456000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.fbFastFaultOutput1</Name>
@@ -106329,1558 +106315,47 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1304951488</BitOffs>
+            <BitOffs>1304951744</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M1</Name>
-            <Comment> M1K2 Yleft</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
+            <BitSize>646272</BitSize>
+            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
             <Default>
               <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
+                <Name>.bAutoReset</Name>
                 <Bool>true</Bool>
               </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:YLEFT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306000576</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m1</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306026496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M2</Name>
-            <Comment> M1K2 Yright</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
               <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:YRIGHT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306353920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m2</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306379840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M3</Name>
-            <Comment> M1K2 Xup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
-                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:XUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306707264</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m3</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1306733184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M4</Name>
-            <Comment> M1K2 Xdwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:XDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307060608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m4</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307086528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M5</Name>
-            <Comment> M1K2 Pitch Stepper</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>30</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K2:SWITCH:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307413952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M6</Name>
-            <Comment> M_PI, urad</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>200</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
+                <Name>.i_sNetID</Name>
+                <String>172.21.42.126.1.1</String>
               </SubItem>
             </Default>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_PI
-    </Value>
+                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
               </Property>
               <Property>
                 <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
               </Property>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307439872</BitOffs>
+            <BitOffs>1305598016</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M8</Name>
-            <Comment> M_H, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:M_H
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307491712</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M9</Name>
-            <Comment> G_H, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>1000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:G_H
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307517632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M10</Name>
-            <Comment> SD_V, um</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:SD_V
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307543552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M11</Name>
-            <Comment> SD_R, urad</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>500</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SP1K1:MONO:MMS:SD_ROT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307569472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M12</Name>
-            <Comment> M1K1 Yup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
-                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:YUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307595392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m12</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Name>GVL_PMPS.rPhotonEnergy</Name>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1307621312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M13</Name>
-            <Comment> M1K1 Ydwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>100</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
-                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:YDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307948736</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m13</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1307974656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M14</Name>
-            <Comment> M1K1 Xup</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:XUP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308302080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m14</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308328000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M15</Name>
-            <Comment> M1K1 Xdwn</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>150</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 2</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:XDWN
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308655424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m15</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1308681344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M16</Name>
-            <Comment> M1K1 Pitch Stepper</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>30</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Pitch]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K1:BEND:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309008768</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M17</Name>
-            <Comment>MR1K1 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: MR1K1:BEND:MMS:US
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309034688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m17</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309060608</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M18</Name>
-            <Comment>MR1K1 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-    pv: MR1K1:BEND:MMS:DS
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309388032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStage_m18</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309413952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M19</Name>
-            <Comment> Air Pitch</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:PITCH</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.12</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 1;
-                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:PITCH
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309741376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M20</Name>
-            <Comment> Air Vertical</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:VERT</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.3</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
-                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:VERT
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309767296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M21</Name>
-            <Comment> Air Roll</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:ROLL</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.24</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:ROLL
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309793216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M22</Name>
-            <Comment> GAP</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:GAP</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:GAP
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309819136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M23</Name>
-            <Comment> YAG</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>SL1K2:EXIT:MMS:YAG</String>
-              </SubItem>
-              <SubItem>
-                <Name>.fVelocity</Name>
-                <Value>0.5</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: SL1K2:EXIT:MMS:YAG
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309845056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M24</Name>
-            <Comment> ST1K1-ZOS-MMS</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sName</Name>
-                <String>ST1K1:ZOS:MMS</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: ST1K1:ZOS:MMS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable  := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
-                              .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309870976</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M25</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309896896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM25</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1309922816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M26</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310250240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM26</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310276160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M27</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR2K2:FLAT:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
-                              .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310603584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM27</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310629504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M28</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310956928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM28</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1310982848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M29</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311310272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM29</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311336192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M30</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311663616</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM30</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1311689536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M31</Name>
-            <Comment>MR3K2 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR3K2:KBH:MMS:BEND:US</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312016960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM31</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312042880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M32</Name>
-            <Comment>MR3K2 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR3K2:KBH:MMS:BEND:DS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312370304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM32</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312396224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M33</Name>
-            <Comment>X mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:X</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312723648</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM33</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1312749568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M34</Name>
-            <Comment>Y mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:Y</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313076992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM34</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313102912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M35</Name>
-            <Comment>Pitch mot</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:PITCH</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313430336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM35</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313456256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M36</Name>
-            <Comment>MR4K2 US BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>	pv: MR4K2:KBV:MMS:BEND:US</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313783680</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM36</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1313809600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M37</Name>
-            <Comment>MR4K2 DS BEND</Comment>
-            <BitSize>25920</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nEnableMode</Name>
-                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
-              </SubItem>
-              <SubItem>
-                <Name>.bPowerSelf</Name>
-                <Bool>true</Bool>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: MR4K2:KBV:MMS:BEND:DS</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
-                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
-                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314137024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbMotionStageM37</Name>
-            <BitSize>327424</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314162944</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.dummyBool</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1314490416</BitOffs>
+            <BitOffs>1306244288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetY</Name>
@@ -107921,7 +106396,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314490432</BitOffs>
+            <BitOffs>1306244736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultOffsetX</Name>
@@ -107962,7 +106437,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314494080</BitOffs>
+            <BitOffs>1306248384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBX</Name>
@@ -108003,7 +106478,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314497728</BitOffs>
+            <BitOffs>1306252032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_States.stDefaultKBY</Name>
@@ -108044,7 +106519,1543 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314501376</BitOffs>
+            <BitOffs>1306255680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1</Name>
+            <Comment> M1K2 Yleft</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yleft]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:YLEFT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306259328</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m1</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306285248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M2</Name>
+            <Comment> M1K2 Yright</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Yright]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Yleftright]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:YRIGHT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306612672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m2</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306638592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M3</Name>
+            <Comment> M1K2 Xup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xup]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:XUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306966016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m3</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1306991936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M4</Name>
+            <Comment> M1K2 Xdwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_Xdwn]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K2_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:XDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307319360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m4</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307345280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M5</Name>
+            <Comment> M1K2 Pitch Stepper</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>30</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K2_PitchCoarse]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K2:SWITCH:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307672704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M6</Name>
+            <Comment> M_PI, urad</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>200</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_PI
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_pi_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_pi_up_dwn_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307698624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M8</Name>
+            <Comment> M_H, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:M_H
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[m_h_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307750464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M9</Name>
+            <Comment> G_H, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>1000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:G_H
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[g_h_m]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[m_h_e-g_h_e]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307776384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M10</Name>
+            <Comment> SD_V, um</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:SD_V
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[s_io_m]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307802304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M11</Name>
+            <Comment> SD_R, urad</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>500</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SP1K1:MONO:MMS:SD_ROT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307828224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M12</Name>
+            <Comment> M1K1 Yup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2;
+                              .bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Yupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:YUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307854144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m12</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1307880064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M13</Name>
+            <Comment> M1K1 Ydwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>100</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 1;
+                        .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Ydwn]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:YDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308207488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m13</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308233408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M14</Name>
+            <Comment> M1K1 Xup</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xup]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Xupdwn]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:XUP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308560832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m14</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308586752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M15</Name>
+            <Comment> M1K1 Xdwn</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>150</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_Xdwn]^STM Status^Status^Digital input 2</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:XDWN
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308914176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m15</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1308940096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M16</Name>
+            <Comment> M1K1 Pitch Stepper</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>30</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_M1K1_PitchCoarse]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M1K1_Pitch]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K1:BEND:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309267520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M17</Name>
+            <Comment>MR1K1 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: MR1K1:BEND:MMS:US
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309293440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m17</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309319360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M18</Name>
+            <Comment>MR1K1 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M1K1_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT    := TIIB[EL5042_M1K1_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+    pv: MR1K1:BEND:MMS:DS
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309646784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStage_m18</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1309672704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M19</Name>
+            <Comment> Air Pitch</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:PITCH</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.12</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_PITCH]^STM Status^Status^Digital input 1;
+                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:PITCH
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310000128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M20</Name>
+            <Comment> Air Vertical</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:VERT</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.3</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_VERT]^STM Status^Status^Digital input 2;
+                               .nRawEncoderULINT      := TIIB[EL5042_SL1K2_PITCH_VERT]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:VERT
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310026048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M21</Name>
+            <Comment> Air Roll</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:ROLL</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.24</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_ROLL]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:ROLL
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310051968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M22</Name>
+            <Comment> GAP</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:GAP</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_GAP]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_ROLL_GAP]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:GAP
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310077888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M23</Name>
+            <Comment> YAG</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>SL1K2:EXIT:MMS:YAG</String>
+              </SubItem>
+              <SubItem>
+                <Name>.fVelocity</Name>
+                <Value>0.5</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7047_SL1K2_YAG]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT      := TIIB[EL5042_SL1K2_YAG]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: SL1K2:EXIT:MMS:YAG
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310103808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M24</Name>
+            <Comment> ST1K1-ZOS-MMS</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sName</Name>
+                <String>ST1K1:ZOS:MMS</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: ST1K1:ZOS:MMS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable  := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable := TIIB[ST1K1-EL7041]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT     :=TIIB[ST1K1-EL5042]^FB Inputs Channel 1^Position;
+                              .bBrakeRelease        := TIIB[ST1K1-EL2008]^Channel 1^Output</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310129728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M25</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310155648</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM25</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310181568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M26</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2X_M2K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310508992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM26</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310534912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M27</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR2K2:FLAT:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 2;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M2K2rX]^STM Status^Status^Digital input 1;
+                              .nRawEncoderULINT:=TIIB[EL5042_M2K2rX]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310862336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM27</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1310888256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M28</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311215680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM28</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311241600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M29</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2X_M3K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311569024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM29</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311594944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M30</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M3K2rY]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2ry]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M3K2rY]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311922368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM30</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1311948288</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M31</Name>
+            <Comment>MR3K2 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR3K2:KBH:MMS:BEND:US</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312275712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM31</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312301632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M32</Name>
+            <Comment>MR3K2 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR3K2:KBH:MMS:BEND:DS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M3K2_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M3K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312629056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM32</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312654976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M33</Name>
+            <Comment>X mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:X</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2X]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1312982400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM33</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313008320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M34</Name>
+            <Comment>Y mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:Y</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2Y]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2X_M4K2Y]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313335744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM34</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313361664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M35</Name>
+            <Comment>Pitch mot</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:PITCH</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2rX]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:=TIIB[EL5042_M4K2rX]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313689088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM35</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1313715008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M36</Name>
+            <Comment>MR4K2 US BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>	pv: MR4K2:KBV:MMS:BEND:US</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_US]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 1^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314042432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM36</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314068352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M37</Name>
+            <Comment>MR4K2 DS BEND</Comment>
+            <BitSize>25920</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nEnableMode</Name>
+                <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
+              </SubItem>
+              <SubItem>
+                <Name>.bPowerSelf</Name>
+                <Bool>true</Bool>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>pv: MR4K2:KBV:MMS:BEND:DS</Value>
+              </Property>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.bLimitForwardEnable :=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 1;
+                              .bLimitBackwardEnable:=TIIB[EL7041_M4K2_BEND_DS]^STM Status^Status^Digital input 2;
+                              .nRawEncoderULINT:= TIIB[EL5042_M4K2_BEND_USDS]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314395776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbMotionStageM37</Name>
+            <BitSize>327424</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314421696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.dummyBool</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -108074,7 +108085,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505024</BitOffs>
+            <BitOffs>1314749152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -108104,7 +108115,22 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505088</BitOffs>
+            <BitOffs>1314749216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.nRegisterSize</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>1314749280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -108119,7 +108145,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505152</BitOffs>
+            <BitOffs>1314749296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -108134,7 +108160,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505168</BitOffs>
+            <BitOffs>1314749312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -108148,7 +108174,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505176</BitOffs>
+            <BitOffs>1314749320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -108163,7 +108189,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505184</BitOffs>
+            <BitOffs>1314749344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -108178,7 +108204,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505216</BitOffs>
+            <BitOffs>1314749376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -108299,7 +108325,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314505248</BitOffs>
+            <BitOffs>1314749408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -108313,7 +108339,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514720</BitOffs>
+            <BitOffs>1314758880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -108327,7 +108353,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314514752</BitOffs>
+            <BitOffs>1314758912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -108348,7 +108374,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314518400</BitOffs>
+            <BitOffs>1314762560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -108420,7 +108446,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536320</BitOffs>
+            <BitOffs>1314780480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -108492,7 +108518,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536448</BitOffs>
+            <BitOffs>1314780608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -108564,7 +108590,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536576</BitOffs>
+            <BitOffs>1314780736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -108636,7 +108662,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536704</BitOffs>
+            <BitOffs>1314780864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -108708,7 +108734,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536832</BitOffs>
+            <BitOffs>1314780992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -108780,7 +108806,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314536960</BitOffs>
+            <BitOffs>1314781120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -108852,7 +108878,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314537088</BitOffs>
+            <BitOffs>1314781248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -108924,7 +108950,7 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314537216</BitOffs>
+            <BitOffs>1314781376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -108950,43 +108976,14 @@ M4K2 KBV X ENC CNT</Comment>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>1314570240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_PMPS.fbFastFaultOutput2</Name>
-            <BitSize>646272</BitSize>
-            <BaseType Namespace="PMPS">FB_HardwareFFOutput</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.bAutoReset</Name>
-                <Bool>true</Bool>
-              </SubItem>
-              <SubItem>
-                <Name>.i_sNetID</Name>
-                <String>172.21.42.126.1.1</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>pv: PLC:RIX:OPTICS:FFO:02</Value>
-              </Property>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.q_xFastFaultOut:=TIIB[PMPS_FFO]^Channel 2^Output</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>1323772224</BitOffs>
+            <BitOffs>1314814400</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165675008</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109072,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-10-08T17:21:58</Value>
+          <Value>2024-10-25T15:23:10</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D8BF7053-7E9C-584B-4462-76CB1F372AAA}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{CB96F166-08A2-0ABA-C7F0-6CA5A48D2126}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82277,7 +82277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82298,7 +82298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82396,7 +82396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82414,7 +82414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82572,7 +82572,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
@@ -82669,7 +82669,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82724,7 +82724,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -83201,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -92400,7 +92400,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -94592,7 +94592,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -108983,7 +108983,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165609472</ByteSize>
+          <ByteSize>165543936</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109069,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-11-05T16:03:18</Value>
+          <Value>2024-11-11T08:48:44</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
+++ b/lcls-plc-rixs-optics/rixs_optics/rixs_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{2707D1F5-BCA0-02BB-828A-6DF293445FCB}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{815704F1-BAE3-4AB7-FF09-EA71736E6709}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -82254,7 +82254,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K2</Name>
             <Comment>Better have your inputs and outputs!
@@ -82277,7 +82277,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K2</Name>
             <BitSize>192</BitSize>
@@ -82298,7 +82298,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K2</Name>
             <BitSize>10752</BitSize>
@@ -82396,7 +82396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">16</AreaNo>
           <Name>StatsTask Inputs</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -82414,7 +82414,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>StatsTask Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PRG_Stats.fGpiEncoderPosDiff</Name>
             <Comment> SP1K1 Grating Mono Vibration Stats</Comment>
@@ -82572,13 +82572,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K2</Name>
             <Comment>PI Serial</Comment>
             <BitSize>112640</BitSize>
             <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>1265797632</BitOffs>
+            <BitOffs>1265016832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K2.M1K2_Pitch</Name>
@@ -82669,7 +82669,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">48</AreaNo>
           <Name>DaqTask Inputs</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchPos</Name>
             <Comment> Inputs</Comment>
@@ -82685,7 +82685,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265017536</BitOffs>
+            <BitOffs>1265133632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iLatchNeg</Name>
@@ -82701,7 +82701,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265017600</BitOffs>
+            <BitOffs>1265133696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nEncoderCount</Name>
@@ -82717,14 +82717,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>1265017664</BitOffs>
+            <BitOffs>1265133760</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">51</AreaNo>
           <Name>DaqTask Internal</Name>
           <ContextId>3</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
             <BitSize>56</BitSize>
@@ -82868,7 +82868,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <String>172.21.140.21</String>
             </Default>
-            <BitOffs>1265017728</BitOffs>
+            <BitOffs>1265133824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseHWTriggers</Name>
@@ -82877,7 +82877,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>true</Bool>
             </Default>
-            <BitOffs>1265018376</BitOffs>
+            <BitOffs>1265134472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bUseSWTriggers</Name>
@@ -82886,14 +82886,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Bool>false</Bool>
             </Default>
-            <BitOffs>1265018384</BitOffs>
+            <BitOffs>1265134480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.bNewTrigger</Name>
             <Comment> Internals</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>1265018392</BitOffs>
+            <BitOffs>1265134488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tSWTriggerDelay</Name>
@@ -82902,20 +82902,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <DateTime>T#8ms</DateTime>
             </Default>
-            <BitOffs>1265018400</BitOffs>
+            <BitOffs>1265134496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSincePos</Name>
             <Comment> Outputs</Comment>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265018432</BitOffs>
+            <BitOffs>1265134528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMaxTime</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265018496</BitOffs>
+            <BitOffs>1265134592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iMinTime</Name>
@@ -82924,19 +82924,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000000</Value>
             </Default>
-            <BitOffs>1265018560</BitOffs>
+            <BitOffs>1265134656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265018624</BitOffs>
+            <BitOffs>1265134720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTriggerWidth</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265018688</BitOffs>
+            <BitOffs>1265134784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fTriggerRate</Name>
@@ -82951,25 +82951,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265018752</BitOffs>
+            <BitOffs>1265134848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.tonSWTrigger</Name>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_Standard">TON</BaseType>
-            <BitOffs>1265018816</BitOffs>
+            <BitOffs>1265134912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iPrevLatchPos</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265019072</BitOffs>
+            <BitOffs>1265135168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMaxTimeInS</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265019136</BitOffs>
+            <BitOffs>1265135232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fMinTimeInS</Name>
@@ -82978,19 +82978,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Default>
               <Value>10000000</Value>
             </Default>
-            <BitOffs>1265019200</BitOffs>
+            <BitOffs>1265135296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iTimeSinceLast</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265019264</BitOffs>
+            <BitOffs>1265135360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nUpdateCycles</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265019328</BitOffs>
+            <BitOffs>1265135424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.nFrameCount</Name>
@@ -83005,67 +83005,67 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265019392</BitOffs>
+            <BitOffs>1265135488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.stTaskInfo</Name>
             <BitSize>1024</BitSize>
             <BaseType GUID="{56294066-FFF7-46F3-8206-FA06A30B13BA}">PlcTaskSystemInfo</BaseType>
-            <BitOffs>1265019456</BitOffs>
+            <BitOffs>1265135552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.iUnderflowCount</Name>
             <BitSize>64</BitSize>
             <BaseType>ULINT</BaseType>
-            <BitOffs>1265020480</BitOffs>
+            <BitOffs>1265136576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fUnderflowPercent</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265020544</BitOffs>
+            <BitOffs>1265136640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScale</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265020608</BitOffs>
+            <BitOffs>1265136704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEncScaleDenominator</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>1265020672</BitOffs>
+            <BitOffs>1265136768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandler</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265020736</BitOffs>
+            <BitOffs>1265136832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSend</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265131328</BitOffs>
+            <BitOffs>1265247424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketHandlerTest</Name>
             <BitSize>110592</BitSize>
             <BaseType>FB_UDPSocketHandler</BaseType>
-            <BitOffs>1265406528</BitOffs>
+            <BitOffs>1265522624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbSocketSendTest</Name>
             <BitSize>275200</BitSize>
             <BaseType>FB_BufferedSocketSend</BaseType>
-            <BitOffs>1265517120</BitOffs>
+            <BitOffs>1265633216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.payload</Name>
             <BitSize>512</BitSize>
             <BaseType>DUT_01_Channel_NW</BaseType>
-            <BitOffs>1265792320</BitOffs>
+            <BitOffs>1265908416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbHeader</Name>
@@ -83077,7 +83077,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <String>plc-tst-proto6</String>
               </SubItem>
             </Default>
-            <BitOffs>1265792832</BitOffs>
+            <BitOffs>1265908928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbChannel</Name>
@@ -83089,14 +83089,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>1</Value>
               </SubItem>
             </Default>
-            <BitOffs>1265793408</BitOffs>
+            <BitOffs>1265909504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fbGetTaskIndex</Name>
             <Comment> Function blocks</Comment>
             <BitSize>256</BitSize>
             <BaseType Namespace="Tc2_System">GETCURTASKINDEX</BaseType>
-            <BitOffs>1265794240</BitOffs>
+            <BitOffs>1265910336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsEncCount</Name>
@@ -83112,7 +83112,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265794496</BitOffs>
+            <BitOffs>1265910592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_DAQ_ENCODER.fEpicsTrigWidth</Name>
@@ -83127,7 +83127,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
     </Value>
               </Property>
             </Properties>
-            <BitOffs>1265794528</BitOffs>
+            <BitOffs>1265910624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -83201,7 +83201,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">64</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
@@ -92400,7 +92400,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">65</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PRG_MR1K1_BEND.fbM1K1PitchControl.fbMotionStage.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -94592,7 +94592,7 @@ Emergency Stop for MR1K1</Comment>
           <AreaNo AreaType="Internal" CreateSymbols="true">67</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -101843,29 +101843,10 @@ Emergency Stop for MR1K1</Comment>
             <BitOffs>1264978656</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
-            <Comment> Temp testing</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265019408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265019424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <BitOffs>1265019440</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>PiezoSerial.rtInitParams_M1K2</Name>
             <BitSize>128</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>1265910272</BitOffs>
+            <BitOffs>1265129472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PiezoSerial.tonTimeoutRst_M1K2</Name>
@@ -101878,7 +101859,26 @@ Emergency Stop for MR1K1</Comment>
                 <DateTime>T#2S</DateTime>
               </SubItem>
             </Default>
-            <BitOffs>1265910400</BitOffs>
+            <BitOffs>1265129600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nBusyCycles</Name>
+            <Comment> Temp testing</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265135504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nMaxBusyCycles</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265135520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_DAQ_ENCODER.nDroppedFrames</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <BitOffs>1265135536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_1_PlcTask.fbLogHandler</Name>
@@ -105234,7 +105234,7 @@ M3K2 KBH X ENC CNT</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-        pv: MR3K2:KBV:RTD:CHIN:L
+        pv: MR3K2:KBH:RTD:CHIN:L
         field: EGU C
         io: i
     </Value>
@@ -108983,7 +108983,7 @@ M4K2 KBV X ENC CNT</Comment>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">68</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>4</ContextId>
-          <ByteSize>165543936</ByteSize>
+          <ByteSize>165675008</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -109069,7 +109069,7 @@ M4K2 KBV X ENC CNT</Comment>
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-10-25T15:23:10</Value>
+          <Value>2024-11-05T15:47:38</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- changed mr1k1 bend 2d state mover implementation to 1d in `PRG_MR1K1_BEND`
- I left 2d implementation commented so it can be re-implementated when the motor gets replaced.
- changes in lcls-plc-rixs-optics/rixs_optics/POUs/PRG_MR1K1_BEND.TcPOU are the relevant to this PR, the rest will be remove in a rebase. Those commits are merged in #130 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- MR1K1 Xdwn stream motor had a catastrophic failure and needs replacement; currently unlpugged along with Xup.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- not tested yet.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-6792
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
